### PR TITLE
[Android] Fix failing tests after API changes

### DIFF
--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
@@ -74,7 +74,7 @@ class MockComposer {
     fun givenReplaceAllHtmlResult(
         html: String,
         update: ComposerUpdate = MockComposerUpdateFactory.create(),
-    ) = every { instance.replaceAllHtml(html = html) } returns update
+    ) = every { instance.setContentFromHtml(html = html) } returns update
 
     fun givenUndoResult(
         update: ComposerUpdate = MockComposerUpdateFactory.create(),

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
@@ -205,7 +205,7 @@ internal class EditorViewModelTest {
         val result = viewModel.processInput(EditorInputAction.ReplaceAllHtml("new html"))
 
         verify {
-            composer.instance.replaceAllHtml("new html")
+            composer.instance.setContentFromHtml("new html")
             menuStateCallback(menuStateUpdate)
         }
         assertThat(result, equalTo(replaceTextResult))


### PR DESCRIPTION
Fix missing rename from `replace_all_html` to `set_content_from_html` in Android tests