### PR TITLE
Fix build phase scripts warning

### DIFF
--- a/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
+++ b/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		A6F3FC0728DCADB300C170E8 /* ⚠️ SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -289,6 +290,7 @@
 		};
 		A6F3FC0828DCAF8400C170E8 /* 🧹 SwiftFormat */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
This add a flag that explicitly informs XCode that we'll be running SwiftLint/SwiftFormat on every build. No change at all on what is actually happening during a build, as skipping these on incremental builds is not easily supported yet, this only removes the XCode warning

For more information, see https://github.com/realm/SwiftLint/issues/4015