### PR TITLE
feat(wysiwyg): Markdown compiles `<u>` to… `<u>` (raw HTML)

### DIFF
--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -544,9 +544,11 @@ where
             S: UnicodeString,
         {
             // Underline format is absent from Markdown. Let's
-            // ignore it!
+            // use raw HTML.
 
+            buffer.push("<u>");
             fmt_children(this, buffer, &options)?;
+            buffer.push("</u>");
 
             Ok(())
         }

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -104,7 +104,7 @@ line3~~ def"#,
 
 #[test]
 fn text_with_underline() {
-    assert_to_md_no_roundtrip("<u>abc</u>", "abc");
+    assert_to_md("<u>abc</u>", "<u>abc</u>");
 }
 
 #[test]


### PR DESCRIPTION
So that it improves the roundtrip from HTML to Markdown back to HTML.

Raw HTML is allowed by the spec, https://github.github.com/gfm/#raw-html.