### PR TITLE
Fixing panic when adding a link to a nested formatted text - innermost approach

### DIFF
--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -16,6 +16,7 @@ use crate::dom::nodes::DomNode;
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{DomLocation, Range};
 use crate::{ComposerModel, ComposerUpdate, UnicodeString};
+use crate::dom::action_list::{DomActionList, DomAction, DomAction::Add, AddNodeAction};
 
 impl<S> ComposerModel<S>
 where
@@ -36,36 +37,50 @@ where
 
     fn set_link_range(&mut self, range: Range, link: S) -> ComposerUpdate<S> {
         let leaves: Vec<&DomLocation> = range.leaves().collect();
-        if leaves.len() == 1 {
-            let location = leaves[0];
-            let handle = &location.node_handle;
-
+        let mut actions: Vec<DomAction<S>> = vec!();
+        for leaf in leaves.iter().rev() {
+            let handle = &leaf.node_handle;
             // TODO: set link should be able to wrap container nodes, unlike formatting
-            let node = self.state.dom.lookup_node(handle);
+            let node = self.state.dom.lookup_node(&handle);
             if let DomNode::Text(t) = node {
                 let text = t.data();
-                let before = text[..location.start_offset].to_owned();
+                let before = text[..leaf.start_offset].to_owned();
                 let during =
-                    text[location.start_offset..location.end_offset].to_owned();
-                let after = text[location.end_offset..].to_owned();
-                let mut new_nodes = Vec::new();
+                    text[leaf.start_offset..leaf.end_offset].to_owned();
+                let after = text[leaf.end_offset..].to_owned();
+                let mut index = 0;
                 if !before.is_empty() {
-                    new_nodes.push(DomNode::new_text(before));
+                    actions.push(Add(AddNodeAction{
+                        parent_handle: handle.clone(),
+                        index: index,
+                        node: DomNode::new_text(before),
+                    }));
+                    index += 1;
                 }
-                new_nodes.push(DomNode::new_link(
-                    link,
-                    vec![DomNode::new_text(during)],
-                ));
+                actions.push(Add(AddNodeAction{
+                    parent_handle: handle.clone(),
+                    index: index,
+                    node: DomNode::new_link(
+                        link.clone(),
+                        vec![DomNode::new_text(during)],
+                    ),
+                }));
+                index += 1;
                 if !after.is_empty() {
-                    new_nodes.push(DomNode::new_text(after));
+                    actions.push(Add(AddNodeAction{
+                        parent_handle: handle.clone(),
+                        index: index,
+                        node: DomNode::new_text(after),
+                    }));
                 }
-                self.state.dom.replace(handle, new_nodes);
-                self.create_update_replace_all()
             } else {
                 panic!("Trying to linkify a non-text node")
             }
-        } else {
-            panic!("Can't add link in complex object models yet")
         }
+        let actions_list = DomActionList::new(actions);
+        for action in actions_list.grouped().0 {
+            self.state.dom.replace(&action.parent_handle, vec![action.node]);
+        }
+        self.create_update_replace_all()
     }
 }

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -16,7 +16,6 @@ use crate::dom::nodes::DomNode;
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{DomLocation, Range};
 use crate::{ComposerModel, ComposerUpdate, UnicodeString};
-use crate::dom::action_list::{DomActionList, DomAction, DomAction::Add, AddNodeAction};
 
 impl<S> ComposerModel<S>
 where
@@ -37,49 +36,30 @@ where
 
     fn set_link_range(&mut self, range: Range, link: S) -> ComposerUpdate<S> {
         let leaves: Vec<&DomLocation> = range.leaves().collect();
-        let mut actions: Vec<DomAction<S>> = vec!();
-        for leaf in leaves.iter().rev() {
+        for leaf in leaves.into_iter().rev() {
             let handle = &leaf.node_handle;
+
             // TODO: set link should be able to wrap container nodes, unlike formatting
-            let node = self.state.dom.lookup_node(&handle);
+            let node = self.state.dom.lookup_node(handle);
             if let DomNode::Text(t) = node {
                 let text = t.data();
                 let before = text[..leaf.start_offset].to_owned();
                 let during =
                     text[leaf.start_offset..leaf.end_offset].to_owned();
                 let after = text[leaf.end_offset..].to_owned();
-                let mut index = 0;
+                let mut new_nodes = Vec::new();
                 if !before.is_empty() {
-                    actions.push(Add(AddNodeAction{
-                        parent_handle: handle.clone(),
-                        index: index,
-                        node: DomNode::new_text(before),
-                    }));
-                    index += 1;
+                    new_nodes.push(DomNode::new_text(before));
                 }
-                actions.push(Add(AddNodeAction{
-                    parent_handle: handle.clone(),
-                    index: index,
-                    node: DomNode::new_link(
-                        link.clone(),
-                        vec![DomNode::new_text(during)],
-                    ),
-                }));
-                index += 1;
+                new_nodes.push(DomNode::new_link(
+                    link.clone(),
+                    vec![DomNode::new_text(during)],
+                ));
                 if !after.is_empty() {
-                    actions.push(Add(AddNodeAction{
-                        parent_handle: handle.clone(),
-                        index: index,
-                        node: DomNode::new_text(after),
-                    }));
+                    new_nodes.push(DomNode::new_text(after));
                 }
-            } else {
-                panic!("Trying to linkify a non-text node")
+                self.state.dom.replace(handle, new_nodes);
             }
-        }
-        let actions_list = DomActionList::new(actions);
-        for action in actions_list.grouped().0 {
-            self.state.dom.replace(&action.parent_handle, vec![action.node]);
         }
         self.create_update_replace_all()
     }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -60,6 +60,17 @@ fn set_link_in_multiple_leaves_of_formatted_text_partially_covered_2() {
     model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
-        "<i><u>test_it<a href=\"https://element.io\">alic_underline</a></u><b><a href=\"https://element.io\">test_ital</a>ic_bold</b></i>"
+        "<i><u>test_it<a href=\"https://element.io\">alic_underline</a></u><a href=\"https://element.io\">test_italic</a><b><a href=\"https://element.io\">test_ital</a>ic_bold</b></i>"
+    )
+}
+
+#[test]
+#[ignore]
+fn set_link_in_already_linked_text() {
+    let mut model = cm("{<a href=\"https://element.io\">link_text</a>}|");
+    model.set_link(utf16("https://element.io"));
+    assert_eq!(
+        model.state.dom.to_string(),
+        ""
     )
 }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -69,8 +69,5 @@ fn set_link_in_multiple_leaves_of_formatted_text_partially_covered_2() {
 fn set_link_in_already_linked_text() {
     let mut model = cm("{<a href=\"https://element.io\">link_text</a>}|");
     model.set_link(utf16("https://element.io"));
-    assert_eq!(
-        model.state.dom.to_string(),
-        ""
-    )
+    assert_eq!(model.state.dom.to_string(),"")
 }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -35,7 +35,7 @@ fn set_link_wraps_selection_in_link_tag() {
 }
 
 #[test]
-fn set_link_in_multiple_leaves() {
+fn set_link_in_multiple_leaves_of_formatted_text() {
     let mut model = cm("{<i>test_italic<b>test_italic_bold</b></i>}|");
     model.set_link(utf16("https://element.io"));
     assert_eq!(
@@ -45,11 +45,21 @@ fn set_link_in_multiple_leaves() {
 }
 
 #[test]
-fn set_link_in_multiple_leaves_partially_covered() {
+fn set_link_in_multiple_leaves_of_formatted_text_partially_covered() {
     let mut model = cm("<i>test_it{alic<b>test_ital}|ic_bold</b></i>");
     model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
         "<i>test_it<a href=\"https://element.io\">alic</a><b><a href=\"https://element.io\">test_ital</a>ic_bold</b></i>"
+    )
+}
+
+#[test]
+fn set_link_in_multiple_leaves_of_formatted_text_partially_covered_2() {
+    let mut model = cm("<i><u>test_it{alic_underline</u>test_italic<b>test_ital}|ic_bold</b></i>");
+    model.set_link(utf16("https://element.io"));
+    assert_eq!(
+        model.state.dom.to_string(),
+        "<i><u>test_it<a href=\"https://element.io\">alic_underline</a></u><b><a href=\"https://element.io\">test_ital</a>ic_bold</b></i>"
     )
 }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -50,6 +50,6 @@ fn set_link_in_multiple_leaves_partially_covered() {
     model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
-        "<i>test_it<b><a href=\"https://element.io\">test_ital</a></b></i>"
+        "<i>test_it<a href=\"https://element.io\">alic</a><b><a href=\"https://element.io\">test_ital</a>ic_bold</b></i>"
     )
 }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -69,5 +69,5 @@ fn set_link_in_multiple_leaves_of_formatted_text_partially_covered_2() {
 fn set_link_in_already_linked_text() {
     let mut model = cm("{<a href=\"https://element.io\">link_text</a>}|");
     model.set_link(utf16("https://element.io"));
-    assert_eq!(model.state.dom.to_string(),"")
+    assert_eq!(model.state.dom.to_string(), "")
 }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -33,3 +33,23 @@ fn set_link_wraps_selection_in_link_tag() {
         "<a href=\"https://element.io\">hello</a> world"
     );
 }
+
+#[test]
+fn set_link_in_multiple_leaves() {
+    let mut model = cm("{<i>test_italic<b>test_italic_bold</b></i>}|");
+    model.set_link(utf16("https://element.io"));
+    assert_eq!(
+        model.state.dom.to_string(),
+        "<i><a href=\"https://element.io\">test_italic</a><b><a href=\"https://element.io\">test_italic_bold</a></b></i>"
+    )
+}
+
+#[test]
+fn set_link_in_multiple_leaves_partially_covered() {
+    let mut model = cm("<i>test_it{alic<b>test_ital}|ic_bold</b></i>");
+    model.set_link(utf16("https://element.io"));
+    assert_eq!(
+        model.state.dom.to_string(),
+        "<i>test_it<b><a href=\"https://element.io\">test_ital</a></b></i>"
+    )
+}


### PR DESCRIPTION
When trying to add a link to neste formatted text like the following: _test italic **test italic and bold**_ this caused a panic in the rust SDK. Now it's possible to handle these simple cases.
For now we are using a simple solution where we just add in place of the highlighted text node, a link node, even if this means adding the same link into multiple different nodes that live on different leaves.