### PR TITLE
[iOS] WysiwygComposerViewModel clean-up

### DIFF
--- a/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
+++ b/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
@@ -47,7 +47,7 @@ struct WysiwygActionToolbar: View {
             guard let url = url else { return }
             // Note: the selection needs to be restored because of an issue with SwiftUI
             // integrating multiple UITextField/UITextView breaking selection.
-            viewModel.select(text: viewModel.content.attributed, range: linkAttributedRange)
+            viewModel.select(range: linkAttributedRange)
             let action: WysiwygAction = .link(url: url)
             toolbarAction(action)
         }))

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygAction.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygAction.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+/// Describes an action that can be done in the rich text editor.
 public enum WysiwygAction {
     /// Apply bold formatting to the current selection.
     case bold

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -57,7 +57,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
         textView.placeholderColor = UIColor(placeholderColor)
         textView.placeholder = placeholder
         viewModel.textView = textView
-        viewModel.updateCompressedHeightIfNeeded(textView)
+        viewModel.updateCompressedHeightIfNeeded()
         return textView
     }
 
@@ -87,13 +87,13 @@ public struct WysiwygComposerView: UIViewRepresentable {
     /// Coordinates UIKit communication.
     public class Coordinator: NSObject, UITextViewDelegate, NSTextStorageDelegate {
         var focused: Binding<Bool>
-        var replaceText: (UITextView, NSRange, String) -> Bool
-        var select: (NSAttributedString, NSRange) -> Void
-        var didUpdateText: (UITextView) -> Void
+        var replaceText: (NSRange, String) -> Bool
+        var select: (NSRange) -> Void
+        var didUpdateText: () -> Void
         init(_ focused: Binding<Bool>,
-             _ replaceText: @escaping (UITextView, NSRange, String) -> Bool,
-             _ select: @escaping (NSAttributedString, NSRange) -> Void,
-             _ didUpdateText: @escaping (UITextView) -> Void) {
+             _ replaceText: @escaping (NSRange, String) -> Bool,
+             _ select: @escaping (NSRange) -> Void,
+             _ didUpdateText: @escaping () -> Void) {
             self.focused = focused
             self.replaceText = replaceText
             self.select = select
@@ -105,7 +105,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
                                       textView.logText,
                                       "Replacement: \"\(text)\""],
                                      functionName: #function)
-            return replaceText(textView, range, text)
+            return replaceText(range, text)
         }
         
         public func textViewDidChange(_ textView: UITextView) {
@@ -116,7 +116,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
                 ],
                 functionName: #function
             )
-            didUpdateText(textView)
+            didUpdateText()
         }
 
         public func textViewDidChangeSelection(_ textView: UITextView) {
@@ -124,7 +124,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
                                      functionName: #function)
             // Fixes long press delete issue
             DispatchQueue.main.async {
-                self.select(textView.attributedText, textView.selectedRange)
+                self.select(textView.selectedRange)
             }
         }
         

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -19,13 +19,18 @@ import SwiftUI
 
 /// Provides a SwiftUI displayable view for the composer UITextView component.
 public struct WysiwygComposerView: UIViewRepresentable {
-    // MARK: - Internal
+    // MARK: - Public
+
+    @Binding public var focused: Bool
+
+    // MARK: - Private
 
     private var viewModel: WysiwygComposerViewModelProtocol
     private var tintColor = Color.accentColor
     private var placeholderColor = Color(UIColor.placeholderText)
     private var placeholder: String?
-    @Binding public var focused: Bool
+
+    // MARK: - Public
 
     public init(focused: Binding<Bool>,
                 viewModel: WysiwygComposerViewModelProtocol) {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -114,20 +114,25 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
             }
             .store(in: &cancellables)
     }
+}
 
+// MARK: - Public
+
+public extension WysiwygComposerViewModel {
     /// Apply any additional setup required.
     /// Should be called when the view appears.
-    public func setup() {
+    func setup() {
+        // FIXME: multiple textViews sharing the model might unwittingly clear the composer because of this.
         applyUpdate(model.replaceAllHtml(html: ""))
         updateTextView()
     }
-    
+
     /// Select given range of text within the model.
     ///
     /// - Parameters:
     ///   - text: Text currently displayed in the composer.
     ///   - range: Range to select.
-    public func select(text: NSAttributedString, range: NSRange) {
+    func select(text: NSAttributedString, range: NSRange) {
         do {
             // FIXME: temporary workaround as trailing newline should be ignored but are now replacing ZWSP from Rust model
             let htmlSelection = try text.htmlRange(from: range,
@@ -151,7 +156,7 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
     ///
     /// - Parameters:
     ///   - action: Action to apply.
-    public func apply(_ action: WysiwygAction) {
+    func apply(_ action: WysiwygAction) {
         Logger.viewModel.logDebug([content.logAttributedSelection,
                                    "Apply action: \(action)"],
                                   functionName: #function)
@@ -186,27 +191,23 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
     ///
     /// - Parameters:
     ///   - html: HTML content to apply
-    public func setHtmlContent(_ html: String) {
+    func setHtmlContent(_ html: String) {
         let update = model.replaceAllHtml(html: html)
         applyUpdate(update)
         updateTextView()
     }
 
     /// Clear the content of the composer.
-    public func clearContent() {
+    func clearContent() {
         applyUpdate(model.clear())
         updateTextView()
     }
 
     /// Returns a textual representation of the composer model as a tree.
-    public func treeRepresentation() -> String {
+    func treeRepresentation() -> String {
         model.toTree()
     }
-}
 
-// MARK: - Internal
-
-public extension WysiwygComposerViewModel {
     /// Replace text in the model.
     ///
     /// - Parameters:
@@ -412,7 +413,11 @@ private extension WysiwygComposerViewModel {
             updateTextView()
         }
     }
-    
+
+    /// Generate an HTML body with standard style from given fragment.
+    ///
+    /// - Parameter htmlFragment: HTML fragment
+    /// - Returns: HTML body
     func generateHtmlBodyWithStyle(htmlFragment: String) -> String {
         "<html><head><style>body {font-family:-apple-system;font:-apple-system-body;}</style></head><body>\(htmlFragment)</body></html>"
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -23,28 +23,23 @@ public protocol WysiwygComposerViewModelProtocol: AnyObject {
     var content: WysiwygComposerContent { get }
 
     /// Update the composer compressed required height if it has changed.
-    ///
-    /// - Parameters:
-    ///   - textView: The composer's text view.
-    func updateCompressedHeightIfNeeded(_ textView: UITextView)
+    func updateCompressedHeightIfNeeded()
 
     /// Replace text in the model.
     ///
     /// - Parameters:
-    ///   - textView: TextView which currently holds the displayed text in the composer.
     ///   - range: Range to replace.
     ///   - replacementText: Replacement text to apply.
-    func replaceText(_ textView: UITextView, range: NSRange, replacementText: String) -> Bool
+    func replaceText(range: NSRange, replacementText: String) -> Bool
 
     /// Select given range of text within the model.
     ///
     /// - Parameters:
-    ///   - text: Text currently displayed in the composer.
     ///   - range: Range to select.
-    func select(text: NSAttributedString, range: NSRange)
+    func select(range: NSRange)
 
     /// Notify that the text view content has changed.
     ///
     /// - Parameter textView: The composer's text view.
-    func didUpdateText(textView: UITextView)
+    func didUpdateText()
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+public protocol WysiwygComposerViewModelProtocol: AnyObject {
+    /// The textView with placeholder support that the model manages
+    var textView: PlaceholdableTextView? { get set }
+    /// The composer content.
+    var content: WysiwygComposerContent { get }
+
+    /// Update the composer compressed required height if it has changed.
+    ///
+    /// - Parameters:
+    ///   - textView: The composer's text view.
+    func updateCompressedHeightIfNeeded(_ textView: UITextView)
+
+    /// Replace text in the model.
+    ///
+    /// - Parameters:
+    ///   - textView: TextView which currently holds the displayed text in the composer.
+    ///   - range: Range to replace.
+    ///   - replacementText: Replacement text to apply.
+    func replaceText(_ textView: UITextView, range: NSRange, replacementText: String) -> Bool
+
+    /// Select given range of text within the model.
+    ///
+    /// - Parameters:
+    ///   - text: Text currently displayed in the composer.
+    ///   - range: Range to select.
+    func select(text: NSAttributedString, range: NSRange)
+
+    /// Notify that the text view content has changed.
+    ///
+    /// - Parameter textView: The composer's text view.
+    func didUpdateText(textView: UITextView)
+}

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/ComposerModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/ComposerModel.swift
@@ -1,0 +1,49 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+extension ComposerModel {
+    /// Apply given action to the composer model.
+    ///
+    /// - Parameters:
+    ///   - action: Action to apply.
+    func apply(_ action: WysiwygAction) -> ComposerUpdateProtocol {
+        let update: ComposerUpdateProtocol
+        switch action {
+        case .bold:
+            update = bold()
+        case .italic:
+            update = italic()
+        case .strikeThrough:
+            update = strikeThrough()
+        case .underline:
+            update = underline()
+        case .inlineCode:
+            update = inlineCode()
+        case let .link(url: url):
+            update = setLink(newText: url)
+        case .undo:
+            update = undo()
+        case .redo:
+            update = redo()
+        case .orderedList:
+            update = orderedList()
+        case .unorderedList:
+            update = unorderedList()
+        }
+
+        return update
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
@@ -1,0 +1,51 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+/// Provides tools to parse from HTML to NSAttributedString with a standard style.
+final class HTMLParser {
+    // MARK: - Private
+
+    private init() { }
+
+    // MARK: - Internal
+
+    /// Parse given HTML to NSAttributedString with a standard style.
+    ///
+    /// - Parameters:
+    ///   - html: HTML to parse
+    ///   - encoding: string encoding to use
+    ///   - textColor: text color to apply to the result string
+    /// - Returns: an attributed string representation of the HTML content
+    static func parse(html: String,
+                      encoding: String.Encoding = .utf16,
+                      textColor: UIColor) throws -> NSAttributedString {
+        let htmlWithStyle = generateHtmlBodyWithStyle(htmlFragment: html)
+        let attributed = try NSAttributedString(html: htmlWithStyle).changeColor(to: textColor)
+        return attributed
+    }
+}
+
+private extension HTMLParser {
+    /// Generate an HTML body with standard style from given fragment.
+    ///
+    /// - Parameter htmlFragment: HTML fragment
+    /// - Returns: HTML body
+    static func generateHtmlBodyWithStyle(htmlFragment: String) -> String {
+        "<html><head><style>body {font-family:-apple-system;font:-apple-system-body;}</style></head><body>\(htmlFragment)</body></html>"
+    }
+}


### PR DESCRIPTION
* Move public functions to appropriate extension
* Add a missing comment
* Add a FIXME for clear on appear issue with multiple text fields
* Move HTML parsing to a dedicated file
* Add dedicated WysiwygComposerViewModelProtocol file and extract documentation to it 
* Extract WysiwygAction apply to a ComposerModel extension