### PR TITLE
[iOS] Add a StringDiffer to help reconciliate the model with the content of the field

### DIFF
--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -49,7 +49,9 @@ class WysiwygUITests: XCTestCase {
         // Double tap results in selecting the last word.
         textView.doubleTap()
         deleteKey.tap()
-        assertTextViewContent("abcde 🥳 ")
+        // Note: iOS is removing the whitespace right after the emoji, even though it reports
+        // through `shouldChangeTextIn` that it is removing only the 3 last chars.
+        assertTextViewContent("abcde 🥳")
 
         // Triple tap selects the entire line.
         textView.tap(withNumberOfTaps: 3, numberOfTouches: 1)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
@@ -40,7 +40,7 @@ public class WysiwygComposerContent: NSObject {
     }
 }
 
-public struct WysiwygComposerAttributedContent {
+public struct WysiwygComposerAttributedContent: Equatable {
     /// Attributed string representation of the displayed text.
     public let text: NSAttributedString
     /// Range of the selected text within the attributed representation.

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
@@ -40,7 +40,7 @@ public class WysiwygComposerContent: NSObject {
     }
 }
 
-public struct WysiwygComposerAttributedContent: Equatable {
+public struct WysiwygComposerAttributedContent {
     /// Attributed string representation of the displayed text.
     public let text: NSAttributedString
     /// Range of the selected text within the attributed representation.

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -78,15 +78,14 @@ public struct WysiwygComposerView: UIViewRepresentable {
 
     /// Coordinates UIKit communication.
     public class Coordinator: NSObject, UITextViewDelegate, NSTextStorageDelegate {
-        private var hasSkippedShouldAcceptChanges = true
         var focused: Binding<Bool>
         var replaceText: (NSRange, String) -> Bool
         var select: (NSRange) -> Void
-        var didUpdateText: (Bool) -> Void
+        var didUpdateText: () -> Void
         init(_ focused: Binding<Bool>,
              _ replaceText: @escaping (NSRange, String) -> Bool,
              _ select: @escaping (NSRange) -> Void,
-             _ didUpdateText: @escaping (Bool) -> Void) {
+             _ didUpdateText: @escaping () -> Void) {
             self.focused = focused
             self.replaceText = replaceText
             self.select = select
@@ -98,7 +97,6 @@ public struct WysiwygComposerView: UIViewRepresentable {
                                       textView.logText,
                                       "Replacement: \"\(text)\""],
                                      functionName: #function)
-            hasSkippedShouldAcceptChanges = false
             return replaceText(range, text)
         }
         
@@ -110,8 +108,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
                 ],
                 functionName: #function
             )
-            didUpdateText(!hasSkippedShouldAcceptChanges)
-            hasSkippedShouldAcceptChanges = true
+            didUpdateText()
         }
 
         public func textViewDidChangeSelection(_ textView: UITextView) {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -98,6 +98,8 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
          .foregroundColor: textColor]
     }
 
+    private var hasPendingFormats = false
+
     // MARK: - Public
 
     public init(minHeight: CGFloat = 22,
@@ -153,6 +155,9 @@ public extension WysiwygComposerViewModel {
                                    "Apply action: \(action)"],
                                   functionName: #function)
         let update = model.apply(action)
+        if update.textUpdate() == .keep {
+            hasPendingFormats = true
+        }
         applyUpdate(update)
     }
 
@@ -250,46 +255,8 @@ public extension WysiwygComposerViewModel {
                 isContentEmpty = textView.text.isEmpty
             }
         } else {
-            do {
-                if let replacement = try StringDiffer.replacement(from: attributedContent.text.string,
-                                                                  to: textView.text ?? "") {
-                    // Reconciliate
-                    let rustRange = try attributedContent.text.htmlRange(from: replacement.range)
-
-                    let replaceUpdate = model.replaceTextIn(newText: replacement.text,
-                                                            start: UInt32(rustRange.location),
-                                                            end: UInt32(rustRange.upperBound))
-                    applyUpdate(replaceUpdate, skipTextViewUpdate: true)
-
-                    // Resync selectedRange
-                    let rustSelection = try textView.attributedText.htmlRange(from: textView.selectedRange)
-                    let selectUpdate = model.select(startUtf16Codeunit: UInt32(rustSelection.location),
-                                                    endUtf16Codeunit: UInt32(rustSelection.upperBound))
-                    applyUpdate(selectUpdate)
-
-                    Logger.viewModel.logDebug(["Reconciliate from \"\(attributedContent.text.string)\" to \"\(textView.text ?? "")\" with \"\(replacement.text)\""],
-                                              functionName: #function)
-                    Logger.viewModel.logDebug(["Reconciliate model markdown: \"\(model.getContentAsMarkdown())\""],
-                                              functionName: #function)
-                }
-            } catch {
-                switch error {
-                case StringDifferError.tooComplicated,
-                     StringDifferError.insertionsDontMatchRemovals:
-                    // Restore from the model, as otherwise the composer will enter a broken state
-                    textView.apply(attributedContent)
-                    updateCompressedHeightIfNeeded()
-                    Logger.viewModel.logError(["Reconciliate failed, content has been restored from the model"],
-                                              functionName: #function)
-                case AttributedRangeError.outOfBoundsAttributedIndex,
-                     AttributedRangeError.outOfBoundsHtmlIndex:
-                    // Just log here for now, the composer is already in a broken state
-                    Logger.viewModel.logError(["Reconciliate failed due to out of bounds indexes"],
-                                              functionName: #function)
-                default:
-                    break
-                }
-            }
+            reconciliateIfNeeded()
+            applyPendingFormatsIfNeeded()
         }
 
         textView.shouldShowPlaceholder = textView.attributedText.length == 0
@@ -413,6 +380,61 @@ private extension WysiwygComposerViewModel {
             applyUpdate(update)
             updateTextView()
         }
+    }
+
+    /// Reconcilaite the content of the model with the content of the text view.
+    func reconciliateIfNeeded() {
+        do {
+            guard let replacement = try StringDiffer.replacement(from: attributedContent.text.string,
+                                                                 to: textView.text ?? "") else {
+                return
+            }
+            // Reconciliate
+            let rustRange = try attributedContent.text.htmlRange(from: replacement.range)
+
+            let replaceUpdate = model.replaceTextIn(newText: replacement.text,
+                                                    start: UInt32(rustRange.location),
+                                                    end: UInt32(rustRange.upperBound))
+            applyUpdate(replaceUpdate, skipTextViewUpdate: true)
+
+            // Resync selectedRange
+            let rustSelection = try textView.attributedText.htmlRange(from: textView.selectedRange)
+            let selectUpdate = model.select(startUtf16Codeunit: UInt32(rustSelection.location),
+                                            endUtf16Codeunit: UInt32(rustSelection.upperBound))
+            applyUpdate(selectUpdate)
+
+            Logger.viewModel.logDebug(["Reconciliate from \"\(attributedContent.text.string)\" to \"\(textView.text ?? "")\" with \"\(replacement.text)\""],
+                                      functionName: #function)
+            Logger.viewModel.logDebug(["Reconciliate model markdown: \"\(model.getContentAsMarkdown())\""],
+                                      functionName: #function)
+        } catch {
+            switch error {
+            case StringDifferError.tooComplicated,
+                 StringDifferError.insertionsDontMatchRemovals:
+                // Restore from the model, as otherwise the composer will enter a broken state
+                textView.apply(attributedContent)
+                updateCompressedHeightIfNeeded()
+                Logger.viewModel.logError(["Reconciliate failed, content has been restored from the model"],
+                                          functionName: #function)
+            case AttributedRangeError.outOfBoundsAttributedIndex,
+                 AttributedRangeError.outOfBoundsHtmlIndex:
+                // Just log here for now, the composer is already in a broken state
+                Logger.viewModel.logError(["Reconciliate failed due to out of bounds indexes"],
+                                          functionName: #function)
+            default:
+                break
+            }
+        }
+    }
+
+    /// Updates the text view with the current content if we have some pending formats
+    /// to apply (e.g. we hit the bold button with no selection).
+    func applyPendingFormatsIfNeeded() {
+        guard hasPendingFormats else { return }
+
+        textView.apply(attributedContent)
+        updateCompressedHeightIfNeeded()
+        hasPendingFormats = false
     }
 }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -211,12 +211,9 @@ public extension WysiwygComposerViewModel {
         }
 
         if attributedContent.selection.length == 0, replacementText == "" {
-            Logger.viewModel.logDebug(["Ignored an empty replacement"],
-                                      functionName: #function)
-            return false
-        }
-
-        if replacementText.count == 1, replacementText[String.Index(utf16Offset: 0, in: replacementText)].isNewline {
+            update = model.backspace()
+            shouldAcceptChange = false
+        } else if replacementText.count == 1, replacementText[String.Index(utf16Offset: 0, in: replacementText)].isNewline {
             update = model.enter()
             shouldAcceptChange = false
         } else {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -227,6 +227,7 @@ public extension WysiwygComposerViewModel {
         }
 
         applyUpdate(update)
+
         if !shouldAcceptChange {
             textView?.apply(attributedContent)
             updateCompressedHeightIfNeeded()
@@ -280,6 +281,7 @@ public extension WysiwygComposerViewModel {
         }
         // }
 
+        textView.shouldShowPlaceholder = textView.attributedText.length == 0
         updateCompressedHeightIfNeeded()
     }
 }
@@ -330,12 +332,15 @@ private extension WysiwygComposerViewModel {
             // FIXME: temporary workaround as trailing newline should be ignored but are now replacing ZWSP from Rust model
             let textSelection = try attributed.attributedRange(from: htmlSelection,
                                                                shouldIgnoreTrailingNewline: false)
-            attributedContent = WysiwygComposerAttributedContent(text: attributed, selection: textSelection)
-            Logger.viewModel.logDebug(["Sel(att): \(textSelection)",
-                                       "Sel: \(htmlSelection)",
-                                       "HTML: \"\(html)\"",
-                                       "replaceAll"],
-                                      functionName: #function)
+            let newContent = WysiwygComposerAttributedContent(text: attributed, selection: textSelection)
+            if attributedContent != newContent {
+                attributedContent = newContent
+                Logger.viewModel.logDebug(["Sel(att): \(textSelection)",
+                                           "Sel: \(htmlSelection)",
+                                           "HTML: \"\(html)\"",
+                                           "replaceAll"],
+                                          functionName: #function)
+            }
         } catch {
             Logger.viewModel.logError(["Sel: {\(start), \(end - start)}",
                                        "Error: \(error.localizedDescription)",
@@ -355,10 +360,12 @@ private extension WysiwygComposerViewModel {
             // FIXME: temporary workaround as trailing newline should be ignored but are now replacing ZWSP from Rust model
             let textSelection = try attributedContent.text.attributedRange(from: htmlSelection,
                                                                            shouldIgnoreTrailingNewline: false)
-            attributedContent.selection = textSelection
-            Logger.viewModel.logDebug(["Sel(att): \(textSelection)",
-                                       "Sel: \(htmlSelection)"],
-                                      functionName: #function)
+            if attributedContent.selection != textSelection {
+                attributedContent.selection = textSelection
+                Logger.viewModel.logDebug(["Sel(att): \(textSelection)",
+                                           "Sel: \(htmlSelection)"],
+                                          functionName: #function)
+            }
         } catch {
             Logger.viewModel.logError(["Sel: {\(start), \(end - start)}",
                                        "Error: \(error.localizedDescription)"],

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -249,7 +249,7 @@ public extension WysiwygComposerViewModel {
         }
     }
 
-    func didUpdateText(shouldReconciliate: Bool = true) {
+    func didUpdateText() {
         if plainTextMode {
             if textView.text.isEmpty != isContentEmpty {
                 isContentEmpty = textView.text.isEmpty

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -382,7 +382,7 @@ private extension WysiwygComposerViewModel {
         }
     }
 
-    /// Reconcilaite the content of the model with the content of the text view.
+    /// Reconciliate the content of the model with the content of the text view.
     func reconciliateIfNeeded() {
         do {
             guard let replacement = try StringDiffer.replacement(from: attributedContent.text.string,
@@ -403,9 +403,7 @@ private extension WysiwygComposerViewModel {
                                             endUtf16Codeunit: UInt32(rustSelection.upperBound))
             applyUpdate(selectUpdate)
 
-            Logger.viewModel.logDebug(["Reconciliate from \"\(attributedContent.text.string)\" to \"\(textView.text ?? "")\" with \"\(replacement.text)\""],
-                                      functionName: #function)
-            Logger.viewModel.logDebug(["Reconciliate model markdown: \"\(model.getContentAsMarkdown())\""],
+            Logger.viewModel.logDebug(["Reconciliate from \"\(attributedContent.text.string)\" to \"\(textView.text ?? "")\""],
                                       functionName: #function)
         } catch {
             switch error {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -265,13 +265,13 @@ public extension WysiwygComposerViewModel {
             // Reconciliate
 
             // swiftlint:disable:next force_try
-            let rustRange = try! attributedContent.text.htmlRange(from: replacement.0)
+            let rustRange = try! attributedContent.text.htmlRange(from: replacement.range)
 
-            _ = model.replaceTextIn(newText: replacement.1,
+            _ = model.replaceTextIn(newText: replacement.text,
                                     start: UInt32(rustRange.location),
                                     end: UInt32(rustRange.upperBound))
 
-            Logger.viewModel.logDebug(["Reconciliate from \"\(attributedContent.text.string)\" to \"\(textView.text ?? "")\" with \"\(replacement.1)\""],
+            Logger.viewModel.logDebug(["Reconciliate from \"\(attributedContent.text.string)\" to \"\(textView.text ?? "")\" with \"\(replacement.text)\""],
                                       functionName: #function)
             Logger.viewModel.logDebug(["Reconciliate model markdown: \"\(model.getContentAsMarkdown())\""],
                                       functionName: #function)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -37,7 +37,5 @@ public protocol WysiwygComposerViewModelProtocol: AnyObject {
     func select(range: NSRange)
 
     /// Notify that the text view content has changed.
-    ///
-    /// - Parameter shouldReconciliate: value that indicates if the the function should reconciliate the content of the model to the content of the textView.
-    func didUpdateText(shouldReconciliate: Bool)
+    func didUpdateText()
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/CollectionDifference.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/CollectionDifference.swift
@@ -16,23 +16,32 @@
 
 import Foundation
 
+typealias UTF16Removals = [NSRange]
+typealias UTF16Insertions = [(range: NSRange, text: String)]
+
 extension CollectionDifference<Character> {
     /// Transforms the removals in the `CollectionDifference` into an array of ranges.
-    var removedRanges: [NSRange] {
+    /// Output ranges are defined with UTF16 locations and lengths.
+    ///
+    /// - Parameter string: String in which the characters have been removed.
+    /// - Returns: Array of removed ranges.
+    func utf16Removals(in string: String) -> UTF16Removals {
         removals.reduce([]) { partialResult, change in
             var partialRes = partialResult
             switch change {
-            case .remove(offset: let offset, element: _, associatedWith: _):
+            case .remove(offset: let offset, element: let element, associatedWith: _):
+                let index = string.index(string.startIndex, offsetBy: offset)
+                let utf16Offset = string[..<index].utf16.count
                 if let lastRange = partialRes.popLast() {
-                    if lastRange.upperBound == offset {
-                        partialRes.append(NSRange(location: lastRange.location, length: lastRange.length + 1))
+                    if lastRange.upperBound == utf16Offset {
+                        partialRes.append(NSRange(location: lastRange.location, length: lastRange.length + element.utf16.count))
                     } else {
                         partialRes.append(lastRange)
-                        partialRes.append(NSRange(location: offset, length: 1))
+                        partialRes.append(NSRange(location: utf16Offset, length: element.utf16.count))
                     }
                     return partialRes
                 } else {
-                    return [NSRange(location: offset, length: 1)]
+                    return [NSRange(location: utf16Offset, length: element.utf16.count)]
                 }
             default:
                 return []
@@ -41,24 +50,30 @@ extension CollectionDifference<Character> {
     }
 
     /// Transforms the insertions in the `CollectionDifference` into an array of ranges and associated text.
-    var textInsertions: [(range: NSRange, text: String)] {
+    /// Output ranges are defined with UTF16 locations and lengths.
+    ///
+    /// - Parameter string: String in which the characters have been inserted.
+    /// - Returns: Array of inserted ranges and text.
+    func utf16Insertions(in string: String) -> UTF16Insertions {
         insertions.reduce([]) { partialResult, change in
             var partialRes = partialResult
             switch change {
             case .insert(offset: let offset, element: let element, associatedWith: _):
+                let index = string.index(string.startIndex, offsetBy: offset)
+                let utf16Offset = string[..<index].utf16.count
                 if let lastRange = partialRes.popLast() {
                     let (range, text) = lastRange
-                    if range.upperBound == offset {
+                    if range.upperBound == utf16Offset {
                         partialRes.append(
-                            (NSRange(location: range.location, length: range.length + 1), text + String(element))
+                            (NSRange(location: range.location, length: range.length + element.utf16.count), text + String(element))
                         )
                     } else {
                         partialRes.append(lastRange)
-                        partialRes.append((NSRange(location: offset, length: 1), String(element)))
+                        partialRes.append((NSRange(location: utf16Offset, length: element.utf16.count), String(element)))
                     }
                     return partialRes
                 } else {
-                    return [(NSRange(location: offset, length: 1), String(element))]
+                    return [(NSRange(location: utf16Offset, length: element.utf16.count), String(element))]
                 }
             default:
                 return []

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/CollectionDifference.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/CollectionDifference.swift
@@ -32,23 +32,22 @@ extension CollectionDifference<Character> {
             case .remove(offset: let offset, element: let element, associatedWith: _):
                 let index = string.index(string.startIndex, offsetBy: offset)
                 let utf16Offset = string[..<index].utf16.count
-                if let lastRange = partialRes.popLast() {
-                    if lastRange.upperBound == utf16Offset {
-                        partialRes.append(NSRange(location: lastRange.location, length: lastRange.length + element.utf16.count))
-                    } else {
-                        partialRes.append(lastRange)
-                        partialRes.append(NSRange(location: utf16Offset, length: element.utf16.count))
-                    }
-                    return partialRes
-                } else {
+                guard let lastRange = partialRes.popLast() else {
                     return [NSRange(location: utf16Offset, length: element.utf16.count)]
                 }
+                if lastRange.upperBound == utf16Offset {
+                    partialRes.append(NSRange(location: lastRange.location, length: lastRange.length + element.utf16.count))
+                } else {
+                    partialRes.append(lastRange)
+                    partialRes.append(NSRange(location: utf16Offset, length: element.utf16.count))
+                }
+                return partialRes
             default:
                 return []
             }
         }
     }
-
+    
     /// Transforms the insertions in the `CollectionDifference` into an array of ranges and associated text.
     /// Output ranges are defined with UTF16 locations and lengths.
     ///
@@ -61,20 +60,19 @@ extension CollectionDifference<Character> {
             case .insert(offset: let offset, element: let element, associatedWith: _):
                 let index = string.index(string.startIndex, offsetBy: offset)
                 let utf16Offset = string[..<index].utf16.count
-                if let lastRange = partialRes.popLast() {
-                    let (range, text) = lastRange
-                    if range.upperBound == utf16Offset {
-                        partialRes.append(
-                            (NSRange(location: range.location, length: range.length + element.utf16.count), text + String(element))
-                        )
-                    } else {
-                        partialRes.append(lastRange)
-                        partialRes.append((NSRange(location: utf16Offset, length: element.utf16.count), String(element)))
-                    }
-                    return partialRes
-                } else {
+                guard let lastRange = partialRes.popLast() else {
                     return [(NSRange(location: utf16Offset, length: element.utf16.count), String(element))]
                 }
+                let (range, text) = lastRange
+                if range.upperBound == utf16Offset {
+                    partialRes.append(
+                        (NSRange(location: range.location, length: range.length + element.utf16.count), text + String(element))
+                    )
+                } else {
+                    partialRes.append(lastRange)
+                    partialRes.append((NSRange(location: utf16Offset, length: element.utf16.count), String(element)))
+                }
+                return partialRes
             default:
                 return []
             }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/CollectionDifference.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/CollectionDifference.swift
@@ -1,0 +1,68 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+extension CollectionDifference<Character> {
+    /// Transforms the removals in the `CollectionDifference` into an array of ranges.
+    var removedRanges: [NSRange] {
+        removals.reduce([]) { partialResult, change in
+            var partialRes = partialResult
+            switch change {
+            case .remove(offset: let offset, element: _, associatedWith: _):
+                if let lastRange = partialRes.popLast() {
+                    if lastRange.upperBound == offset {
+                        partialRes.append(NSRange(location: lastRange.location, length: lastRange.length + 1))
+                    } else {
+                        partialRes.append(lastRange)
+                        partialRes.append(NSRange(location: offset, length: 1))
+                    }
+                    return partialRes
+                } else {
+                    return [NSRange(location: offset, length: 1)]
+                }
+            default:
+                return []
+            }
+        }
+    }
+
+    /// Transforms the insertions in the `CollectionDifference` into an array of ranges and associated text.
+    var textInsertions: [(range: NSRange, text: String)] {
+        insertions.reduce([]) { partialResult, change in
+            var partialRes = partialResult
+            switch change {
+            case .insert(offset: let offset, element: let element, associatedWith: _):
+                if let lastRange = partialRes.popLast() {
+                    let (range, text) = lastRange
+                    if range.upperBound == offset {
+                        partialRes.append(
+                            (NSRange(location: range.location, length: range.length + 1), text + String(element))
+                        )
+                    } else {
+                        partialRes.append(lastRange)
+                        partialRes.append((NSRange(location: offset, length: 1), String(element)))
+                    }
+                    return partialRes
+                } else {
+                    return [(NSRange(location: offset, length: 1), String(element))]
+                }
+            default:
+                return []
+            }
+        }
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
@@ -25,6 +25,8 @@ extension UITextView {
     /// - Parameters:
     ///   - content: Content to apply.
     func apply(_ content: WysiwygComposerAttributedContent) {
+        guard content.text != attributedText || content.selection != selectedRange else { return }
+
         performWithoutDelegate {
             self.attributedText = content.text
             // Set selection to {0, 0} then to expected position

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
@@ -36,8 +36,8 @@ final class StringDiffer {
 
     // MARK: - Internal
 
-    static func replacement(from oldString: String, to newString: String) throws -> (NSRange, String)? {
-        let difference = newString.withNBSP.difference(from: oldString.withNBSP)
+    static func replacement(from oldText: String, to newText: String) throws -> (range: NSRange, text: String)? {
+        let difference = newText.withNBSP.difference(from: oldText.withNBSP)
 
         guard !difference.isEmpty else {
             Logger.stringDiffer.log("No difference between strings")

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
@@ -145,7 +145,7 @@ private extension CollectionDifference<Character> {
     }
 
     var insertedText: [Character] {
-        compactMap {
+        insertions.compactMap {
             switch $0 {
             case .insert(offset: _, element: let element, associatedWith: _):
                 return element

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
@@ -1,0 +1,128 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OSLog
+
+/// Describe an error occurring during HTML string build.
+enum StringDifferError: LocalizedError, Equatable {
+    case unknown
+
+    var errorDescription: String? {
+        switch self {
+        case .unknown:
+            return "An unknown error occurred during string diffing"
+        }
+    }
+}
+
+final class StringDiffer {
+    // MARK: - Private
+
+    private init() { }
+
+    // MARK: - Internal
+
+    static func replacement(from oldString: String, to newString: String) throws -> (NSRange, String)? {
+        let difference = newString.withNBSP.difference(from: oldString.withNBSP)
+
+        guard !difference.isEmpty else {
+            Logger.stringDiffer.log("No difference between strings")
+            return nil
+        }
+
+        let insertedText = String(difference.insertedText)
+
+        if let removedRange = difference.removedRange {
+            Logger.stringDiffer.log("Range: \(removedRange), Text: \(insertedText)")
+            return (removedRange, insertedText)
+        } else if let insertedRange = difference.insertedRange {
+            Logger.stringDiffer.log("Range: \(NSRange(location: insertedRange.location, length: 0)), Text: \(insertedText)")
+            return (NSRange(location: insertedRange.location, length: 0), insertedText)
+        } else {
+            Logger.stringDiffer.log("No difference between strings ???")
+            throw StringDifferError.unknown
+        }
+    }
+}
+
+private extension Logger {
+    static let stringDiffer = Logger(subsystem: subsystem, category: "StringDiffer")
+}
+
+private extension String {
+    /// Converts all whitespaces to NBSP to avoid diffs caused by HTML translations.
+    var withNBSP: String {
+        String(map { $0.isWhitespace ? Character("\u{00A0}") : $0 })
+    }
+}
+
+private extension CollectionDifference<Character> {
+    var removedRange: NSRange? {
+        removals.reduce(nil) { partialResult, change in
+            let index: Int
+            switch change {
+            case .remove(offset: let offset, element: _, associatedWith: _):
+                index = offset
+            default:
+                return nil
+            }
+
+            if let partialResult = partialResult {
+                if partialResult.upperBound == index {
+                    return NSRange(location: partialResult.location, length: partialResult.length + 1)
+                } else {
+                    return nil
+                }
+            } else {
+                return NSRange(location: index, length: 1)
+            }
+        }
+    }
+
+    var insertedRange: NSRange? {
+        insertions.reduce(nil) { partialResult, change in
+            let index: Int
+            switch change {
+            case .insert(offset: let offset, element: _, associatedWith: _):
+                index = offset
+            default:
+                return nil
+            }
+
+            if let partialResult = partialResult {
+                if partialResult.upperBound == index {
+                    return NSRange(location: partialResult.location, length: partialResult.length + 1)
+                } else {
+                    return nil
+                }
+            } else {
+                return NSRange(location: index, length: 1)
+            }
+        }
+    }
+
+    var insertedText: [Character] {
+        compactMap {
+            switch $0 {
+            case .insert(offset: _, element: let element, associatedWith: _):
+                return element
+            default:
+                return nil
+            }
+        }
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -100,6 +100,13 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.attributedContent.selection, .zero)
     }
 
+    func testReconciliateRestoresFromModel() {
+        _ = viewModel.replaceText(range: .zero, replacementText: "Some text")
+        viewModel.textView.attributedText = NSAttributedString(string: "Some text")
+        reconciliate(to: "Home test", selectedRange: .zero)
+        XCTAssertEqual(viewModel.textView.text, "Some text")
+    }
+
     func testPlainTextMode() {
         _ = viewModel.replaceText(range: .zero,
                                   replacementText: "Some bold text")

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -77,13 +77,15 @@ final class WysiwygComposerViewModelTests: XCTestCase {
 
     func testReconciliateTextView() {
         _ = viewModel.replaceText(range: .zero,
-                                  replacementText: "A")
-        viewModel.textView.attributedText = NSAttributedString(string: "AA")
-        XCTAssertEqual(viewModel.textView.text, "AA")
-        XCTAssertEqual(viewModel.textView.selectedRange, NSRange(location: 2, length: 0))
-        viewModel.didUpdateText()
-        XCTAssertEqual(viewModel.textView.text, "A")
+                                  replacementText: "wa")
+        viewModel.textView.attributedText = NSAttributedString(string: "わ")
+        XCTAssertEqual(viewModel.textView.text, "わ")
         XCTAssertEqual(viewModel.textView.selectedRange, NSRange(location: 1, length: 0))
+        XCTAssertEqual(viewModel.attributedContent.text.string, "wa")
+        XCTAssertEqual(viewModel.attributedContent.selection, NSRange(location: 2, length: 0))
+        viewModel.didUpdateText()
+        XCTAssertEqual(viewModel.attributedContent.text.string, "わ")
+        XCTAssertEqual(viewModel.attributedContent.selection, NSRange(location: 1, length: 0))
     }
 
     func testPlainTextMode() {

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/CollectionDifferenceTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/CollectionDifferenceTests.swift
@@ -18,59 +18,99 @@
 import XCTest
 
 final class CollectionDifferenceTests: XCTestCase {
+    func testNoChanges() {
+        let changes = changes(from: "text", to: "text")
+        XCTAssertTrue(changes.removals.isEmpty)
+        XCTAssertTrue(changes.insertions.isEmpty)
+    }
+
     func testSimpleRemoval() {
-        let difference = "tex".difference(from: "text")
-        XCTAssertEqual(difference.removedRanges,
+        let changes = changes(from: "text", to: "tex")
+        XCTAssertEqual(changes.removals,
                        [NSRange(location: 3, length: 1)])
-        XCTAssertTrue(difference.textInsertions.isEmpty)
+        XCTAssertTrue(changes.insertions.isEmpty)
     }
 
     func testMultipleRemovals() {
-        let difference = "ex".difference(from: "text")
-        XCTAssertEqual(difference.removedRanges,
+        let changes = changes(from: "text", to: "ex")
+        XCTAssertEqual(changes.removals,
                        [NSRange(location: 0, length: 1),
                         NSRange(location: 3, length: 1)])
-        XCTAssertTrue(difference.textInsertions.isEmpty)
+        XCTAssertTrue(changes.insertions.isEmpty)
     }
 
     func testSimpleInsertion() {
-        let difference = "text".difference(from: "tex")
-        XCTAssertEqual(difference.textInsertions.map(\.range),
+        let changes = changes(from: "tex", to: "text")
+        XCTAssertEqual(changes.insertions.map(\.range),
                        [NSRange(location: 3, length: 1)])
-        XCTAssertEqual(difference.textInsertions.map(\.text),
+        XCTAssertEqual(changes.insertions.map(\.text),
                        ["t"])
-        XCTAssertTrue(difference.removedRanges.isEmpty)
+        XCTAssertTrue(changes.removals.isEmpty)
     }
 
     func testMultipleInsertions() {
-        let difference = "texts".difference(from: "ex")
-        XCTAssertEqual(difference.textInsertions.map(\.range),
+        let changes = changes(from: "ex", to: "texts")
+        XCTAssertEqual(changes.insertions.map(\.range),
                        [NSRange(location: 0, length: 1),
                         NSRange(location: 3, length: 2)])
-        XCTAssertEqual(difference.textInsertions.map(\.text),
+        XCTAssertEqual(changes.insertions.map(\.text),
                        ["t", "ts"])
-        XCTAssertTrue(difference.removedRanges.isEmpty)
+        XCTAssertTrue(changes.removals.isEmpty)
     }
 
     func testSimpleReplacement() {
-        let difference = "tessst".difference(from: "text")
-        XCTAssertEqual(difference.removedRanges,
+        let changes = changes(from: "text", to: "tessst")
+        XCTAssertEqual(changes.removals,
                        [NSRange(location: 2, length: 1)])
-        XCTAssertEqual(difference.textInsertions.map(\.range),
+        XCTAssertEqual(changes.insertions.map(\.range),
                        [NSRange(location: 2, length: 3)])
-        XCTAssertEqual(difference.textInsertions.map(\.text),
+        XCTAssertEqual(changes.insertions.map(\.text),
                        ["sss"])
     }
 
     func testMultipleReplacements() {
-        let difference = "wexpf".difference(from: "text")
-        XCTAssertEqual(difference.removedRanges,
+        let changes = changes(from: "text", to: "wexpf")
+        XCTAssertEqual(changes.removals,
                        [NSRange(location: 0, length: 1),
                         NSRange(location: 3, length: 1)])
-        XCTAssertEqual(difference.textInsertions.map(\.range),
+        XCTAssertEqual(changes.insertions.map(\.range),
                        [NSRange(location: 0, length: 1),
                         NSRange(location: 3, length: 2)])
-        XCTAssertEqual(difference.textInsertions.map(\.text),
+        XCTAssertEqual(changes.insertions.map(\.text),
                        ["w", "pf"])
+    }
+
+    func testMultipleCodeUnitsReplacements() {
+        let changes1 = changes(from: "abcde 🥳", to: "abcde")
+        XCTAssertEqual(changes1.removals,
+                       [NSRange(location: 5, length: 3)])
+        let changes2 = changes(from: "abcde", to: "abcde 🥳")
+        XCTAssertEqual(changes2.insertions.map(\.range),
+                       [NSRange(location: 5, length: 3)])
+        XCTAssertEqual(changes2.insertions.map(\.text),
+                       [" 🥳"])
+    }
+
+    func testRemovalNearMultiCodeUnitsCharacters() {
+        let changes = changes(from: "abcde 🥳 ", to: "abcde 🥳")
+        XCTAssertEqual(changes.removals,
+                       [NSRange(location: 8, length: 1)])
+    }
+}
+
+private extension CollectionDifferenceTests {
+    func removals(from oldText: String, to newText: String) -> UTF16Removals {
+        let difference = newText.difference(from: oldText)
+        return difference.utf16Removals(in: oldText)
+    }
+
+    func insertions(from oldText: String, to newText: String) -> UTF16Insertions {
+        let difference = newText.difference(from: oldText)
+        return difference.utf16Insertions(in: newText)
+    }
+
+    func changes(from oldText: String, to newText: String) -> (removals: UTF16Removals, insertions: UTF16Insertions) {
+        let difference = newText.difference(from: oldText)
+        return (difference.utf16Removals(in: oldText), difference.utf16Insertions(in: newText))
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/CollectionDifferenceTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/CollectionDifferenceTests.swift
@@ -1,0 +1,76 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import WysiwygComposer
+import XCTest
+
+final class CollectionDifferenceTests: XCTestCase {
+    func testSimpleRemoval() {
+        let difference = "tex".difference(from: "text")
+        XCTAssertEqual(difference.removedRanges,
+                       [NSRange(location: 3, length: 1)])
+        XCTAssertTrue(difference.textInsertions.isEmpty)
+    }
+
+    func testMultipleRemovals() {
+        let difference = "ex".difference(from: "text")
+        XCTAssertEqual(difference.removedRanges,
+                       [NSRange(location: 0, length: 1),
+                        NSRange(location: 3, length: 1)])
+        XCTAssertTrue(difference.textInsertions.isEmpty)
+    }
+
+    func testSimpleInsertion() {
+        let difference = "text".difference(from: "tex")
+        XCTAssertEqual(difference.textInsertions.map(\.range),
+                       [NSRange(location: 3, length: 1)])
+        XCTAssertEqual(difference.textInsertions.map(\.text),
+                       ["t"])
+        XCTAssertTrue(difference.removedRanges.isEmpty)
+    }
+
+    func testMultipleInsertions() {
+        let difference = "texts".difference(from: "ex")
+        XCTAssertEqual(difference.textInsertions.map(\.range),
+                       [NSRange(location: 0, length: 1),
+                        NSRange(location: 3, length: 2)])
+        XCTAssertEqual(difference.textInsertions.map(\.text),
+                       ["t", "ts"])
+        XCTAssertTrue(difference.removedRanges.isEmpty)
+    }
+
+    func testSimpleReplacement() {
+        let difference = "tessst".difference(from: "text")
+        XCTAssertEqual(difference.removedRanges,
+                       [NSRange(location: 2, length: 1)])
+        XCTAssertEqual(difference.textInsertions.map(\.range),
+                       [NSRange(location: 2, length: 3)])
+        XCTAssertEqual(difference.textInsertions.map(\.text),
+                       ["sss"])
+    }
+
+    func testMultipleReplacements() {
+        let difference = "wexpf".difference(from: "text")
+        XCTAssertEqual(difference.removedRanges,
+                       [NSRange(location: 0, length: 1),
+                        NSRange(location: 3, length: 1)])
+        XCTAssertEqual(difference.textInsertions.map(\.range),
+                       [NSRange(location: 0, length: 1),
+                        NSRange(location: 3, length: 2)])
+        XCTAssertEqual(difference.textInsertions.map(\.text),
+                       ["w", "pf"])
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import WysiwygComposer
+import XCTest
+
+final class StringDifferTests: XCTestCase {
+    func testNoReplacement() throws {
+        let identicalText = "text"
+        let replacement = try StringDiffer.replacement(from: identicalText, to: identicalText)
+        XCTAssertNil(replacement)
+    }
+
+    func testFullReplacement() throws {
+        let oldText = "wa"
+        let newText = "わ"
+        let replacement = try StringDiffer.replacement(from: oldText, to: newText)
+        XCTAssertEqual(replacement?.range,
+                       NSRange(location: 0, length: 2))
+        XCTAssertEqual(replacement?.text, "わ")
+    }
+
+    func testPartialReplacement() throws {
+        let oldText = "わta"
+        let newText = "わた"
+        let replacement = try StringDiffer.replacement(from: oldText, to: newText)
+        XCTAssertEqual(replacement?.range,
+                       NSRange(location: 1, length: 2))
+        XCTAssertEqual(replacement?.text, "た")
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
@@ -24,6 +24,21 @@ final class StringDifferTests: XCTestCase {
         XCTAssertNil(replacement)
     }
 
+    func testSimpleRemoval() throws {
+        let replacement = try StringDiffer.replacement(from: "text", to: "te")
+        XCTAssertEqual(replacement?.range,
+                       NSRange(location: 2, length: 2))
+        XCTAssertEqual(replacement?.text, "")
+    }
+
+    func testSimpleInsertion() throws {
+        let replacement = try StringDiffer.replacement(from: "te", to: "text")
+        XCTAssertEqual(replacement?.range,
+                       NSRange(location: 2, length: 0))
+        XCTAssertEqual(replacement?.text,
+                       "xt")
+    }
+
     func testFullReplacement() throws {
         let oldText = "wa"
         let newText = "わ"
@@ -40,5 +55,23 @@ final class StringDifferTests: XCTestCase {
         XCTAssertEqual(replacement?.range,
                        NSRange(location: 1, length: 2))
         XCTAssertEqual(replacement?.text, "た")
+    }
+
+    func testDoubleReplacementIsNotHandled() throws {
+        let oldText = "text"
+        let newText = "fexf"
+        XCTAssertThrowsError(try StringDiffer.replacement(from: oldText, to: newText), "doubleReplacementIsNotHandled") { error in
+            XCTAssertEqual(error as? StringDifferError,
+                           StringDifferError.tooComplicated)
+        }
+    }
+
+    func testInsertionsDontMatchRemovalsLocation() throws {
+        let oldText = "text"
+        let newText = "extab"
+        XCTAssertThrowsError(try StringDiffer.replacement(from: oldText, to: newText), "insertionsDontMatchRemovalsLocation") { error in
+            XCTAssertEqual(error as? StringDifferError,
+                           StringDifferError.insertionsDontMatchRemovals)
+        }
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
@@ -20,56 +20,38 @@ import XCTest
 final class StringDifferTests: XCTestCase {
     func testNoReplacement() throws {
         let identicalText = "text"
-        let replacement = try StringDiffer.replacement(from: identicalText, to: identicalText)
-        XCTAssertNil(replacement)
+        XCTAssertNil(try StringDiffer.replacement(from: identicalText, to: identicalText))
     }
 
     func testSimpleRemoval() throws {
-        let replacement = try StringDiffer.replacement(from: "text", to: "te")
-        XCTAssertEqual(replacement?.range,
-                       NSRange(location: 2, length: 2))
-        XCTAssertEqual(replacement?.text, "")
+        XCTAssertEqual(try StringDiffer.replacement(from: "text", to: "te"),
+                       .init(location: 2, length: 2, text: ""))
     }
 
     func testSimpleInsertion() throws {
-        let replacement = try StringDiffer.replacement(from: "te", to: "text")
-        XCTAssertEqual(replacement?.range,
-                       NSRange(location: 2, length: 0))
-        XCTAssertEqual(replacement?.text,
-                       "xt")
+        XCTAssertEqual(try StringDiffer.replacement(from: "te", to: "text"),
+                       .init(location: 2, length: 0, text: "xt"))
     }
 
     func testFullReplacement() throws {
-        let oldText = "wa"
-        let newText = "わ"
-        let replacement = try StringDiffer.replacement(from: oldText, to: newText)
-        XCTAssertEqual(replacement?.range,
-                       NSRange(location: 0, length: 2))
-        XCTAssertEqual(replacement?.text, "わ")
+        XCTAssertEqual(try StringDiffer.replacement(from: "wa", to: "わ"),
+                       .init(location: 0, length: 2, text: "わ"))
     }
 
     func testPartialReplacement() throws {
-        let oldText = "わta"
-        let newText = "わた"
-        let replacement = try StringDiffer.replacement(from: oldText, to: newText)
-        XCTAssertEqual(replacement?.range,
-                       NSRange(location: 1, length: 2))
-        XCTAssertEqual(replacement?.text, "た")
+        XCTAssertEqual(try StringDiffer.replacement(from: "わta", to: "わた"),
+                       .init(location: 1, length: 2, text: "た"))
     }
 
     func testDoubleReplacementIsNotHandled() throws {
-        let oldText = "text"
-        let newText = "fexf"
-        XCTAssertThrowsError(try StringDiffer.replacement(from: oldText, to: newText), "doubleReplacementIsNotHandled") { error in
+        XCTAssertThrowsError(try StringDiffer.replacement(from: "text", to: "fexf"), "doubleReplacementIsNotHandled") { error in
             XCTAssertEqual(error as? StringDifferError,
                            StringDifferError.tooComplicated)
         }
     }
 
     func testInsertionsDontMatchRemovalsLocation() throws {
-        let oldText = "text"
-        let newText = "extab"
-        XCTAssertThrowsError(try StringDiffer.replacement(from: oldText, to: newText), "insertionsDontMatchRemovalsLocation") { error in
+        XCTAssertThrowsError(try StringDiffer.replacement(from: "text", to: "extab"), "insertionsDontMatchRemovalsLocation") { error in
             XCTAssertEqual(error as? StringDifferError,
                            StringDifferError.insertionsDontMatchRemovals)
         }


### PR DESCRIPTION
Adds a StringDiffer that reconciliate content between the UITextView and the Rust model.

Fixes: 

* Magic replacements of the text view content from iOS, including:
  - Japanese auto-replacement from latin input (Romaji keyboard)
  - Korean replacement through combining symbols
  - Chinese keyboard suggestions (Pinyin keyboard)
  - Smart punctuation (e.g.: double space replaced by a dot)
  - iOS inconsistencies over characters (e.g.: `shouldChangeTextIn` providing U+0027 but actually using U+2019)
* Pending formats not applying during voice dictation
* Fixes backspace sometimes blocking on whitespaces
* Improves spell-checker/auto-correct since it lets the system handle more of the text view updates #277 
