### PR TITLE
[Android] Add incremental text diff support when typing

### DIFF
--- a/platforms/android/.gitignore
+++ b/platforms/android/.gitignore
@@ -9,6 +9,8 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/kotlinc.xml
+/.idea/androidTestResultsUserPreferences.xml
 .DS_Store
 /build
 /captures

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -258,4 +258,40 @@ class InterceptInputConnectionIntegrationTest {
             )
         )
     }
+
+    @Test
+    fun testIncrementalCommitTextRespectsFormatting() {
+        // Set initial text
+        val initialText = viewModel.processInput(
+            EditorInputAction.ReplaceAllHtml("<strong>test</strong>")
+        )?.text
+        textView.setText(initialText)
+        // Disable bold at end of string
+        textView.setSelection(4)
+        viewModel.processInput(EditorInputAction.ApplyInlineFormat(InlineFormat.Bold))
+        // Autocomplete 'test' -> 'testing'
+        inputConnection.setComposingRegion(0, 4)
+        inputConnection.commitText("testing", 1)
+
+        assertThat(viewModel.getHtml(), equalTo("<strong>test</strong>ing"))
+    }
+
+    @Test
+    fun testIncrementalCommitWithFormattingDisabledKeepsItDisabledWithWhitespace() {
+        // Set initial text
+        val initialText = viewModel.processInput(
+            EditorInputAction.ReplaceAllHtml("<strong>test</strong>")
+        )?.text
+        textView.setText(initialText)
+        // Disable bold at end of string
+        textView.setSelection(4)
+        viewModel.processInput(EditorInputAction.ApplyInlineFormat(InlineFormat.Bold))
+        // Autocomplete 'test' -> 'testing'
+        inputConnection.setComposingRegion(0, 4)
+        inputConnection.commitText("test ", 1)
+        // Add some extra text
+        inputConnection.setComposingText("whitespaces", 1)
+
+        assertThat(viewModel.getHtml(), equalTo("<strong>test</strong> whitespaces"))
+    }
 }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -277,7 +277,7 @@ class InterceptInputConnectionIntegrationTest {
     }
 
     @Test
-    fun testIncrementalCommitWithFormattingDisabledKeepsItDisabledWithWhitespace() {
+    fun testIncrementalCommitWithDisabledFormattingKeepsItDisabledAfterWhitespace() {
         // Set initial text
         val initialText = viewModel.processInput(
             EditorInputAction.ReplaceAllHtml("<strong>test</strong>")
@@ -286,7 +286,7 @@ class InterceptInputConnectionIntegrationTest {
         // Disable bold at end of string
         textView.setSelection(4)
         viewModel.processInput(EditorInputAction.ApplyInlineFormat(InlineFormat.Bold))
-        // Autocomplete 'test' -> 'testing'
+        // Autocomplete 'test' -> 'test '
         inputConnection.setComposingRegion(0, 4)
         inputConnection.commitText("test ", 1)
         // Add some extra text

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
@@ -29,8 +29,6 @@ import io.mockk.spyk
 import io.mockk.verify
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Description
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
 import org.junit.*
 import org.junit.runner.RunWith
 import uniffi.wysiwyg_composer.ActionState
@@ -209,6 +207,7 @@ class EditorEditTextInputTests {
     }
 
     @Test
+    @Ignore("Lists are being refactored at the moment")
     fun testAddingOrderedList() {
         onView(withId(R.id.rich_text_edit_text))
             .perform(EditorActions.toggleList(true))
@@ -223,6 +222,7 @@ class EditorEditTextInputTests {
     }
 
     @Test
+    @Ignore("Lists are being refactored at the moment")
     fun testAddingUnorderedList() {
         onView(withId(R.id.rich_text_edit_text))
             .perform(EditorActions.toggleList(false))

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -17,6 +17,7 @@ import io.element.android.wysiwyg.utils.EditorIndexMapper
 import io.element.android.wysiwyg.utils.HtmlToSpansParser.FormattingSpans.removeFormattingSpans
 import io.element.android.wysiwyg.viewmodel.EditorViewModel
 import kotlin.math.abs
+import kotlin.math.max
 import kotlin.math.min
 
 internal class InterceptInputConnection(
@@ -199,9 +200,11 @@ internal class InterceptInputConnection(
         if (start == 0 && end == 0) return false
 
         val toDelete = if (start == end) 1 else abs(start - end)
+        // We're going to copy backspace behaviour, the selection must be at the greater value
+        val deletePos = max(start, end)
 
         // Imitate the software key backspace which updates the selection start to match the end.
-        Selection.setSelection(editable, end, end)
+        Selection.setSelection(editable, deletePos, deletePos)
 
         return deleteSurroundingText(toDelete, 0)
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -12,12 +12,10 @@ import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
+import io.element.android.wysiwyg.inputhandlers.models.ReplaceTextResult
 import io.element.android.wysiwyg.utils.EditorIndexMapper
 import io.element.android.wysiwyg.utils.HtmlToSpansParser.FormattingSpans.removeFormattingSpans
 import io.element.android.wysiwyg.viewmodel.EditorViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.min
 
@@ -105,10 +103,7 @@ internal class InterceptInputConnection(
     // Called when started typing
     override fun setComposingText(text: CharSequence?, newCursorPosition: Int): Boolean {
         val (start, end) = getCurrentCompositionOrSelection()
-        viewModel.updateSelection(editable, start, end)
-        val result = withProcessor {
-            processInput(EditorInputAction.ReplaceText(text.toString()))
-        }
+        val result = processTextEntry(text, start, end)
 
         return if (result != null) {
             val newText = result.text.subSequence(start, start + (text?.length ?: 0))
@@ -118,13 +113,13 @@ internal class InterceptInputConnection(
             // shift the composition indices so that it is not included.
             val compositionStart = start
                 .let { if (newText.startsWith("\u200b")) it + 1 else it }
-            val compositionEnd = (text?.length?.let { it + start } ?: end)
+            val compositionEnd = (newText.length + start)
                 .let { if (newText.startsWith("\u200b")) it + 1 else it }
 
             // Here we restore the background color spans from the IME input. This seems to be
             // important for Japanese input.
-            if (text is Spannable && result.text is Spannable) {
-                copyImeHighlightSpans(text, result.text, start)
+            if (newText is Spannable && result.text is Spannable) {
+                copyImeHighlightSpans(newText, result.text, start)
             }
             replaceAll(result.text, compositionStart = compositionStart, compositionEnd = compositionEnd)
             setSelectionOnEditable(editable, result.selection.last, result.selection.last)
@@ -137,14 +132,7 @@ internal class InterceptInputConnection(
     // Called for suggestion from IME selected
     override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
         val (start, end) = getCurrentCompositionOrSelection()
-        val result = withProcessor {
-            if (text?.lastOrNull() == '\n') {
-                processInput(EditorInputAction.InsertParagraph)
-            } else {
-                viewModel.updateSelection(editable, start, end)
-                processInput(EditorInputAction.ReplaceText(text.toString()))
-            }
-        }
+        val result = processTextEntry(text, start, end)
 
         return if (result != null) {
             replaceAll(result.text, compositionStart = end, compositionEnd = end)
@@ -152,6 +140,55 @@ internal class InterceptInputConnection(
             true
         } else {
             super.commitText(text, newCursorPosition)
+        }
+    }
+
+    private fun processTextEntry(newText: CharSequence?, start: Int, end: Int): ReplaceTextResult? {
+        val previousText = editable.substring(start until end)
+        return withProcessor {
+            when {
+                // Special case for whitespace, to keep the formatting status we need to add it first
+                newText != null && newText.length > 1 && newText.lastOrNull() == ' ' -> {
+                    val toAppend = newText.substring(0 until newText.length - 1)
+                    val (cStart, cEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editable)
+                        ?: error("Invalid indexes in composer $start, $end")
+                    // First add whitespace
+                    processInput(EditorInputAction.ReplaceTextIn(cEnd, cEnd, " "))
+                    // Then replace text
+                    processInput(EditorInputAction.ReplaceTextIn(cStart, cEnd, toAppend))?.let {
+                        // Fix selection to include whitespace at the end
+                        val prevSelection = it.selection
+                        it.copy(selection = prevSelection.first until prevSelection.last + 2)
+                    }
+                }
+                // This only happens when a new line key stroke is received
+                newText?.lastOrNull() == '\n' -> {
+                    processInput(EditorInputAction.InsertParagraph)
+                }
+                previousText.isNotEmpty() && newText?.startsWith(previousText) == true -> {
+                    // Appending new text at the end
+                    val pos = end - start
+                    val diff = newText.length - previousText.length
+                    val toAppend = newText.substring(pos until pos + diff)
+                    val (_, cEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editable)
+                        ?: error("Invalid indexes in composer $start, $end")
+                    processInput(EditorInputAction.ReplaceTextIn(cEnd, cEnd, toAppend))
+                }
+                newText != null && previousText.startsWith(newText) -> {
+                    // Removing text from the end
+                    val diff = previousText.length - newText.length
+                    val pos = end - diff
+                    val (cStart, cEnd) = EditorIndexMapper.fromEditorToComposer(pos, end, editable)
+                        ?: error("Invalid indexes in composer $pos, $end")
+                    processInput(EditorInputAction.ReplaceTextIn(cStart, cEnd, ""))
+                }
+                else -> {
+                    // New composing text
+                    val (cStart, cEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editable)
+                        ?: error("Invalid indexes in composer $start, $end")
+                    processInput(EditorInputAction.ReplaceTextIn(cStart, cEnd, newText.toString()))
+                }
+            }
         }
     }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/EditorInputAction.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/EditorInputAction.kt
@@ -12,6 +12,11 @@ sealed interface EditorInputAction {
     data class ReplaceText(val value: CharSequence): EditorInputAction
 
     /**
+     * Replaces the text in the [start]..[end] selection with the provided [value] in plain text.
+     */
+    data class ReplaceTextIn(val start: UInt, val end: UInt, val value: CharSequence): EditorInputAction
+
+    /**
      * Replaces the whole contents of the editor with the passed [html], re-creating the Dom.
      */
     data class ReplaceAllHtml(val html: String): EditorInputAction

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
@@ -51,6 +51,10 @@ internal class EditorViewModel(
                     // This conversion to a plain String might be too simple
                     composer?.replaceText(action.value.toString())
                 }
+                is EditorInputAction.ReplaceTextIn -> {
+                    // This conversion to a plain String might be too simple
+                    composer?.replaceTextIn(action.value.toString(), action.start.toUInt(), action.end.toUInt())
+                }
                 is EditorInputAction.InsertParagraph -> composer?.enter()
                 is EditorInputAction.BackPress -> composer?.backspace()
                 is EditorInputAction.ApplyInlineFormat -> when (action.format) {


### PR DESCRIPTION
Previously, when we typed something using the IME keyboard on Android, we were using `setComposingText` to replace the current composition (aka: the word being currently typed) with a new text, same for deleting using backspace. 

This, however, causes quite a few issues as you type and use autocorrect or replace the text using the suggestions, as it would either partially or completely remove the formatting of the composition, and it would create some weird formatting issues when finishing a composition by adding a whitespace (if you disabled formatting at the end of a word, after adding the whitespace it would be enabled again).

This implementation tries to diff if there's new content being added at the end of the composition or if we're removing some, and add special cases for them instead of just replacing everything. The same is done when replacing a composition with a suggestion or gets replaced by autocorrect, fixing also the mentioned bug about adding a whitespace resetting the formatting modes.