### PR TITLE
Inline code formatting for several nodes

### DIFF
--- a/crates/wysiwyg/src/composer_model.rs
+++ b/crates/wysiwyg/src/composer_model.rs
@@ -16,6 +16,7 @@ pub mod base;
 pub mod delete_text;
 pub mod example_format;
 pub mod format;
+mod format_inline_code;
 pub mod hyperlinks;
 pub mod join_nodes;
 pub mod lists;

--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -93,6 +93,8 @@ where
         }
     }
 
+    /// Deletes the given [to_delete] nodes and then removes any given parent nodes that became
+    /// empty, recursively.
     pub(crate) fn delete_nodes(&mut self, mut to_delete: Vec<DomHandle>) {
         // Delete in reverse order to avoid invalidating handles
         to_delete.reverse();
@@ -115,6 +117,24 @@ where
             }
 
             to_delete = new_to_delete;
+        }
+    }
+
+    /// Removes the node at [cur_handle] and then will recursively delete any empty parent nodes
+    /// until we reach the [top_handle] node.
+    pub(crate) fn remove_and_clean_up_empty_nodes_until(
+        &mut self,
+        cur_handle: &DomHandle,
+        top_handle: &DomHandle,
+    ) {
+        self.state.dom.remove(cur_handle);
+        if cur_handle != top_handle
+            && self.state.dom.parent(cur_handle).children().is_empty()
+        {
+            self.remove_and_clean_up_empty_nodes_until(
+                &cur_handle.parent_handle(),
+                top_handle,
+            )
         }
     }
 

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -119,8 +119,7 @@ where
                                 ),
                             );
                             // Update insertion point and reset text
-                            insert_text_at =
-                                Some(ancestor_child_handle.clone());
+                            insert_text_at = Some(ancestor_child_handle);
                             cur_text = S::default();
                         }
                         _ => panic!(
@@ -135,8 +134,7 @@ where
 
                     // If there is still some collected text add it to he list of nodes to insert
                     if !cur_text.is_empty() {
-                        nodes_to_add
-                            .insert(0, DomNode::new_text(cur_text.clone()));
+                        nodes_to_add.insert(0, DomNode::new_text(cur_text));
                     }
 
                     // Insert the inline code node

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use crate::composer_model::menu_state::MenuStateComputeType;
 use crate::dom::action_list::DomActionList;
-use crate::dom::nodes::{ContainerNodeKind, DomNode, TextNode};
+use crate::dom::nodes::{ContainerNodeKind, DomNode};
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{Dom, DomHandle, DomLocation, Range};
 use crate::{ComposerModel, ComposerUpdate, InlineFormatType, UnicodeString};
@@ -61,163 +61,10 @@ where
         }
     }
 
-    fn add_inline_code(&mut self) -> ComposerUpdate<S> {
-        let (s, e) = self.safe_selection();
-        let format = InlineFormatType::InlineCode;
-
-        if s == e {
-            self.toggle_zero_length_format(&format);
-            ComposerUpdate::update_menu_state(
-                self.compute_menu_state(MenuStateComputeType::KeepIfUnchanged),
-            )
-        } else {
-            let range = self.state.dom.find_range(s, e);
-            let leaves: Vec<&DomLocation> = range.leaves().collect();
-            // We'll iterate through the leaves finding their closest structural node ancestor and
-            // grouping these leaves based on the handles of these ancestors.
-            let structure_ancestors = self
-                .group_leaves_by_closest_structure_ancestors(leaves.clone());
-
-            // Order those ancestors (important to avoid node replacement & conflicts of handles)
-            let mut keys: Vec<&DomHandle> =
-                structure_ancestors.keys().collect();
-            keys.sort();
-
-            // Iterate through them backwards, replacing their descendant leaves as needed
-            for ancestor_handle in keys.into_iter().rev() {
-                let leaves = structure_ancestors.get(ancestor_handle).unwrap();
-                // We'll store the text contents of the removed formatted nodes here
-                let mut cur_text = S::default();
-                // Where we'll insert the result of merging the text contents
-                let mut insert_text_at: Option<DomHandle> = None;
-                // Nodes to be added to the Dom, might contain both TextNodes and LineBreaks
-                let mut nodes_to_add = Vec::new();
-                // Iterate the leaves backwards to avoid modifying the previous Dom structure
-                for leaf in leaves.into_iter().rev() {
-                    // Find the immediate child of the common ancestor containing this leaf as its descendant
-                    let ancestor_child_handle = leaf
-                        .node_handle
-                        .sub_handle_up_to(ancestor_handle.raw().len() + 1);
-
-                    let node =
-                        self.state.dom.lookup_node(&leaf.node_handle).clone();
-                    match node {
-                        DomNode::Text(text_node) => {
-                            let (text, pos) = self
-                                .process_text_node_for_inline_code(
-                                    &text_node,
-                                    leaf,
-                                    &ancestor_child_handle,
-                                );
-                            cur_text.insert(0, &text);
-                            insert_text_at = pos;
-                        }
-                        DomNode::LineBreak(_) => {
-                            nodes_to_add.extend(
-                                self.process_line_break_for_inline_code(
-                                    &leaf, &cur_text,
-                                ),
-                            );
-                            // Update insertion point and reset text
-                            insert_text_at = Some(ancestor_child_handle);
-                            cur_text = S::default();
-                        }
-                        _ => panic!(
-                            "Leaf should be either a line break or a text node"
-                        ),
-                    }
-                }
-
-                // Insert the nodes into the Dom inside an inline code node
-                if insert_text_at.is_some() {
-                    let insert_at = insert_text_at.unwrap();
-
-                    // If there is still some collected text add it to he list of nodes to insert
-                    if !cur_text.is_empty() {
-                        nodes_to_add.insert(0, DomNode::new_text(cur_text));
-                    }
-
-                    // Insert the inline code node
-                    self.state.dom.insert_at(
-                        &insert_at,
-                        DomNode::new_formatting(
-                            InlineFormatType::InlineCode,
-                            nodes_to_add,
-                        ),
-                    );
-
-                    // Merge inline code nodes for clean up
-                    self.merge_formatting_node_with_siblings(&insert_at);
-                }
-            }
-            self.create_update_replace_all()
-        }
-    }
-
-    fn process_text_node_for_inline_code(
-        &mut self,
-        text_node: &TextNode<S>,
-        location: &DomLocation,
-        ancestor_child_handle: &DomHandle,
-    ) -> (S, Option<DomHandle>) {
-        let mut insert_text_at = None;
-        // Add the selected text to the current text holder
-        let text = text_node.data()[location.start_offset..location.end_offset]
-            .to_owned();
-
-        if location.is_covered() {
-            // This node is covered, remove it and any empty ancestors and set
-            // the insertion point to be at its position.
-            insert_text_at = Some(ancestor_child_handle.clone());
-            self.remove_and_clean_up_empty_nodes_until(
-                &location.node_handle,
-                ancestor_child_handle,
-            );
-        } else if location.is_start() {
-            // This node is at the start of the selection and not completely
-            // covered, split it and set the insertion point to be after it.
-            insert_text_at = Some(ancestor_child_handle.next_sibling());
-            let text = text_node.data()[..location.start_offset].to_owned();
-            self.state
-                .dom
-                .replace(&location.node_handle, vec![DomNode::new_text(text)]);
-        } else if location.is_end() {
-            // This node is at the end of the selection and not completely
-            // covered, split it and set the insertion point to be before it.
-            insert_text_at = if ancestor_child_handle.index_in_parent() > 0 {
-                Some(ancestor_child_handle.prev_sibling())
-            } else {
-                Some(ancestor_child_handle.clone())
-            };
-            let text = text_node.data()[location.end_offset..].to_owned();
-            self.state
-                .dom
-                .replace(&location.node_handle, vec![DomNode::new_text(text)]);
-        }
-
-        (text, insert_text_at)
-    }
-
-    fn process_line_break_for_inline_code(
-        &mut self,
-        location: &DomLocation,
-        cur_text: &S,
-    ) -> Vec<DomNode<S>> {
-        let mut nodes_to_add = Vec::new();
-        // Get any pending text and create a new TextNode to insert along with
-        // the LineBreak one, removing the old LineBreak node.
-        if !cur_text.is_empty() {
-            nodes_to_add.insert(0, DomNode::new_text(cur_text.clone()));
-        }
-        nodes_to_add.insert(0, DomNode::new_line_break());
-        self.state.dom.remove(&location.node_handle);
-        nodes_to_add
-    }
-
     /// Finds the closest structure node ancestor for each leaf node handle and groups it with other
     /// leaves that share it as the common closest structure node ancestor. If none is found,
     /// the root/document node is used instead.
-    fn group_leaves_by_closest_structure_ancestors(
+    pub(crate) fn group_leaves_by_closest_structure_ancestors(
         &self,
         leaves: Vec<&DomLocation>,
     ) -> HashMap<DomHandle, Vec<DomLocation>> {
@@ -238,7 +85,7 @@ where
         structure_ancestors
     }
 
-    fn remove_and_clean_up_empty_nodes_until(
+    pub(crate) fn remove_and_clean_up_empty_nodes_until(
         &mut self,
         cur_handle: &DomHandle,
         top_handle: &DomHandle,
@@ -337,7 +184,10 @@ where
         self.unformat_several_nodes(start, end, &range, format);
     }
 
-    fn toggle_zero_length_format(&mut self, format: &InlineFormatType) {
+    pub(crate) fn toggle_zero_length_format(
+        &mut self,
+        format: &InlineFormatType,
+    ) {
         let index = self
             .state
             .toggled_format_types
@@ -632,7 +482,7 @@ where
         }
     }
 
-    fn merge_formatting_node_with_siblings(
+    pub(crate) fn merge_formatting_node_with_siblings(
         &mut self,
         handle: &DomHandle,
     ) -> DomActionList<S> {
@@ -831,157 +681,5 @@ mod test {
         assert_eq!(tx(&model), "AAA&nbsp;|");
         model.bold();
         assert_eq!(tx(&model), "AAA&nbsp;|");
-    }
-
-    #[test]
-    fn inline_code_replacing_formatting_removes_formatting() {
-        let mut model = cm("<b>{bold</b><i>text}|</i>");
-        model.inline_code();
-        assert_eq!(tx(&model), "<code>{boldtext}|</code>");
-    }
-
-    #[test]
-    fn inline_code_replacing_partial_formatting_removes_overlapping_formatting()
-    {
-        let mut model = cm("<b>bo{ld</b><i>te}|xt</i>");
-        model.inline_code();
-        assert_eq!(tx(&model), "<b>bo</b><code>{ldte}|</code><i>xt</i>");
-    }
-
-    #[test]
-    fn inline_code_with_formatting_preserves_line_breaks() {
-        let mut model = cm("<b>{bold</b><br /><i>text}|</i>");
-        model.inline_code();
-        assert_eq!(tx(&model), "<code>{bold<br />text}|</code>");
-    }
-
-    #[test]
-    fn inline_code_replacing_complex_formatting_removes_formatting() {
-        let mut model = cm("<b><u>{bold</u></b><i>text}|</i>");
-        model.inline_code();
-        assert_eq!(tx(&model), "<code>{boldtext}|</code>");
-    }
-
-    #[test]
-    fn inline_code_replacing_nested_and_complex_formatting_removes_formatting()
-    {
-        let mut model = cm("<b><u>{bold</u><i>italic</i></b><i>text}|</i>");
-        model.inline_code();
-        assert_eq!(tx(&model), "<code>{bolditalictext}|</code>");
-    }
-
-    #[test]
-    fn inline_code_partially_replacing_formatting_removes_overlap() {
-        let mut model = cm("<b><u>bo{ld</u></b><i>te}|xt</i>");
-        model.inline_code();
-        assert_eq!(tx(&model), "<b><u>bo</u></b><code>{ldte}|</code><i>xt</i>");
-    }
-
-    #[test]
-    fn inline_code_on_partial_nested_line_break_removes_formatting() {
-        let mut model = cm("<b><u>bo{ld</u></b><br /><i>te}|xt</i>");
-        model.inline_code();
-        assert_eq!(
-            tx(&model),
-            "<b><u>bo</u></b><code>{ld<br />te}|</code><i>xt</i>"
-        );
-    }
-
-    #[test]
-    fn inline_code_on_partial_nested_line_break_within_parent_removes_formatting(
-    ) {
-        let mut model = cm("<b><u>bo{ld</u><br /></b><i>te}|xt</i>");
-        model.inline_code();
-        assert_eq!(
-            tx(&model),
-            "<b><u>bo</u></b><code>{ld<br />te}|</code><i>xt</i>"
-        );
-    }
-
-    #[test]
-    fn format_inline_code_in_list_item() {
-        let mut model = cm("<ul><li><b>bo{ld</b><i>text}|</i></li></ul>");
-        model.inline_code();
-        assert_eq!(
-            tx(&model),
-            "<ul><li><b>bo</b><code>{ldtext}|</code></li></ul>"
-        );
-    }
-
-    #[test]
-    fn format_inline_code_in_several_list_items() {
-        let mut model =
-            cm("<ul><li><b>bo{ld</b></li><li><i>text}|</i></li></ul>");
-        model.inline_code();
-        assert_eq!(
-            tx(&model),
-            "<ul><li><b>bo</b><code>{ld</code></li><li><code>text}|</code></li></ul>"
-        );
-    }
-
-    #[test]
-    fn format_inline_code_in_several_list_items_and_text() {
-        let mut model =
-            cm("Text {before<br /><ul><li><b>bo}|ld</b></li><li><i>text</i></li></ul>");
-        model.inline_code();
-        assert_eq!(
-            tx(&model),
-            "Text <code>{before<br /></code><ul><li><code>bo}|</code><b>ld</b></li><li><i>text</i></li></ul>"
-        );
-    }
-
-    #[test]
-    fn format_inline_code_with_existing_inline_code_start() {
-        let mut model = cm("{Some <code>co}|de</code>");
-        model.inline_code();
-        assert_eq!(tx(&model), "<code>{Some co}|de</code>");
-    }
-
-    #[test]
-    fn format_inline_code_with_existing_inline_code_end() {
-        let mut model = cm("<code>So{me </code>code}|");
-        model.inline_code();
-        assert_eq!(tx(&model), "<code>So{me code}|</code>");
-    }
-
-    #[test]
-    fn format_inline_code_with_existing_inline_code_side_to_side_start() {
-        let mut model = cm("<code>Some </code>{code}|");
-        model.inline_code();
-        assert_eq!(tx(&model), "<code>Some {code}|</code>");
-    }
-
-    #[test]
-    fn format_inline_code_with_existing_inline_code_side_to_side_end() {
-        let mut model = cm("{Some }|<code>code</code>");
-        model.inline_code();
-        assert_eq!(tx(&model), "<code>{Some }|code</code>");
-    }
-
-    #[test]
-    fn unformat_inline_code_same_row_with_line_breaks() {
-        let mut model = cm("<code>{bold<br />text}|</code>");
-        model.inline_code();
-        assert_eq!(tx(&model), "{bold<br />text}|");
-    }
-
-    #[test]
-    fn unformat_inline_code_in_several_list_items_and_text() {
-        let mut model =
-            cm("Text <code>{before<br /></code><ul><li><code>bo}|</code><b>ld</b></li><li><i>text</i></li></ul>");
-        model.inline_code();
-        assert_eq!(
-            tx(&model),
-            "Text {before<br /><ul><li>bo}|<b>ld</b></li><li><i>text</i></li></ul>"
-        );
-    }
-
-    // TODO: might need to re-visit it if we add ZWSP at the end of inline code tags
-    #[test]
-    fn disable_inline_code_then_write_text() {
-        let mut model = cm("<code>code|</code>");
-        model.inline_code();
-        model.replace_text(" plain text".into());
-        assert_eq!(tx(&model), "<code>code</code> plain text|");
     }
 }

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -73,9 +73,8 @@ where
             let first_structure_ancestor =
                 self.find_structure_ancestor(&leaf.node_handle);
             // Get the closest ancestor path or the root one (empty Vec) if there is none
-            let ancestor_handle = first_structure_ancestor
-                .map(|a| a.clone())
-                .unwrap_or(DomHandle::root());
+            let ancestor_handle =
+                first_structure_ancestor.unwrap_or(DomHandle::root());
             let list = structure_ancestors
                 .entry(ancestor_handle)
                 .or_insert(Vec::new());
@@ -83,33 +82,6 @@ where
             list.push(leaf.clone());
         }
         structure_ancestors
-    }
-
-    pub(crate) fn remove_and_clean_up_empty_nodes_until(
-        &mut self,
-        cur_handle: &DomHandle,
-        top_handle: &DomHandle,
-    ) {
-        self.state.dom.remove(cur_handle);
-        if cur_handle != top_handle
-            && self.state.dom.parent(cur_handle).children().is_empty()
-        {
-            self.remove_and_clean_up_empty_nodes_until(
-                &cur_handle.parent_handle(),
-                top_handle,
-            )
-        }
-    }
-
-    fn find_structure_ancestor(&self, handle: &DomHandle) -> Option<DomHandle> {
-        let parent = self.state.dom.parent(handle);
-        if parent.is_structure_node() {
-            Some(parent.handle().clone())
-        } else if parent.handle().has_parent() {
-            self.find_structure_ancestor(&parent.handle())
-        } else {
-            None
-        }
     }
 
     fn format_or_unformat(

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -914,9 +914,34 @@ mod test {
     }
 
     #[test]
-    fn format_inline_code_with_existing_inline_code() {
+    fn format_inline_code_in_several_list_items_and_text() {
+        let mut model =
+            cm("Text {before<br /><ul><li><b>bo}|ld</b></li><li><i>text</i></li></ul>");
+        model.inline_code();
+        assert_eq!(
+            tx(&model),
+            "Text <code>{before</code><br /><ul><li><code>bo}|</code><b>ld</b></li><li><i>text</i></li></ul>"
+        );
+    }
+
+    #[test]
+    fn format_inline_code_with_existing_inline_code_start() {
         let mut model = cm("{Some <code>co}|de</code>");
         model.inline_code();
         assert_eq!(tx(&model), "<code>{Some co}|de</code>");
+    }
+
+    #[test]
+    fn format_inline_code_with_existing_inline_code_end() {
+        let mut model = cm("<code>So{me </code>code}|");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>So{me code}|</code>");
+    }
+
+    #[test]
+    fn format_inline_code_with_existing_inline_code_side_to_side() {
+        let mut model = cm("<code>Some </code>{code}|");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>Some {code}|</code>");
     }
 }

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -916,10 +916,17 @@ mod test {
     }
 
     #[test]
-    fn format_inline_code_with_existing_inline_code_side_to_side() {
+    fn format_inline_code_with_existing_inline_code_side_to_side_start() {
         let mut model = cm("<code>Some </code>{code}|");
         model.inline_code();
         assert_eq!(tx(&model), "<code>Some {code}|</code>");
+    }
+
+    #[test]
+    fn format_inline_code_with_existing_inline_code_side_to_side_end() {
+        let mut model = cm("{Some }|<code>code</code>");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>{Some }|code</code>");
     }
 
     #[test]
@@ -938,5 +945,14 @@ mod test {
             tx(&model),
             "Text {before<br /><ul><li>bo}|<b>ld</b></li><li><i>text</i></li></ul>"
         );
+    }
+
+    // TODO: might need to re-visit it if we add ZWSP ant the end of inline code tags
+    #[test]
+    fn disable_inline_code_then_write_text() {
+        let mut model = cm("<code>code|</code>");
+        model.inline_code();
+        model.replace_text(" plain text".into());
+        assert_eq!(tx(&model), "<code>code</code> plain text|");
     }
 }

--- a/crates/wysiwyg/src/composer_model/format_inline_code.rs
+++ b/crates/wysiwyg/src/composer_model/format_inline_code.rs
@@ -93,9 +93,7 @@ where
                 }
 
                 // Insert the nodes into the Dom inside an inline code node
-                if insert_text_at.is_some() {
-                    let insert_at = insert_text_at.unwrap();
-
+                if let Some(insert_text_at) = insert_text_at {
                     // If there is still some collected text add it to he list of nodes to insert
                     if !cur_text.is_empty() {
                         nodes_to_add.insert(0, DomNode::new_text(cur_text));
@@ -103,7 +101,7 @@ where
 
                     // Insert the inline code node
                     self.state.dom.insert_at(
-                        &insert_at,
+                        &insert_text_at,
                         DomNode::new_formatting(
                             InlineFormatType::InlineCode,
                             nodes_to_add,
@@ -111,7 +109,7 @@ where
                     );
 
                     // Merge inline code nodes for clean up
-                    self.merge_formatting_node_with_siblings(&insert_at);
+                    self.merge_formatting_node_with_siblings(&insert_text_at);
                 }
             }
             self.create_update_replace_all()

--- a/crates/wysiwyg/src/composer_model/format_inline_code.rs
+++ b/crates/wysiwyg/src/composer_model/format_inline_code.rs
@@ -1,0 +1,337 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::composer_model::menu_state::MenuStateComputeType;
+use crate::dom::nodes::{DomNode, TextNode};
+use crate::dom::unicode_string::UnicodeStrExt;
+use crate::dom::{DomHandle, DomLocation};
+use crate::{ComposerModel, ComposerUpdate, InlineFormatType, UnicodeString};
+
+/// Special implementations of formatting for inline code
+impl<S> ComposerModel<S>
+where
+    S: UnicodeString,
+{
+    pub(crate) fn add_inline_code(&mut self) -> ComposerUpdate<S> {
+        let (s, e) = self.safe_selection();
+        let format = InlineFormatType::InlineCode;
+
+        if s == e {
+            self.toggle_zero_length_format(&format);
+            ComposerUpdate::update_menu_state(
+                self.compute_menu_state(MenuStateComputeType::KeepIfUnchanged),
+            )
+        } else {
+            let range = self.state.dom.find_range(s, e);
+            let leaves: Vec<&DomLocation> = range.leaves().collect();
+            // We'll iterate through the leaves finding their closest structural node ancestor and
+            // grouping these leaves based on the handles of these ancestors.
+            let structure_ancestors = self
+                .group_leaves_by_closest_structure_ancestors(leaves.clone());
+
+            // Order those ancestors (important to avoid node replacement & conflicts of handles)
+            let mut keys: Vec<&DomHandle> =
+                structure_ancestors.keys().collect();
+            keys.sort();
+
+            // Iterate through them backwards, replacing their descendant leaves as needed
+            for ancestor_handle in keys.into_iter().rev() {
+                let leaves = structure_ancestors.get(ancestor_handle).unwrap();
+                // We'll store the text contents of the removed formatted nodes here
+                let mut cur_text = S::default();
+                // Where we'll insert the result of merging the text contents
+                let mut insert_text_at: Option<DomHandle> = None;
+                // Nodes to be added to the Dom, might contain both TextNodes and LineBreaks
+                let mut nodes_to_add = Vec::new();
+                // Iterate the leaves backwards to avoid modifying the previous Dom structure
+                for leaf in leaves.into_iter().rev() {
+                    // Find the immediate child of the common ancestor containing this leaf as its descendant
+                    let ancestor_child_handle = leaf
+                        .node_handle
+                        .sub_handle_up_to(ancestor_handle.raw().len() + 1);
+
+                    let node =
+                        self.state.dom.lookup_node(&leaf.node_handle).clone();
+                    match node {
+                        DomNode::Text(text_node) => {
+                            let (text, pos) = self
+                                .process_text_node_for_inline_code(
+                                    &text_node,
+                                    leaf,
+                                    &ancestor_child_handle,
+                                );
+                            // Add the selected text to the current text holder
+                            cur_text.insert(0, &text);
+                            // Update insertion position for the inline code node
+                            insert_text_at = pos;
+                        }
+                        DomNode::LineBreak(_) => {
+                            nodes_to_add.extend(
+                                self.process_line_break_for_inline_code(
+                                    &leaf, &cur_text,
+                                ),
+                            );
+                            // Update insertion point and reset text
+                            insert_text_at = Some(ancestor_child_handle);
+                            cur_text = S::default();
+                        }
+                        _ => panic!(
+                            "Leaf should be either a line break or a text node"
+                        ),
+                    }
+                }
+
+                // Insert the nodes into the Dom inside an inline code node
+                if insert_text_at.is_some() {
+                    let insert_at = insert_text_at.unwrap();
+
+                    // If there is still some collected text add it to he list of nodes to insert
+                    if !cur_text.is_empty() {
+                        nodes_to_add.insert(0, DomNode::new_text(cur_text));
+                    }
+
+                    // Insert the inline code node
+                    self.state.dom.insert_at(
+                        &insert_at,
+                        DomNode::new_formatting(
+                            InlineFormatType::InlineCode,
+                            nodes_to_add,
+                        ),
+                    );
+
+                    // Merge inline code nodes for clean up
+                    self.merge_formatting_node_with_siblings(&insert_at);
+                }
+            }
+            self.create_update_replace_all()
+        }
+    }
+
+    fn process_text_node_for_inline_code(
+        &mut self,
+        text_node: &TextNode<S>,
+        location: &DomLocation,
+        ancestor_child_handle: &DomHandle,
+    ) -> (S, Option<DomHandle>) {
+        let mut insert_text_at = None;
+        // Get the selected text from the TextNode
+        let text = text_node.data()[location.start_offset..location.end_offset]
+            .to_owned();
+        let handle = &location.node_handle;
+        let dom = &mut self.state.dom;
+
+        if location.is_covered() {
+            // This node is covered, remove it and any empty ancestors and set
+            // the insertion point to be at its position.
+            insert_text_at = Some(ancestor_child_handle.clone());
+            self.remove_and_clean_up_empty_nodes_until(
+                handle,
+                ancestor_child_handle,
+            );
+        } else if location.is_start() {
+            // This node is at the start of the selection and not completely
+            // covered, split it and set the insertion point to be after it.
+            insert_text_at = Some(ancestor_child_handle.next_sibling());
+            let text = text_node.data()[..location.start_offset].to_owned();
+            dom.replace(handle, vec![DomNode::new_text(text)]);
+        } else if location.is_end() {
+            // This node is at the end of the selection and not completely
+            // covered, split it and set the insertion point to be before it.
+            insert_text_at = if ancestor_child_handle.index_in_parent() > 0 {
+                Some(ancestor_child_handle.prev_sibling())
+            } else {
+                Some(ancestor_child_handle.clone())
+            };
+            let text = text_node.data()[location.end_offset..].to_owned();
+            dom.replace(handle, vec![DomNode::new_text(text)]);
+        }
+
+        (text, insert_text_at)
+    }
+
+    fn process_line_break_for_inline_code(
+        &mut self,
+        location: &DomLocation,
+        cur_text: &S,
+    ) -> Vec<DomNode<S>> {
+        let mut nodes_to_add = Vec::new();
+        // Get any pending text and create a new TextNode to insert along with
+        // the LineBreak one, removing the old LineBreak node.
+        if !cur_text.is_empty() {
+            nodes_to_add.insert(0, DomNode::new_text(cur_text.clone()));
+        }
+        nodes_to_add.insert(0, DomNode::new_line_break());
+        self.state.dom.remove(&location.node_handle);
+        nodes_to_add
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::tests::testutils_composer_model::{cm, tx};
+
+    #[test]
+    fn inline_code_replacing_formatting_removes_formatting() {
+        let mut model = cm("<b>{bold</b><i>text}|</i>");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>{boldtext}|</code>");
+    }
+
+    #[test]
+    fn inline_code_replacing_partial_formatting_removes_overlapping_formatting()
+    {
+        let mut model = cm("<b>bo{ld</b><i>te}|xt</i>");
+        model.inline_code();
+        assert_eq!(tx(&model), "<b>bo</b><code>{ldte}|</code><i>xt</i>");
+    }
+
+    #[test]
+    fn inline_code_with_formatting_preserves_line_breaks() {
+        let mut model = cm("<b>{bold</b><br /><i>text}|</i>");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>{bold<br />text}|</code>");
+    }
+
+    #[test]
+    fn inline_code_replacing_complex_formatting_removes_formatting() {
+        let mut model = cm("<b><u>{bold</u></b><i>text}|</i>");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>{boldtext}|</code>");
+    }
+
+    #[test]
+    fn inline_code_replacing_nested_and_complex_formatting_removes_formatting()
+    {
+        let mut model = cm("<b><u>{bold</u><i>italic</i></b><i>text}|</i>");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>{bolditalictext}|</code>");
+    }
+
+    #[test]
+    fn inline_code_partially_replacing_formatting_removes_overlap() {
+        let mut model = cm("<b><u>bo{ld</u></b><i>te}|xt</i>");
+        model.inline_code();
+        assert_eq!(tx(&model), "<b><u>bo</u></b><code>{ldte}|</code><i>xt</i>");
+    }
+
+    #[test]
+    fn inline_code_on_partial_nested_line_break_removes_formatting() {
+        let mut model = cm("<b><u>bo{ld</u></b><br /><i>te}|xt</i>");
+        model.inline_code();
+        assert_eq!(
+            tx(&model),
+            "<b><u>bo</u></b><code>{ld<br />te}|</code><i>xt</i>"
+        );
+    }
+
+    #[test]
+    fn inline_code_on_partial_nested_line_break_within_parent_removes_formatting(
+    ) {
+        let mut model = cm("<b><u>bo{ld</u><br /></b><i>te}|xt</i>");
+        model.inline_code();
+        assert_eq!(
+            tx(&model),
+            "<b><u>bo</u></b><code>{ld<br />te}|</code><i>xt</i>"
+        );
+    }
+
+    #[test]
+    fn format_inline_code_in_list_item() {
+        let mut model = cm("<ul><li><b>bo{ld</b><i>text}|</i></li></ul>");
+        model.inline_code();
+        assert_eq!(
+            tx(&model),
+            "<ul><li><b>bo</b><code>{ldtext}|</code></li></ul>"
+        );
+    }
+
+    #[test]
+    fn format_inline_code_in_several_list_items() {
+        let mut model =
+            cm("<ul><li><b>bo{ld</b></li><li><i>text}|</i></li></ul>");
+        model.inline_code();
+        assert_eq!(
+            tx(&model),
+            "<ul><li><b>bo</b><code>{ld</code></li><li><code>text}|</code></li></ul>"
+        );
+    }
+
+    #[test]
+    fn format_inline_code_in_several_list_items_and_text() {
+        let mut model =
+            cm("Text {before<br /><ul><li><b>bo}|ld</b></li><li><i>text</i></li></ul>");
+        model.inline_code();
+        assert_eq!(
+            tx(&model),
+            "Text <code>{before<br /></code><ul><li><code>bo}|</code><b>ld</b></li><li><i>text</i></li></ul>"
+        );
+    }
+
+    #[test]
+    fn format_inline_code_with_existing_inline_code_start() {
+        let mut model = cm("{Some <code>co}|de</code>");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>{Some co}|de</code>");
+    }
+
+    #[test]
+    fn format_inline_code_with_existing_inline_code_end() {
+        let mut model = cm("<code>So{me </code>code}|");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>So{me code}|</code>");
+    }
+
+    #[test]
+    fn format_inline_code_with_existing_inline_code_side_to_side_start() {
+        let mut model = cm("<code>Some </code>{code}|");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>Some {code}|</code>");
+    }
+
+    #[test]
+    fn format_inline_code_with_existing_inline_code_side_to_side_end() {
+        let mut model = cm("{Some }|<code>code</code>");
+        model.inline_code();
+        assert_eq!(tx(&model), "<code>{Some }|code</code>");
+    }
+
+    #[test]
+    fn unformat_inline_code_same_row_with_line_breaks() {
+        let mut model = cm("<code>{bold<br />text}|</code>");
+        model.inline_code();
+        assert_eq!(tx(&model), "{bold<br />text}|");
+    }
+
+    #[test]
+    fn unformat_inline_code_in_several_list_items_and_text() {
+        let mut model =
+            cm("Text <code>{before<br /></code><ul><li><code>bo}|</code><b>ld</b></li><li><i>text</i></li></ul>");
+        model.inline_code();
+        assert_eq!(
+            tx(&model),
+            "Text {before<br /><ul><li>bo}|<b>ld</b></li><li><i>text</i></li></ul>"
+        );
+    }
+
+    // TODO: might need to re-visit it if we add ZWSP at the end of inline code tags,
+    // otherwise this test should actually follow the same behaviour as those in `test_formatting.rs`
+    // for 'unformatting_...'.
+    #[test]
+    fn disable_inline_code_then_write_text() {
+        let mut model = cm("<code>code|</code>");
+        model.inline_code();
+        model.replace_text(" plain text".into());
+        assert_eq!(tx(&model), "<code>code</code> plain text|");
+    }
+}

--- a/crates/wysiwyg/src/composer_model/join_nodes.rs
+++ b/crates/wysiwyg/src/composer_model/join_nodes.rs
@@ -56,8 +56,11 @@ where
         // Find next node
         if let Some(mut next_handle) = self.find_leaf_containing(new_pos) {
             // Find struct parents
-            if let (Some(struct_parent_start), Some(struct_parent_next)) =
-                self.find_struct_parents(start_handle, &next_handle)
+            if let (Some(struct_parent_start), Some(struct_parent_next)) = self
+                .find_closest_structure_ancestors_to_join(
+                    start_handle,
+                    &next_handle,
+                )
             {
                 if struct_parent_start != struct_parent_next {
                     // Move children
@@ -70,8 +73,10 @@ where
                 }
 
                 // Find ancestor lists
-                let ancestors_start = Self::find_ancestor_list(start_handle);
-                let ancestors_next = Self::find_ancestor_list(&next_handle);
+                let ancestors_start =
+                    Self::list_of_ancestors_from_root(start_handle);
+                let ancestors_next =
+                    Self::list_of_ancestors_from_root(&next_handle);
 
                 // Merge nodes based on ancestors
                 self.do_join_structure_nodes(&ancestors_start, &ancestors_next);
@@ -257,7 +262,7 @@ where
         let new_next_handle = DomHandle::from_raw(new_next_path);
 
         // Re-calculate ancestors
-        Self::find_ancestor_list(&new_next_handle)
+        Self::list_of_ancestors_from_root(&new_next_handle)
     }
 
     /// Given a position, find the text or line break node containing it
@@ -270,28 +275,41 @@ where
         range.leaves().next().map(|loc| loc.node_handle.clone())
     }
 
-    fn find_struct_parents(
+    /// Finds the closest structure ancestors to join for the start and end handles, or None if they
+    /// can't be found.
+    /// Note: If a ListItem is found, the parent List will be returned instead.
+    fn find_closest_structure_ancestors_to_join(
         &self,
         start: &DomHandle,
         next: &DomHandle,
     ) -> (Option<DomHandle>, Option<DomHandle>) {
-        let struct_parent_start = self.find_struct_parent(start);
-        let struct_parent_next = self.find_struct_parent(next);
+        let get_list_parent_if_is_list_item = |handle| {
+            let node = self.state.dom.lookup_node(&handle);
+            if node.is_list_item() {
+                handle.parent_handle()
+            } else {
+                handle.clone()
+            }
+        };
+        let struct_parent_start = self
+            .find_structure_ancestor(start)
+            .map(get_list_parent_if_is_list_item);
+        let struct_parent_next = self
+            .find_structure_ancestor(next)
+            .map(get_list_parent_if_is_list_item);
         (struct_parent_start, struct_parent_next)
     }
 
-    fn find_struct_parent(&self, handle: &DomHandle) -> Option<DomHandle> {
-        let parent_handle = handle.parent_handle();
-        let parent = self.state.dom.lookup_node(&parent_handle);
-        if parent.is_structure_node() && parent_handle.has_parent() {
-            if let Some(parent_result) = self.find_struct_parent(&parent_handle)
-            {
-                Some(parent_result)
-            } else {
-                Some(parent_handle)
-            }
-        } else if parent_handle.has_parent() {
-            self.find_struct_parent(&parent_handle)
+    /// Finds the closest structure node ancestor for the given handle, or None if it doesn't exist
+    pub(crate) fn find_structure_ancestor(
+        &self,
+        handle: &DomHandle,
+    ) -> Option<DomHandle> {
+        let parent = self.state.dom.parent(handle);
+        if parent.is_structure_node() {
+            Some(parent.handle().clone())
+        } else if parent.handle().has_parent() {
+            self.find_structure_ancestor(&parent.handle())
         } else {
             None
         }
@@ -333,7 +351,7 @@ where
         (ret, moved_handles)
     }
 
-    fn find_ancestor_list(handle: &DomHandle) -> Vec<DomHandle> {
+    fn list_of_ancestors_from_root(handle: &DomHandle) -> Vec<DomHandle> {
         let mut ancestors = Vec::new();
         let mut cur_handle = handle.clone();
         while cur_handle.has_parent() {

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -249,7 +249,7 @@ where
         let range = self.state.dom.find_range(s, e);
 
         if range.is_empty() {
-            self.state.dom.append_child(DomNode::new_list(
+            self.state.dom.append_at_end_of_document(DomNode::new_list(
                 list_type,
                 vec![DomNode::Container(ContainerNode::new_list_item(
                     "li".into(),

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -181,7 +181,8 @@ where
         let action_list = self.replace_in_text_nodes(range.clone(), new_text);
 
         let (to_add, to_delete, _) = action_list.grouped();
-        let to_delete = to_delete.into_iter().map(|a| a.handle).collect();
+        let to_delete: Vec<DomHandle> =
+            to_delete.into_iter().map(|a| a.handle).collect();
 
         // We only add nodes in one special case: when the selection ends at
         // a BR tag. In that case, the only nodes that might be deleted are
@@ -198,7 +199,9 @@ where
         }
 
         // Delete the nodes marked for deletion
-        self.delete_nodes(to_delete);
+        if !to_delete.is_empty() {
+            self.delete_nodes(to_delete);
+        }
 
         // If our range covered multiple text-like nodes, join together
         // the two sides of the range.

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -156,7 +156,9 @@ where
             let range = self.state.dom.find_range(start, end);
             if range.is_empty() {
                 if !new_text.is_empty() {
-                    self.state.dom.append_child(DomNode::new_text(new_text));
+                    self.state
+                        .dom
+                        .append_at_end_of_document(DomNode::new_text(new_text));
                 }
                 start = 0;
             } else {

--- a/crates/wysiwyg/src/dom/dom_handle.rs
+++ b/crates/wysiwyg/src/dom/dom_handle.rs
@@ -19,6 +19,13 @@ pub struct DomHandle {
 }
 
 impl DomHandle {
+    /// Create a new handle for the root/document node.
+    pub fn root() -> Self {
+        Self {
+            path: Some(Vec::new()),
+        }
+    }
+
     /// Create a new handle with the provided path.
     /// So long as the path provided points to a valid node, this handle
     /// can be used (it is set).
@@ -65,6 +72,16 @@ impl DomHandle {
         let mut new_path = self.raw().clone();
         new_path.push(child_index);
         DomHandle::from_raw(new_path)
+    }
+
+    /// Returns a DomHandle with the 'sub-path' up to the passed 'level'.
+    /// i.e.: a DomHandle with path `[0, 1, 2, 3]` with `at_level(2)` will return a DomHandle
+    /// with path `[0, 1, 2]`.
+    pub fn sub_handle_up_to(&self, level: usize) -> DomHandle {
+        assert!(&self.path.is_some());
+        let path = self.path.clone().unwrap();
+        let (new_path, _) = path.split_at(level);
+        DomHandle::from_raw(new_path.to_vec())
     }
 
     /// Return true if this handle has a parent i.e. it is not the root. If

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -86,11 +86,17 @@ where
         }
     }
 
-    pub fn append_child(&mut self, child: DomNode<S>) -> DomHandle {
+    /// Appends the [child] node at the end of the root node (document node).
+    pub fn append_at_end_of_document(
+        &mut self,
+        child: DomNode<S>,
+    ) -> DomHandle {
         self.document_mut().append_child(child)
     }
 
-    pub fn append_child_to_parent(
+    /// Appends [child] node at the end of the node at [parent_handle], if it's a container node.
+    /// Returns the [DomHandle] of the added node.
+    pub fn append(
         &mut self,
         parent_handle: &DomHandle,
         child: DomNode<S>,
@@ -105,12 +111,16 @@ where
         parent.append_child(child)
     }
 
-    pub fn insert(&mut self, node_handle: &DomHandle, node: DomNode<S>) {
+    /// Inserts the given [node] at the [node_handle] position, moving the node at that position
+    /// forward, if any.
+    pub fn insert_at(&mut self, node_handle: &DomHandle, node: DomNode<S>) {
         let parent = self.parent_mut(node_handle);
         let index = node_handle.index_in_parent();
         parent.insert_child(index, node)
     }
 
+    /// Replaces the node at [node_handle] with the list of [nodes]. Returns the list of new handles
+    /// added to the Dom for these nodes.
     pub fn replace(
         &mut self,
         node_handle: &DomHandle,
@@ -121,6 +131,7 @@ where
         parent.replace_child(index, nodes)
     }
 
+    /// Removes the node at [node_handle] and returns it.
     pub fn remove(&mut self, node_handle: &DomHandle) -> DomNode<S> {
         let parent = self.parent_mut(node_handle);
         let index = node_handle.index_in_parent();

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -90,6 +90,27 @@ where
         self.document_mut().append_child(child)
     }
 
+    pub fn append_child_to_parent(
+        &mut self,
+        parent_handle: &DomHandle,
+        child: DomNode<S>,
+    ) -> DomHandle {
+        let parent = if let DomNode::Container(container) =
+            self.lookup_node_mut(parent_handle)
+        {
+            container
+        } else {
+            panic!("Parent is not a container node");
+        };
+        parent.append_child(child)
+    }
+
+    pub fn insert(&mut self, node_handle: &DomHandle, node: DomNode<S>) {
+        let parent = self.parent_mut(node_handle);
+        let index = node_handle.index_in_parent();
+        parent.insert_child(index, node)
+    }
+
     pub fn replace(
         &mut self,
         node_handle: &DomHandle,
@@ -100,10 +121,10 @@ where
         parent.replace_child(index, nodes)
     }
 
-    pub fn remove(&mut self, node_handle: &DomHandle) {
+    pub fn remove(&mut self, node_handle: &DomHandle) -> DomNode<S> {
         let parent = self.parent_mut(node_handle);
         let index = node_handle.index_in_parent();
-        parent.remove_child(index);
+        parent.remove_child(index)
     }
 
     /// Removes node at given handle from the dom, and if it has children

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -225,6 +225,10 @@ where
         matches!(self.kind, ContainerNodeKind::ListItem)
     }
 
+    pub fn is_list(&self) -> bool {
+        matches!(self.kind, ContainerNodeKind::List)
+    }
+
     pub(crate) fn is_list_of_type(&self, list_type: ListType) -> bool {
         match self.kind {
             ContainerNodeKind::List => {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -148,6 +148,15 @@ where
     pub(crate) fn is_block_node(&self) -> bool {
         matches!(self, Self::Container(container) if container.is_block_node())
     }
+
+    pub(crate) fn is_list_item(&self) -> bool {
+        matches!(self, Self::Container(container) if container.is_list_item())
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_list(&self) -> bool {
+        matches!(self, Self::Container(container) if container.is_list())
+    }
 }
 
 impl<S> ToHtml<S> for DomNode<S>

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate core;
+
 mod action_state;
 mod composer_action;
 mod composer_model;

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate core;
-
 mod action_state;
 mod composer_action;
 mod composer_model;

--- a/crates/wysiwyg/src/tests/test_undo_redo.rs
+++ b/crates/wysiwyg/src/tests/test_undo_redo.rs
@@ -24,7 +24,8 @@ fn undoing_action_restores_previous_state() {
     let mut model = cm("hello |");
     let mut prev = model.state.clone();
     let prev_text_node = TextNode::from(utf16("world!"));
-    prev.dom.append_child(DomNode::Text(prev_text_node));
+    prev.dom
+        .append_at_end_of_document(DomNode::Text(prev_text_node));
     model.previous_states.push(prev.clone());
 
     model.undo();


### PR DESCRIPTION
Adds support for formatting several nodes using inline code. At first, I thought about adding an exception for `extend_format_in_multiple_nodes`, but the implementation is so different that I went with a whole different method instead.