### PR TITLE
Add `kind` property to DomLocations

### DIFF
--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -74,7 +74,7 @@ where
         // Find the first leaf node in this selection - note there
         // should only be one because s == e, so we don't have a
         // selection that spans multiple leaves.
-        let first_leaf = range.locations.iter().find(|loc| loc.is_leaf);
+        let first_leaf = range.locations.iter().find(|loc| loc.is_leaf());
         if let Some(leaf) = first_leaf {
             // We are backspacing inside a text node with no
             // selection - we might need special behaviour, if

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -427,7 +427,7 @@ mod test {
         let mut state = SelectionWritingState::new(0, 1, 1);
         let handle = DomHandle::from_raw(vec![0]);
         let location =
-            DomLocation::new(handle, 0, 0, 1, 1, true, DomNodeKind::Generic);
+            DomLocation::new(handle, 0, 0, 1, 1, DomNodeKind::Generic);
 
         // When we advance
         let strings_to_add = state.advance(&location, 1);

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -413,6 +413,7 @@ mod test {
     use speculoos::{prelude::*, AssertionFailure, Spec};
     use widestring::Utf16String;
 
+    use crate::dom::nodes::dom_node::DomNodeKind;
     use crate::dom::{parser, Dom, DomLocation};
     use crate::tests::testutils_composer_model::{cm, restore_whitespace, tx};
     use crate::tests::testutils_conversion::utf16;
@@ -425,7 +426,8 @@ mod test {
         // We have one text node with one character
         let mut state = SelectionWritingState::new(0, 1, 1);
         let handle = DomHandle::from_raw(vec![0]);
-        let location = DomLocation::new(handle, 0, 0, 1, 1, true);
+        let location =
+            DomLocation::new(handle, 0, 0, 1, 1, true, DomNodeKind::Generic);
 
         // When we advance
         let strings_to_add = state.advance(&location, 1);

--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -188,7 +188,7 @@ where
         } else {
             // Find text nodes inside the selection that are not formatted with this format
             let non_formatted_leaf_locations = locations.iter().filter(|l| {
-                l.is_leaf
+                l.is_leaf()
                     && Self::path_contains_format_node(
                         &self.state.dom,
                         &l.node_handle,

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -62,7 +62,7 @@ where
 
     pub fn can_indent(&self, locations: &Vec<DomLocation>) -> bool {
         for loc in locations {
-            if loc.is_leaf && !self.can_indent_handle(&loc.node_handle) {
+            if loc.is_leaf() && !self.can_indent_handle(&loc.node_handle) {
                 return false;
             }
         }
@@ -71,7 +71,7 @@ where
 
     pub fn can_unindent(&self, locations: &Vec<DomLocation>) -> bool {
         for loc in locations {
-            if loc.is_leaf && !self.can_unindent_handle(&loc.node_handle) {
+            if loc.is_leaf() && !self.can_unindent_handle(&loc.node_handle) {
                 return false;
             }
         }
@@ -608,7 +608,7 @@ where
         locations
             .iter()
             .filter_map(|l| {
-                if l.is_leaf {
+                if l.is_leaf() {
                     Some(l.node_handle.clone())
                 } else {
                     None

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -147,7 +147,6 @@ where
             start_offset,
             end_offset,
             length: container_node_len,
-            is_leaf: false,
             kind: DomNodeKind::from_container_kind(node.kind()),
         })
     }
@@ -230,7 +229,6 @@ fn process_textlike_node(
             start_offset,
             end_offset,
             length: node_len,
-            is_leaf: true,
             kind,
         })
     }
@@ -261,7 +259,6 @@ mod test {
             start_offset,
             end_offset,
             length,
-            is_leaf: true,
             kind: DomNodeKind::Text,
         }])
     }
@@ -462,7 +459,6 @@ mod test {
                         end_offset: 2,
                         position: 8,
                         length: 2,
-                        is_leaf: true,
                         kind: DomNodeKind::Text,
                     },
                     DomLocation {
@@ -471,7 +467,6 @@ mod test {
                         end_offset: 2,
                         position: 8,
                         length: 2,
-                        is_leaf: false,
                         kind: DomNodeKind::Formatting(InlineFormatType::Italic),
                     },
                     DomLocation {
@@ -480,7 +475,6 @@ mod test {
                         end_offset: 6,
                         position: 4,
                         length: 6,
-                        is_leaf: false,
                         kind: DomNodeKind::Formatting(InlineFormatType::Bold),
                     }
                 ]

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::dom::dom_handle::DomHandle;
+use crate::dom::nodes::dom_node::DomNodeKind;
 use std::cmp::Ordering;
 
 /// Represents a part of a Range.
@@ -51,6 +52,9 @@ pub struct DomLocation {
     /// True if this is a node which is not a container i.e. a text node or
     /// a text-like node like a line break.
     pub is_leaf: bool,
+
+    /// Node kind
+    pub kind: DomNodeKind,
 }
 
 impl DomLocation {
@@ -61,6 +65,7 @@ impl DomLocation {
         end_offset: usize,
         length: usize,
         is_leaf: bool,
+        kind: DomNodeKind,
     ) -> Self {
         Self {
             node_handle,
@@ -69,6 +74,7 @@ impl DomLocation {
             end_offset,
             length,
             is_leaf,
+            kind,
         }
     }
 
@@ -80,6 +86,7 @@ impl DomLocation {
             end_offset: self.end_offset,
             length: self.length,
             is_leaf: self.is_leaf,
+            kind: self.kind.clone(),
         }
     }
 
@@ -98,6 +105,7 @@ impl DomLocation {
             end_offset: self.start_offset,
             length: self.length,
             is_leaf: self.is_leaf,
+            kind: self.kind.clone(),
         }
     }
 

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -49,10 +49,6 @@ pub struct DomLocation {
     /// a line break, this will be 1.
     pub length: usize,
 
-    /// True if this is a node which is not a container i.e. a text node or
-    /// a text-like node like a line break.
-    pub is_leaf: bool,
-
     /// Node kind
     pub kind: DomNodeKind,
 }
@@ -64,7 +60,6 @@ impl DomLocation {
         start_offset: usize,
         end_offset: usize,
         length: usize,
-        is_leaf: bool,
         kind: DomNodeKind,
     ) -> Self {
         Self {
@@ -73,7 +68,6 @@ impl DomLocation {
             start_offset,
             end_offset,
             length,
-            is_leaf,
             kind,
         }
     }
@@ -85,8 +79,16 @@ impl DomLocation {
             start_offset: self.start_offset,
             end_offset: self.end_offset,
             length: self.length,
-            is_leaf: self.is_leaf,
             kind: self.kind.clone(),
+        }
+    }
+
+    /// True if this is a node which is not a container i.e. a text node or
+    /// a text-like node like a line break.
+    pub fn is_leaf(&self) -> bool {
+        match self.kind {
+            DomNodeKind::Text | DomNodeKind::LineBreak => true,
+            _ => false,
         }
     }
 
@@ -104,7 +106,6 @@ impl DomLocation {
             start_offset: self.end_offset,
             end_offset: self.start_offset,
             length: self.length,
-            is_leaf: self.is_leaf,
             kind: self.kind.clone(),
         }
     }
@@ -173,7 +174,7 @@ impl Range {
         self.locations
             .iter()
             .find_map(|loc| {
-                if loc.is_leaf {
+                if loc.is_leaf() {
                     Some(loc.position + loc.start_offset)
                 } else {
                     None
@@ -187,7 +188,7 @@ impl Range {
             .iter()
             .rev()
             .find_map(|loc| {
-                if loc.is_leaf {
+                if loc.is_leaf() {
                     Some(loc.position + loc.end_offset)
                 } else {
                     None
@@ -197,7 +198,7 @@ impl Range {
     }
 
     pub fn leaves(&self) -> impl Iterator<Item = &DomLocation> {
-        self.locations.iter().filter(|loc| loc.is_leaf)
+        self.locations.iter().filter(|loc| loc.is_leaf())
     }
 
     // TODO: remove all uses of this when we guarantee that Dom is never empty


### PR DESCRIPTION
This should save us from doing unnecessary calls to `self.state.dom.lookup_node(...)` to just check a location's node kind.