### PR TITLE
Add missing `closeAndReleaseRepository` to Android CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           build-root-directory: platforms/android
           arguments: |
-            publishAllPublicationsToMavenCentral
+            publishAllPublicationsToMavenCentral closeAndReleaseRepository
   npm:
     name: Publish to npm
     runs-on: ubuntu-latest


### PR DESCRIPTION
This saves us from having to log into sonatype to manually complete the release.