### PR TITLE
[Android] Add RustCollector to catch and deal with Rust errors.

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -83,6 +83,13 @@ class EditorEditText : TextInputEditText {
         }
 
     /**
+     * When not null, it will serve as an error callback for the client integrating this lib.
+     */
+    var rustErrorCollector: RustErrorCollector?
+        set(value) { viewModel.rustErrorCollector = value }
+        get() = viewModel.rustErrorCollector
+
+    /**
      * We'll do our own text restoration.
      */
     override fun getFreezesText(): Boolean {
@@ -97,6 +104,7 @@ class EditorEditText : TextInputEditText {
 
         val start = Selection.getSelectionStart(editableText)
         val end = Selection.getSelectionEnd(editableText)
+
         viewModel.updateSelection(editableText, start, end)
     }
 
@@ -168,7 +176,6 @@ class EditorEditText : TextInputEditText {
     private fun addHardwareKeyInterceptor() {
         // This seems to be the only way to prevent EditText from automatically handling key strokes
         setOnKeyListener { _, keyCode, event ->
-            println("Key Event: $event")
             if (keyCode == KeyEvent.KEYCODE_ENTER) {
                 if (event.action == MotionEvent.ACTION_DOWN) {
                     inputConnection?.sendHardwareKeyboardInput(event)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/RustErrorCollector.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/RustErrorCollector.kt
@@ -1,0 +1,8 @@
+package io.element.android.wysiwyg.utils
+
+/**
+ * Callback for catching and dealing with Rust-related issues.
+ */
+fun interface RustErrorCollector {
+    fun onRustError(throwable: Throwable)
+}

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
@@ -90,4 +90,8 @@ class MockComposer {
     fun givenToggleUnorderedListResult(
         update: ComposerUpdate = MockComposerUpdateFactory.create(),
     ) = every { instance.unorderedList() } returns update
+
+    fun givenErrorInUpdateSelection(
+        throwable: Throwable = IllegalStateException("Invalid selection range"),
+    ) = every { instance.select(any(), any()) } throws throwable
 }


### PR DESCRIPTION
Just added a simple callback to catch the Rust errors from the client that integrates the library. It will also need some extra work to integrate with EA/Sentry.