### PR TITLE
Enable DomIterator on any subtree

### DIFF
--- a/crates/wysiwyg/src/dom/iter.rs
+++ b/crates/wysiwyg/src/dom/iter.rs
@@ -29,7 +29,7 @@ where
 {
     /// Return an iterator over all nodes of this DOM, in depth-first order
     pub fn iter(&self) -> DomIterator<S> {
-        DomIterator::over(self)
+        DomIterator::over(self.document_node())
     }
 
     /// Return an iterator over all text nodes of this DOM, in depth-first
@@ -52,7 +52,7 @@ where
     /// Return an iterator over all nodes of the subtree starting from this
     /// node (including self), in depth-first order
     pub fn iter(&self) -> DomIterator<S> {
-        DomIterator::over_node(self)
+        DomIterator::over(self)
     }
 
     /// Return an iterator over all text nodes of the subtree starting from
@@ -89,17 +89,7 @@ impl<'a, S> DomIterator<'a, S>
 where
     S: UnicodeString,
 {
-    fn over(dom: &'a Dom<S>) -> Self {
-        Self {
-            started: false,
-            ancestors: vec![NodeAndChildIndex {
-                node: &dom.document_node(),
-                child_index: 0,
-            }],
-        }
-    }
-
-    fn over_node(dom_node: &'a DomNode<S>) -> Self {
+    fn over(dom_node: &'a DomNode<S>) -> Self {
         Self {
             started: false,
             ancestors: vec![NodeAndChildIndex {

--- a/crates/wysiwyg/src/dom/iter.rs
+++ b/crates/wysiwyg/src/dom/iter.rs
@@ -169,7 +169,7 @@ mod test {
     }
 
     #[test]
-    fn can_walk_all_nodes_of_a_leading_subnode() {
+    fn can_walk_all_nodes_of_a_leading_subtree() {
         let dom = cm(EXAMPLE_HTML).state.dom;
         let first_child = dom.children().first().unwrap();
         let text_nodes: Vec<String> =
@@ -182,7 +182,7 @@ mod test {
     }
 
     #[test]
-    fn can_walk_all_nodes_of_a_middle_subnode() {
+    fn can_walk_all_nodes_of_a_middle_subtree() {
         let dom = cm(EXAMPLE_HTML).state.dom;
         let second_child = &dom.children()[1];
         let text_nodes: Vec<String> =
@@ -192,7 +192,7 @@ mod test {
     }
 
     #[test]
-    fn can_walk_all_nodes_of_a_trailing_subnode() {
+    fn can_walk_all_nodes_of_a_trailing_subtree() {
         let dom = cm(EXAMPLE_HTML).state.dom;
         let last_child = dom.children().last().unwrap();
         let text_nodes: Vec<String> = last_child.iter().map(node_txt).collect();
@@ -201,7 +201,7 @@ mod test {
     }
 
     #[test]
-    fn can_walk_all_nodes_of_a_deep_subnode() {
+    fn can_walk_all_nodes_of_a_deep_subtree() {
         let dom = cm(EXAMPLE_HTML).state.dom;
         if let DomNode::Container(list) = dom.children().first().unwrap() {
             let deep_child = list.children().first().unwrap();
@@ -226,7 +226,7 @@ mod test {
     }
 
     #[test]
-    fn can_walk_all_text_nodes_of_a_leading_subnode() {
+    fn can_walk_all_text_nodes_of_a_leading_subtree() {
         let dom = cm(EXAMPLE_HTML).state.dom;
         let first_child = dom.children().first().unwrap();
         let text_nodes: Vec<String> = first_child
@@ -238,7 +238,7 @@ mod test {
     }
 
     #[test]
-    fn can_walk_all_text_nodes_of_a_middle_subnode() {
+    fn can_walk_all_text_nodes_of_a_middle_subtree() {
         let dom = cm(EXAMPLE_HTML).state.dom;
         let second_child = &dom.children()[1];
         let text_nodes: Vec<String> = second_child
@@ -250,7 +250,7 @@ mod test {
     }
 
     #[test]
-    fn can_walk_all_text_nodes_of_a_trailing_subnode() {
+    fn can_walk_all_text_nodes_of_a_trailing_subtree() {
         let dom = cm(EXAMPLE_HTML).state.dom;
         let last_child = dom.children().last().unwrap();
         let text_nodes: Vec<String> = last_child
@@ -262,7 +262,7 @@ mod test {
     }
 
     #[test]
-    fn can_walk_all_text_nodes_of_a_deep_subnode() {
+    fn can_walk_all_text_nodes_of_a_deep_subtree() {
         let dom = cm(EXAMPLE_HTML).state.dom;
         if let DomNode::Container(list) = dom.children().first().unwrap() {
             let deep_child = list.children().first().unwrap();

--- a/crates/wysiwyg/src/dom/iter.rs
+++ b/crates/wysiwyg/src/dom/iter.rs
@@ -35,13 +35,7 @@ where
     /// Return an iterator over all text nodes of this DOM, in depth-first
     /// order
     pub fn iter_text(&self) -> impl Iterator<Item = &TextNode<S>> {
-        self.iter().filter_map(|node| {
-            if let DomNode::Text(t) = node {
-                Some(t)
-            } else {
-                None
-            }
-        })
+        self.iter().filter_map(DomNode::as_text)
     }
 }
 
@@ -58,13 +52,7 @@ where
     /// Return an iterator over all text nodes of the subtree starting from
     /// this node (including self), in depth-first order
     pub fn iter_text(&self) -> impl Iterator<Item = &TextNode<S>> {
-        self.iter().filter_map(|node| {
-            if let DomNode::Text(t) = node {
-                Some(t)
-            } else {
-                None
-            }
-        })
+        self.iter().filter_map(DomNode::as_text)
     }
 }
 

--- a/crates/wysiwyg/src/dom/iter.rs
+++ b/crates/wysiwyg/src/dom/iter.rs
@@ -205,7 +205,8 @@ mod test {
         let dom = cm(EXAMPLE_HTML).state.dom;
         if let DomNode::Container(list) = dom.children().first().unwrap() {
             let deep_child = list.children().first().unwrap();
-            let text_nodes: Vec<String> = deep_child.iter().map(node_txt).collect();
+            let text_nodes: Vec<String> =
+                deep_child.iter().map(node_txt).collect();
 
             assert_eq!(text_nodes, vec!["li", "'b'", "strong", "'c'"])
         } else {
@@ -265,7 +266,10 @@ mod test {
         let dom = cm(EXAMPLE_HTML).state.dom;
         if let DomNode::Container(list) = dom.children().first().unwrap() {
             let deep_child = list.children().first().unwrap();
-            let text_nodes: Vec<String> = deep_child.iter_text().map(|text| text.data().to_string()).collect();
+            let text_nodes: Vec<String> = deep_child
+                .iter_text()
+                .map(|text| text.data().to_string())
+                .collect();
 
             assert_eq!(text_nodes, vec!["b", "c"])
         } else {

--- a/crates/wysiwyg/src/dom/iter.rs
+++ b/crates/wysiwyg/src/dom/iter.rs
@@ -201,6 +201,19 @@ mod test {
     }
 
     #[test]
+    fn can_walk_all_nodes_of_a_deep_subnode() {
+        let dom = cm(EXAMPLE_HTML).state.dom;
+        if let DomNode::Container(list) = dom.children().first().unwrap() {
+            let deep_child = list.children().first().unwrap();
+            let text_nodes: Vec<String> = deep_child.iter().map(node_txt).collect();
+
+            assert_eq!(text_nodes, vec!["li", "'b'", "strong", "'c'"])
+        } else {
+            panic!("First child should have been the list")
+        }
+    }
+
+    #[test]
     fn can_walk_all_text_nodes() {
         let dom = cm(EXAMPLE_HTML).state.dom;
         let text_nodes: Vec<String> = dom
@@ -245,6 +258,19 @@ mod test {
             .collect();
 
         assert_eq!(text_nodes, vec!["x"])
+    }
+
+    #[test]
+    fn can_walk_all_text_nodes_of_a_deep_subnode() {
+        let dom = cm(EXAMPLE_HTML).state.dom;
+        if let DomNode::Container(list) = dom.children().first().unwrap() {
+            let deep_child = list.children().first().unwrap();
+            let text_nodes: Vec<String> = deep_child.iter_text().map(|text| text.data().to_string()).collect();
+
+            assert_eq!(text_nodes, vec!["b", "c"])
+        } else {
+            panic!("First child should have been the list")
+        }
     }
 
     fn node_txt(node: &DomNode<Utf16String>) -> String {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -148,6 +148,14 @@ where
     pub(crate) fn is_block_node(&self) -> bool {
         matches!(self, Self::Container(container) if container.is_block_node())
     }
+
+    pub(crate) fn as_text(&self) -> Option<&TextNode<S>> {
+        if let Self::Text(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 impl<S> ToHtml<S> for DomNode<S>


### PR DESCRIPTION
Provides a way to start a DomIterator from a DomNode rather than the entire Dom. Result will include all the nodes of the subtree at its location, including itself.