### PR TITLE
Refactor WysiwygComposerContent into two entities

### DIFF
--- a/platforms/ios/example/Wysiwyg/Views/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/Views/ContentView.swift
@@ -37,11 +37,7 @@ struct ContentView: View {
             viewModel.plainTextMode.toggle()
         }
         Button("Send") {
-            if viewModel.plainTextMode {
-                sentMessage = viewModel.plainTextModeContent
-            } else {
-                sentMessage = viewModel.content
-            }
+            sentMessage = viewModel.content
             viewModel.clearContent()
         }
         .disabled(viewModel.isContentEmpty)
@@ -59,7 +55,7 @@ struct ContentView: View {
                 VStack {
                     HStack {
                         Text("Content:")
-                        Text(sentMessage.plainText)
+                        Text(sentMessage.markdown)
                             .accessibilityIdentifier(.contentText)
                     }
                     HStack {

--- a/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
+++ b/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
@@ -28,7 +28,7 @@ struct WysiwygActionToolbar: View {
             ForEach(WysiwygAction.allCases) { action in
                 Button {
                     if action == .link(url: "unset") {
-                        linkAttributedRange = viewModel.content.attributedSelection
+                        linkAttributedRange = viewModel.attributedContent.selection
                         isShowingUrlAlert = true
                     } else {
                         toolbarAction(action)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
@@ -21,31 +21,41 @@ import Foundation
 public class WysiwygComposerContent: NSObject {
     // MARK: - Public
 
-    /// Displayed text, as plain text.
-    public let plainText: String
+    /// Markdown representation of the displayed text.
+    public let markdown: String
     /// HTML representation of the displayed text.
     public let html: String
-    /// Attributed string representation of the displayed text.
-    public let attributed: NSAttributedString
-    /// Range of the selected text within the attributed representation.
-    public var attributedSelection: NSRange
 
     // MARK: - Internal
 
     /// Init.
     ///
     /// - Parameters:
-    ///   - plainText: Displayed text, as plain text.
+    ///   - markdown: Markdown representation of the displayed text.
     ///   - html: HTML representation of the displayed text.
-    ///   - attributed: Attributed string representation of the displayed text.
-    ///   - attributedSelection: Range of the selected text within the attributed representation.
-    init(plainText: String = "",
-         html: String = "",
-         attributed: NSAttributedString = .init(string: ""),
-         attributedSelection: NSRange = .zero) {
-        self.plainText = plainText
+    init(markdown: String = "",
+         html: String = "") {
+        self.markdown = markdown
         self.html = html
-        self.attributed = attributed
-        self.attributedSelection = attributedSelection
+    }
+}
+
+public struct WysiwygComposerAttributedContent {
+    /// Attributed string representation of the displayed text.
+    public let text: NSAttributedString
+    /// Range of the selected text within the attributed representation.
+    public var selection: NSRange
+
+    // MARK: - Internal
+
+    /// Init.
+    ///
+    /// - Parameters:
+    ///   - text: Attributed string representation of the displayed text.
+    ///   - selection: Range of the selected text within the attributed representation.
+    init(text: NSAttributedString = .init(string: ""),
+         selection: NSRange = .zero) {
+        self.text = text
+        self.selection = selection
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -64,8 +64,8 @@ public struct WysiwygComposerView: UIViewRepresentable {
     public func updateUIView(_ uiView: PlaceholdableTextView, context: Context) {
         Logger.textView.logDebug(
             [
-                viewModel.content.logAttributedSelection,
-                viewModel.content.logText,
+                viewModel.attributedContent.logSelection,
+                viewModel.attributedContent.logText,
             ],
             functionName: #function
         )

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -19,8 +19,8 @@ import UIKit
 public protocol WysiwygComposerViewModelProtocol: AnyObject {
     /// The textView with placeholder support that the model manages
     var textView: PlaceholdableTextView? { get set }
-    /// The composer content.
-    var content: WysiwygComposerContent { get }
+    /// The composer attributed content.
+    var attributedContent: WysiwygComposerAttributedContent { get }
 
     /// Update the composer compressed required height if it has changed.
     func updateCompressedHeightIfNeeded()

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/Logger.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/Logger.swift
@@ -74,16 +74,16 @@ extension UITextView {
     }
 }
 
-// MARK: - WysiwygComposerContent + Logger
+// MARK: - WysiwygComposerAttributedContent + Logger
 
-extension WysiwygComposerContent {
+extension WysiwygComposerAttributedContent {
     /// Returns a log ready description of the attributed selection.
-    var logAttributedSelection: String {
-        "Sel(att): \(attributedSelection)"
+    var logSelection: String {
+        "Sel(att): \(selection)"
     }
 
-    /// Returns a log ready description of the text.
+    /// Returns a log ready description of the markdown text.
     var logText: String {
-        "Text: \"\(plainText)\""
+        "Text: \"\(text)\""
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
@@ -24,13 +24,13 @@ extension UITextView {
     ///
     /// - Parameters:
     ///   - content: Content to apply.
-    func apply(_ content: WysiwygComposerContent) {
+    func apply(_ content: WysiwygComposerAttributedContent) {
         performWithoutDelegate {
-            self.attributedText = content.attributed
+            self.attributedText = content.text
             // Set selection to {0, 0} then to expected position
             // avoids an issue with autocapitalization.
             self.selectedRange = .zero
-            self.selectedRange = content.attributedSelection
+            self.selectedRange = content.selection
         }
     }
 }


### PR DESCRIPTION
WysiwygComposerContent is now divided into two objects. This will avoid storing and publishing unrequired parts of the content on every update. 

* A published object containing the attributed text and the selection, which is everything that the TextView actually requires. This bit could probably be reworked to be completely internal (as well as the protocol between the TextView and the ViewModel) but there is an issue preventing it right now:
    * Workaround for links that needs to manually reset the selection (which might be required on clients as well, depending on the implementation)
* A computed property returning both the Markdown and the HTML content. This is only needed for example when sending the message, or when saving a partial message (this also removes having to create a half-dummy content for plain text mode when it's needed)

This is a breaking change for iOS implementations and will require an update on client to use the new APIs.