### PR TITLE
chore: Remove warnings when `js` feature is used without a `wasm32` target architecture

### DIFF
--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -73,7 +73,7 @@ where
         self.document().children()
     }
 
-    #[cfg(feature = "js")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
     pub(crate) fn take_children(self) -> Vec<DomNode<S>> {
         if let DomNode::Container(container) = self.document {
             container.take_children()

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -212,7 +212,7 @@ where
         &self.children
     }
 
-    #[cfg(feature = "js")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
     pub(crate) fn take_children(self) -> Vec<DomNode<S>> {
         self.children
     }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -148,10 +148,6 @@ where
     pub(crate) fn is_block_node(&self) -> bool {
         matches!(self, Self::Container(container) if container.is_block_node())
     }
-
-    pub(crate) fn is_inline_node(&self) -> bool {
-        !self.is_block_node()
-    }
 }
 
 impl<S> ToHtml<S> for DomNode<S>

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -21,7 +21,7 @@ where
     cfg_if::cfg_if! {
         if #[cfg(feature = "sys")] {
             sys::parse(html)
-        } else if #[cfg(feature = "js")] {
+        } else if #[cfg(all(feature = "js", target_arch = "wasm32"))] {
             js::parse(html)
         } else {
             unreachable!("The `sys` or `js` are mutually exclusive, and one of them must be enabled.")
@@ -288,7 +288,7 @@ mod sys {
     }
 }
 
-#[cfg(feature = "js")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 mod js {
     use super::*;
     use crate::{


### PR DESCRIPTION
Yup, everything is in the title.