### PR TITLE
[iOS] Example app: Switch directly on action state and improve colours for dark mode

### DIFF
--- a/platforms/ios/example/Wysiwyg/Extensions/WysiwygAction+Utils.swift
+++ b/platforms/ios/example/Wysiwyg/Extensions/WysiwygAction+Utils.swift
@@ -32,16 +32,13 @@ extension WysiwygAction: CaseIterable, Identifiable {
     /// - Parameter viewModel: Composer's view model.
     /// - Returns: Tint color that the button should use.
     public func color(_ viewModel: WysiwygComposerViewModel) -> Color {
-        let isDisabled = isDisabled(viewModel)
-        // Buttons for reversed actions should be highlighted with a specific colour.
-        let isActive = viewModel.actionStates[composerAction] == ActionState.reversed
-        switch (isDisabled, isActive) {
-        case (true, _):
-            return .black.opacity(0.3)
-        case (false, true):
-            return .blue
-        case (false, false):
-            return .black
+        switch viewModel.actionStates[composerAction] {
+        case .enabled:
+            return Color.primary
+        case .reversed:
+            return Color.accentColor
+        default:
+            return Color.primary.opacity(0.3)
         }
     }
 


### PR DESCRIPTION
* Use a direct switch instead of the old double state complicated one
* Use accent & primary colour in the example app for better light/dark mode support