### PR TITLE
[iOS] Add unit test for plain text mode

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -390,10 +390,11 @@ private extension WysiwygComposerViewModel {
     func updatePlainTextMode(_ enabled: Bool) {
         if enabled {
             do {
-                let previousContent = content
-                let attributed = try NSAttributedString(html: generateHtmlBodyWithStyle(htmlFragment: previousContent.plainText)).changeColor(to: textColor)
+                plainText = content.plainText
                 clearContent()
                 guard let textView = textView else { return }
+                let htmlWithStyle = generateHtmlBodyWithStyle(htmlFragment: plainText)
+                let attributed = try NSAttributedString(html: htmlWithStyle).changeColor(to: textColor)
                 textView.attributedText = attributed
             } catch {
                 Logger.viewModel.logError(

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -99,4 +99,28 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         XCTAssertEqual(textView.text, "A")
         XCTAssertEqual(textView.selectedRange, NSRange(location: 1, length: 0))
     }
+
+    func testPlainTextMode() {
+        let textView = UITextView()
+        _ = viewModel.replaceText(textView,
+                                  range: .zero,
+                                  replacementText: "Some bold text")
+        viewModel.select(text: NSAttributedString(string: "Some bold text"),
+                         range: .init(location: 10, length: 4))
+        viewModel.apply(.bold)
+
+        XCTAssertEqual(viewModel.content.html, "Some bold <strong>text</strong>")
+
+        viewModel.plainTextMode = true
+
+        XCTExpectFailure("Plain text should contain the appropriate Markdown")
+        XCTAssertEqual(viewModel.plainTextModeContent.plainText, "Some bold **text**")
+        XCTExpectFailure("HTML should be re-generated from Markdown input upon sending")
+        XCTAssertEqual(viewModel.plainTextModeContent.html, "Some bold <strong>text</strong>")
+
+        viewModel.plainTextMode = false
+
+        XCTExpectFailure("Switching back to WYSIWYG should restore the HTML")
+        XCTAssertEqual(viewModel.content.html, "Some bold <strong>text</strong>")
+    }
 }


### PR DESCRIPTION
* Updates the plainText property so the content is immediately relevant (otherwise it relied on having an existing UITextView bound to the model)
* Add a unit test representing expected results when the Markdown/HTML conversions will be supported