### PR TITLE
[iOS] Fix clearing the content of the text view when plain text mode is enabled

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -346,9 +346,8 @@ private extension WysiwygComposerViewModel {
     /// - Parameter enabled: whether plain text mode is enabled
     func updatePlainTextMode(_ enabled: Bool) {
         if enabled {
-            let plainText = model.getContentAsMarkdown()
             guard let textView = textView else { return }
-            let attributed = NSAttributedString(string: plainText,
+            let attributed = NSAttributedString(string: model.getContentAsMarkdown(),
                                                 attributes: defaultTextAttributes)
             textView.attributedText = attributed
         } else {


### PR DESCRIPTION
* Clear the content of the text view in plain text mode
* Removes unnecessary property storing the content of the textView in plain text mode