### PR TITLE
Fix typo on iOS workflow for GitHub Actions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-    types: [ labeled, synchronized, opened, reopened ]
+    types: [ labeled, synchronize, opened, reopened ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This typo prevented the iOS workflow to be re-triggered on PR updates.