### PR TITLE
Skip the 'Should call inputEventProcessor' test

### DIFF
--- a/platforms/web/lib/useWysiwyg.inputEventProcessor.test.tsx
+++ b/platforms/web/lib/useWysiwyg.inputEventProcessor.test.tsx
@@ -30,7 +30,22 @@ describe('inputEventProcessor', () => {
         );
     });
 
-    it('Should call inputEventProcessor', async () => {
+    /**
+     *
+     * This fails in a flaky way. I (AndyB) spent quite a bit of time today
+     * trying to figure out why it's failing, and look for a workaround. The
+     * situation improves if you add other interactions e.g. send a `type` user
+     * event, but it still fails from time to time.
+     *
+     * There must be something we should be waiting for or similar but I really
+     * can't figure it out. I also can't see why this test is problematic and
+     * others are not.
+     *
+     * If the test is run on its own, it tends to pass, but if others are
+     * running, it is less reliable. This leads me to suspect there is a timing
+     * issue.
+     */
+    it.skip('Should call inputEventProcessor', async () => {
         // When
         inputEventProcessor.mockReturnValue(null);
         fireEvent.input(textbox, {
@@ -40,7 +55,7 @@ describe('inputEventProcessor', () => {
 
         // Then
         await waitFor(() => {
-            expect(textbox).toContainHTML('');
+            expect(textbox).toHaveTextContent(/^$/);
             expect(textbox).toHaveAttribute('data-content', '');
             expect(inputEventProcessor).toBeCalledTimes(1);
             expect(inputEventProcessor).toBeCalledWith(


### PR DESCRIPTION
because it fails in a flaky way. I spent quite a bit of time today trying to figure out why it's failing, and look for a workaround. The situation improves if you add other interactions e.g. send a `type` user event, but it still fails from time to time.

There must be something we should be waiting for or similar but I really can't figure it out. I also can't see why this test is problematic and others are not.

If the test is run on its own, it tends to pass, but if others are running, it is less reliable. This leads me to suspect there is a timing issue.