### PR TITLE
Set the text view as a non optional ViewModel owned property

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -39,7 +39,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
     }
     
     public func makeUIView(context: Context) -> PlaceholdableTextView {
-        let textView = PlaceholdableTextView()
+        let textView = viewModel.textView
         
         textView.accessibilityIdentifier = "WysiwygComposer"
         textView.font = UIFont.preferredFont(forTextStyle: .body)
@@ -56,7 +56,6 @@ public struct WysiwygComposerView: UIViewRepresentable {
         textView.placeholderFont = UIFont.preferredFont(forTextStyle: .body)
         textView.placeholderColor = UIColor(placeholderColor)
         textView.placeholder = placeholder
-        viewModel.textView = textView
         viewModel.updateCompressedHeightIfNeeded()
         return textView
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -18,7 +18,7 @@ import UIKit
 
 public protocol WysiwygComposerViewModelProtocol: AnyObject {
     /// The textView with placeholder support that the model manages
-    var textView: PlaceholdableTextView? { get set }
+    var textView: PlaceholdableTextView { get }
 
     /// Update the composer compressed required height if it has changed.
     func updateCompressedHeightIfNeeded()

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -23,7 +23,6 @@ final class WysiwygComposerViewModelTests: XCTestCase {
 
     override func setUpWithError() throws {
         viewModel.clearContent()
-        viewModel.textView = PlaceholdableTextView()
     }
 
     func testIsContentEmpty() throws {
@@ -41,7 +40,7 @@ final class WysiwygComposerViewModelTests: XCTestCase {
 
         _ = viewModel.replaceText(range: .zero,
                                   replacementText: "Test")
-        viewModel.textView?.attributedText = viewModel.attributedContent.text
+        viewModel.textView.attributedText = viewModel.attributedContent.text
 
         wait(for: [expectFalse], timeout: 2.0)
         cancellableFalse.cancel()
@@ -58,7 +57,7 @@ final class WysiwygComposerViewModelTests: XCTestCase {
 
         _ = viewModel.replaceText(range: .init(location: 0, length: viewModel.attributedContent.text.length),
                                   replacementText: "")
-        viewModel.textView?.attributedText = viewModel.attributedContent.text
+        viewModel.textView.attributedText = viewModel.attributedContent.text
 
         wait(for: [expectTrue], timeout: 2.0)
         cancellableTrue.cancel()
@@ -79,18 +78,18 @@ final class WysiwygComposerViewModelTests: XCTestCase {
     func testReconciliateTextView() {
         _ = viewModel.replaceText(range: .zero,
                                   replacementText: "A")
-        viewModel.textView?.attributedText = NSAttributedString(string: "AA")
-        XCTAssertEqual(viewModel.textView?.text, "AA")
-        XCTAssertEqual(viewModel.textView?.selectedRange, NSRange(location: 2, length: 0))
+        viewModel.textView.attributedText = NSAttributedString(string: "AA")
+        XCTAssertEqual(viewModel.textView.text, "AA")
+        XCTAssertEqual(viewModel.textView.selectedRange, NSRange(location: 2, length: 0))
         viewModel.didUpdateText()
-        XCTAssertEqual(viewModel.textView?.text, "A")
-        XCTAssertEqual(viewModel.textView?.selectedRange, NSRange(location: 1, length: 0))
+        XCTAssertEqual(viewModel.textView.text, "A")
+        XCTAssertEqual(viewModel.textView.selectedRange, NSRange(location: 1, length: 0))
     }
 
     func testPlainTextMode() {
         _ = viewModel.replaceText(range: .zero,
                                   replacementText: "Some bold text")
-        viewModel.textView?.attributedText = NSAttributedString(string: "Some bold text")
+        viewModel.textView.attributedText = NSAttributedString(string: "Some bold text")
         viewModel.select(range: .init(location: 10, length: 4))
         viewModel.apply(.bold)
 


### PR DESCRIPTION
Set the text view as non optional and move it to be directly owned by the view model. This will avoid a lot of unwrapping. 