### PR TITLE
Fix replacing a link with text when the selection begins at the start of the link

### DIFF
--- a/crates/wysiwyg/src/composer_model/join_nodes.rs
+++ b/crates/wysiwyg/src/composer_model/join_nodes.rs
@@ -351,7 +351,9 @@ where
         (ret, moved_handles)
     }
 
-    fn list_of_ancestors_from_root(handle: &DomHandle) -> Vec<DomHandle> {
+    pub(crate) fn list_of_ancestors_from_root(
+        handle: &DomHandle,
+    ) -> Vec<DomHandle> {
         let mut ancestors = Vec::new();
         let mut cur_handle = handle.clone();
         while cur_handle.has_parent() {

--- a/crates/wysiwyg/src/dom/action_list.rs
+++ b/crates/wysiwyg/src/dom/action_list.rs
@@ -154,7 +154,7 @@ impl<S: UnicodeString> DomActionList<S> {
     ) -> Option<(DomHandle, DomHandle)> {
         self.actions.iter().find_map(|action| match action {
             DomAction::Move(a) => {
-                if a.from_handle.is_parent_of(handle)
+                if a.from_handle.is_ancestor_of(handle)
                     || a.from_handle == *handle
                 {
                     Some((a.from_handle.clone(), a.to_handle.clone()))

--- a/crates/wysiwyg/src/dom/dom_handle.rs
+++ b/crates/wysiwyg/src/dom/dom_handle.rs
@@ -128,7 +128,7 @@ impl DomHandle {
 
     /// Returns true if the passed handle is an ancestor of the current one, but false if it is
     /// either unrelated to it or it's the same handle.
-    pub fn is_parent_of(&self, other: &DomHandle) -> bool {
+    pub fn is_ancestor_of(&self, other: &DomHandle) -> bool {
         let own_path = self.raw();
         let other_path = other.raw();
         other_path.starts_with(own_path.as_slice()) && other_path != own_path
@@ -136,7 +136,7 @@ impl DomHandle {
 
     /// Replaces the sub-path shared with [old] handle with the same sub-path in [new].
     pub fn replace_ancestor(&mut self, old: DomHandle, new: DomHandle) {
-        assert!(old.is_parent_of(self) || old == *self);
+        assert!(old.is_ancestor_of(self) || old == *self);
         assert!(self.is_set());
         let mut new_path = self.path.as_ref().unwrap().clone();
         new_path.splice(0..old.raw().len(), new.into_raw());

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -308,6 +308,31 @@ fn inserting_a_new_line_and_text_before_a_new_line_works() {
     assert_eq!(tx(&model), "Test|<br /><br />");
 }
 
+#[test]
+fn replace_text_in_covered_link() {
+    let mut model =
+        cm("test {<a href=\"https://element.io\">test_link</a>}| test");
+    model.replace_text(utf16("added_text"));
+    assert_eq!(tx(&model), "test added_text| test");
+}
+
+#[test]
+fn replace_text_in_covered_link_containing_format_nodes() {
+    let mut model =
+        cm("test {<a href=\"https://element.io\"><b>test_link</b></a>}| test");
+    model.replace_text(utf16("added_text"));
+    assert_eq!(tx(&model), "test added_text| test");
+}
+
+#[test]
+fn replace_text_in_covered_link_inside_format_node() {
+    let mut model = cm(
+        "test <i>{<a href=\"https://element.io\"><b>test_link</b></a></i>}| test",
+    );
+    model.replace_text(utf16("added_text"));
+    assert_eq!(tx(&model), "test <i>added_text|</i> test");
+}
+
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {
     model.replace_text(utf16(new_text));
 }


### PR DESCRIPTION
This is actually a not-so-great workaround, so I'm not even sure if we *should* actually use it.

Suggestions to improve it are **truly** welcome.