### PR TITLE
Code blocks

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_action.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_action.rs
@@ -12,6 +12,7 @@ pub enum ComposerAction {
     UnorderedList,
     Indent,
     UnIndent,
+    CodeBlock,
 }
 
 impl From<&ComposerAction> for wysiwyg::ComposerAction {
@@ -29,6 +30,7 @@ impl From<&ComposerAction> for wysiwyg::ComposerAction {
             ComposerAction::UnorderedList => Self::UnorderedList,
             ComposerAction::Indent => Self::Indent,
             ComposerAction::UnIndent => Self::UnIndent,
+            ComposerAction::CodeBlock => Self::CodeBlock,
         }
     }
 }
@@ -48,6 +50,7 @@ impl From<&wysiwyg::ComposerAction> for ComposerAction {
             wysiwyg::ComposerAction::UnorderedList => Self::UnorderedList,
             wysiwyg::ComposerAction::Indent => Self::Indent,
             wysiwyg::ComposerAction::UnIndent => Self::UnIndent,
+            wysiwyg::ComposerAction::CodeBlock => Self::CodeBlock,
         }
     }
 }

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -100,6 +100,7 @@ mod test {
             (ComposerAction::Underline, ActionState::Enabled),
             (ComposerAction::Undo, ActionState::Enabled),
             (ComposerAction::UnorderedList, ActionState::Enabled),
+            (ComposerAction::CodeBlock, ActionState::Enabled),
         ])
     }
 
@@ -118,6 +119,7 @@ mod test {
             (ComposerAction::Underline, ActionState::Enabled),
             (ComposerAction::Undo, ActionState::Disabled),
             (ComposerAction::UnorderedList, ActionState::Enabled),
+            (ComposerAction::CodeBlock, ActionState::Enabled),
         ])
     }
 }

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -87,6 +87,7 @@ enum ComposerAction {
     "UnorderedList",
     "Indent",
     "UnIndent",
+    "CodeBlock",
 };
 
 enum ActionState {

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -395,6 +395,7 @@ pub enum ComposerAction {
     UnorderedList,
     Indent,
     UnIndent,
+    CodeBlock,
 }
 
 impl ComposerAction {
@@ -412,6 +413,7 @@ impl ComposerAction {
             wysiwyg::ComposerAction::UnorderedList => Self::UnorderedList,
             wysiwyg::ComposerAction::Indent => Self::Indent,
             wysiwyg::ComposerAction::UnIndent => Self::UnIndent,
+            wysiwyg::ComposerAction::CodeBlock => Self::CodeBlock,
         }
     }
 }
@@ -431,6 +433,7 @@ impl From<&ComposerAction> for wysiwyg::ComposerAction {
             ComposerAction::UnorderedList => Self::UnorderedList,
             ComposerAction::Indent => Self::Indent,
             ComposerAction::UnIndent => Self::UnIndent,
+            ComposerAction::CodeBlock => Self::CodeBlock,
         }
     }
 }

--- a/crates/wysiwyg/src/composer_action.rs
+++ b/crates/wysiwyg/src/composer_action.rs
@@ -28,4 +28,5 @@ pub enum ComposerAction {
     UnorderedList,
     Indent,
     UnIndent,
+    CodeBlock,
 }

--- a/crates/wysiwyg/src/composer_model.rs
+++ b/crates/wysiwyg/src/composer_model.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod base;
+pub mod code_block;
 pub mod delete_text;
 pub mod example_format;
 pub mod format;

--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -1,0 +1,269 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::dom::nodes::dom_node::DomNodeKind;
+use crate::dom::nodes::dom_node::DomNodeKind::ListItem;
+use crate::dom::nodes::{DomNode, TextNode};
+use crate::dom::unicode_string::UnicodeStrExt;
+use crate::dom::{DomHandle, DomLocation, Range};
+use crate::{
+    ComposerAction, ComposerModel, ComposerUpdate, Location, UnicodeString,
+};
+use std::cmp::{max, min};
+
+impl<S> ComposerModel<S>
+where
+    S: UnicodeString,
+{
+    pub fn code_block(&mut self) -> ComposerUpdate<S> {
+        if self.action_is_reversed(ComposerAction::CodeBlock) {
+            // TODO: add code block removal
+            ComposerUpdate::keep()
+        } else {
+            self.add_code_block()
+        }
+    }
+
+    fn add_code_block(&mut self) -> ComposerUpdate<S> {
+        let (s, e) = self.safe_selection();
+        let Some((parent_handle, idx_start, idx_end)) = self.find_nodes_to_wrap(s, e) else {
+            return ComposerUpdate::keep();
+        };
+        let mut leaves_to_add = Vec::new();
+        let start_handle = parent_handle.child_handle(idx_start);
+        let up_to_handle = parent_handle.child_handle(idx_end + 1);
+        let iter = self.state.dom.iter_from_handle(&start_handle);
+        for node in iter {
+            if node.handle() >= up_to_handle {
+                break;
+            }
+            if matches!(node.kind(), DomNodeKind::Text | DomNodeKind::LineBreak)
+            {
+                leaves_to_add.push(node.clone());
+            }
+        }
+
+        for i in (idx_start..=idx_end).rev() {
+            self.state.dom.remove(&parent_handle.child_handle(i));
+        }
+
+        self.state
+            .dom
+            .insert_at(&start_handle, DomNode::new_code_block(leaves_to_add));
+
+        self.create_update_replace_all()
+    }
+
+    fn find_nodes_to_wrap(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> Option<(DomHandle, usize, usize)> {
+        let range = self.state.dom.find_range(start, end);
+        let leaves: Vec<&DomLocation> = range.leaves().collect();
+        if leaves.is_empty() {
+            None
+        } else {
+            let first_leaf = leaves.first().unwrap();
+            let last_leaf = leaves.last().unwrap();
+            let iter = self.state.dom.iter_from_handle(&last_leaf.node_handle);
+            let rev_iter = self
+                .state
+                .dom
+                .iter_from_handle(&first_leaf.node_handle)
+                .rev();
+            let mut nodes_to_cover = (
+                HandleWithKind {
+                    handle: first_leaf.node_handle.clone(),
+                    kind: first_leaf.kind.clone(),
+                },
+                HandleWithKind {
+                    handle: last_leaf.node_handle.clone(),
+                    kind: last_leaf.kind.clone(),
+                },
+            );
+            let selection_contains_several_list_items = range
+                .locations
+                .iter()
+                .filter(|l| l.kind == ListItem)
+                .count()
+                > 1;
+            for node in rev_iter {
+                if !node.is_block_node()
+                    && node.kind() != DomNodeKind::LineBreak
+                    && (node.kind() != ListItem
+                        || selection_contains_several_list_items)
+                {
+                    nodes_to_cover.0 = HandleWithKind {
+                        handle: node.handle(),
+                        kind: node.kind().clone(),
+                    };
+                } else {
+                    break;
+                }
+            }
+
+            for node in iter {
+                let handle = node.handle();
+                if !node.is_block_node()
+                    && node.kind() != DomNodeKind::LineBreak
+                    && (node.kind() != ListItem
+                        || selection_contains_several_list_items)
+                {
+                    nodes_to_cover.1 = HandleWithKind {
+                        handle: node.handle(),
+                        kind: node.kind().clone(),
+                    };
+                } else {
+                    break;
+                }
+            }
+
+            let (first, last) = nodes_to_cover;
+            let max_level =
+                min(first.handle.raw().len(), last.handle.raw().len());
+            let mut min_level = 0;
+            for i in min_level..max_level {
+                min_level = i;
+                if first.handle.raw()[i] != last.handle.raw()[i] {
+                    break;
+                }
+            }
+            if first.kind == ListItem || last.kind == ListItem {
+                // We should wrap their parent List instead
+                min_level -= 1;
+            }
+            let idx_start = first.handle.raw()[min_level];
+            let idx_end = last.handle.raw()[min_level];
+            let ancestor_handle = first.handle.sub_handle_up_to(min_level);
+            Some((ancestor_handle, idx_start, idx_end))
+        }
+    }
+}
+
+struct HandleWithKind {
+    handle: DomHandle,
+    kind: DomNodeKind,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::tests::testutils_composer_model::{cm, tx};
+    use crate::DomHandle;
+
+    #[test]
+    fn find_ranges_to_wrap_simple_text() {
+        let model = cm("Some text|");
+        let (s, e) = model.safe_selection();
+        let ret = model.find_nodes_to_wrap(s, e);
+        assert_eq!(ret, Some((DomHandle::from_raw(Vec::new()), 0, 0)));
+    }
+
+    #[test]
+    fn find_ranges_to_wrap_several_nodes() {
+        let model = cm("Some text| <b>and bold </b><i>and italic</i>");
+        let (s, e) = model.safe_selection();
+        let ret = model.find_nodes_to_wrap(s, e);
+        assert_eq!(ret, Some((DomHandle::from_raw(Vec::new()), 0, 2)));
+    }
+
+    #[test]
+    fn find_ranges_to_wrap_several_nodes_with_line_break_at_end() {
+        let model = cm("Some text| <b>and bold </b><br/><i>and italic</i>");
+        let (s, e) = model.safe_selection();
+        let ret = model.find_nodes_to_wrap(s, e);
+        assert_eq!(ret, Some((DomHandle::from_raw(Vec::new()), 0, 1)));
+    }
+
+    #[test]
+    fn find_ranges_to_wrap_several_nodes_with_line_break_at_start() {
+        let model = cm("Some text <br/><b>and bold </b><i>|and italic</i>");
+        let (s, e) = model.safe_selection();
+        let ret = model.find_nodes_to_wrap(s, e);
+        assert_eq!(ret, Some((DomHandle::from_raw(Vec::new()), 2, 3)));
+    }
+
+    #[test]
+    fn find_ranges_to_wrap_list_item() {
+        let model = cm(
+            "<ul><li>Some text <b>and bold </b><i>|and italic</i></li></ul>",
+        );
+        let (s, e) = model.safe_selection();
+        let ret = model.find_nodes_to_wrap(s, e);
+        assert_eq!(ret, Some((DomHandle::from_raw(vec![0, 0]), 0, 2)));
+    }
+
+    #[test]
+    fn find_ranges_to_wrap_list_item_with_line_breaks() {
+        let model = cm(
+            "<ul><li>Some text <b>and bold </b><br/><i>and| italic</i></li></ul>",
+        );
+        let (s, e) = model.safe_selection();
+        let ret = model.find_nodes_to_wrap(s, e);
+        assert_eq!(ret, Some((DomHandle::from_raw(vec![0, 0]), 3, 3)));
+    }
+
+    #[test]
+    fn find_ranges_to_wrap_several_list_items() {
+        let model = cm("<ul><li>{First item</li><li>Second}| item</li></ul>");
+        let (s, e) = model.safe_selection();
+        let ret = model.find_nodes_to_wrap(s, e);
+        assert_eq!(ret, Some((DomHandle::from_raw(vec![]), 0, 0)));
+    }
+
+    #[test]
+    fn find_ranges_to_wrap_list_and_external_nodes() {
+        let model =
+            cm("{Text <ul><li>First item</li><li>Second}| item</li></ul>");
+        let (s, e) = model.safe_selection();
+        let ret = model.find_nodes_to_wrap(s, e);
+        assert_eq!(ret, Some((DomHandle::from_raw(vec![]), 0, 1)));
+    }
+
+    // Tests: Code block
+
+    #[test]
+    fn add_code_block_to_simple_text() {
+        let mut model = cm("Some text|");
+        model.code_block();
+        assert_eq!(tx(&model), "<pre>Some text|</pre>");
+    }
+
+    #[test]
+    fn add_code_block_to_several_nodes() {
+        let mut model = cm("Some text| <b>and bold </b><i>and italic</i>");
+        model.code_block();
+        assert_eq!(tx(&model), "<pre>Some text| and bold and italic</pre>");
+    }
+
+    #[test]
+    fn add_code_block_to_several_nodes_with_line_break_at_end() {
+        let mut model = cm("Some text| <b>and bold </b><br/><i>and italic</i>");
+        model.code_block();
+        assert_eq!(
+            tx(&model),
+            "<pre>Some text| and bold&nbsp;</pre><br /><i>and italic</i>"
+        );
+    }
+
+    #[test]
+    fn add_code_block_to_several_nodes_with_line_break_at_start() {
+        let mut model = cm("Some text <br/><b>and bold </b><i>and |italic</i>");
+        model.code_block();
+        assert_eq!(
+            tx(&model),
+            "Some text <br /><pre>and bold and |italic</pre>"
+        );
+    }
+}

--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -122,7 +122,7 @@ where
         let insert_at_handle =
             start_handle.sub_handle_up_to(ancestor_to_split.raw().len() + 1);
         let insert_at_handle =
-            if idx_start > 0 && self.state.dom.exists(&insert_at_handle) {
+            if idx_start > 0 && self.state.dom.contains(&insert_at_handle) {
                 insert_at_handle.next_sibling()
             } else {
                 insert_at_handle

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -164,6 +164,7 @@ where
                     ListType::Unordered => Some(ComposerAction::UnorderedList),
                 }
             }
+            ContainerNodeKind::CodeBlock => Some(ComposerAction::CodeBlock),
             _ => None,
         }
     }

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -198,16 +198,7 @@ where
         if !self.can_unindent(locations) {
             disabled_actions.insert(UnIndent);
         }
-        let contains_inline_code_node = locations
-            .iter()
-            .find(|l| {
-                matches!(
-                    l.kind,
-                    DomNodeKind::Formatting(InlineFormatType::InlineCode)
-                )
-            })
-            .is_some();
-        if contains_inline_code_node {
+        if contains_inline_code(locations) {
             // Remove the rest of inline formatting options
             disabled_actions.extend(vec![
                 ComposerAction::Bold,
@@ -216,7 +207,28 @@ where
                 ComposerAction::StrikeThrough,
                 ComposerAction::Link,
             ])
+        } else if contains_code_block(locations) {
+            disabled_actions.extend(vec![ComposerAction::InlineCode])
         }
         disabled_actions
     }
+}
+
+fn contains_inline_code(locations: &Vec<DomLocation>) -> bool {
+    locations
+        .iter()
+        .find(|l| {
+            matches!(
+                l.kind,
+                DomNodeKind::Formatting(InlineFormatType::InlineCode)
+            )
+        })
+        .is_some()
+}
+
+fn contains_code_block(locations: &Vec<DomLocation>) -> bool {
+    locations
+        .iter()
+        .find(|l| l.kind == DomNodeKind::CodeBlock)
+        .is_some()
 }

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -215,20 +215,14 @@ where
 }
 
 fn contains_inline_code(locations: &Vec<DomLocation>) -> bool {
-    locations
-        .iter()
-        .find(|l| {
-            matches!(
-                l.kind,
-                DomNodeKind::Formatting(InlineFormatType::InlineCode)
-            )
-        })
-        .is_some()
+    locations.iter().any(|l| {
+        matches!(
+            l.kind,
+            DomNodeKind::Formatting(InlineFormatType::InlineCode)
+        )
+    })
 }
 
 fn contains_code_block(locations: &Vec<DomLocation>) -> bool {
-    locations
-        .iter()
-        .find(|l| l.kind == DomNodeKind::CodeBlock)
-        .is_some()
+    locations.iter().any(|l| l.kind == DomNodeKind::CodeBlock)
 }

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -15,6 +15,7 @@
 use strum::IntoEnumIterator;
 
 use crate::action_state::ActionState;
+use crate::dom::nodes::dom_node::DomNodeKind;
 use crate::dom::nodes::{ContainerNode, ContainerNodeKind};
 use crate::dom::{DomLocation, Range};
 use crate::menu_state::MenuStateUpdate;
@@ -200,10 +201,10 @@ where
         let contains_inline_code_node = locations
             .iter()
             .find(|l| {
-                self.state
-                    .dom
-                    .lookup_node(&l.node_handle)
-                    .is_formatting_node_of_type(&InlineFormatType::InlineCode)
+                matches!(
+                    l.kind,
+                    DomNodeKind::Formatting(InlineFormatType::InlineCode)
+                )
             })
             .is_some();
         if contains_inline_code_node {

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -94,7 +94,8 @@ where
                         .iter()
                         .filter(|l| {
                             l.kind.is_block_kind()
-                                && l.node_handle.is_parent_of(&leaf.node_handle)
+                                && l.node_handle
+                                    .is_ancestor_of(&leaf.node_handle)
                         })
                         .max();
 
@@ -129,8 +130,8 @@ where
                     .find(|l| {
                         block_ancestor_loc
                             .node_handle
-                            .is_parent_of(&l.node_handle)
-                            && l.node_handle.is_parent_of(&leaf.node_handle)
+                            .is_ancestor_of(&l.node_handle)
+                            && l.node_handle.is_ancestor_of(&leaf.node_handle)
                             && l.kind == ListItem
                     })
                     .unwrap();

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::dom::nodes::dom_node::DomNodeKind;
 use crate::dom::nodes::dom_node::DomNodeKind::ListItem;
 use crate::dom::nodes::DomNode;
-use crate::dom::unicode_string::UnicodeStrExt;
+use crate::dom::unicode_string::{UnicodeStr, UnicodeStrExt};
 use crate::dom::{DomLocation, Range};
 use crate::{ComposerModel, ComposerUpdate, Location, UnicodeString};
 
@@ -87,31 +88,138 @@ where
                     );
                     self.create_update_replace_all()
                 } else {
-                    let current_cursor_global_location =
-                        leaf.position + leaf.start_offset;
                     let handle = &leaf.node_handle;
-                    let parent_list_item_handle =
-                        self.state.dom.find_parent_list_item_or_self(handle);
+                    let ancestor_block_location = range
+                        .locations
+                        .iter()
+                        .filter(|l| {
+                            l.kind.is_block_kind()
+                                && l.node_handle.is_parent_of(&leaf.node_handle)
+                        })
+                        .max();
 
-                    match parent_list_item_handle {
-                        Some(handle) => {
-                            let list_item_end_offset = range
-                                .locations
-                                .into_iter()
-                                .find(|loc| loc.kind == ListItem)
-                                .unwrap()
-                                .end_offset;
-                            self.do_enter_in_list(
-                                &handle,
-                                current_cursor_global_location,
-                                list_item_end_offset,
-                            )
-                        }
-                        None => {
-                            self.do_enter_in_text(handle, leaf.start_offset)
-                        }
+                    if let Some(ancestor_block_location) =
+                        ancestor_block_location
+                    {
+                        self.enter_with_zero_selection_in_block_node(
+                            leaf,
+                            ancestor_block_location,
+                            &range,
+                        )
+                    } else {
+                        self.do_enter_in_text(handle, leaf.start_offset)
                     }
                 }
+            }
+        }
+    }
+
+    fn enter_with_zero_selection_in_block_node(
+        &mut self,
+        leaf: &DomLocation,
+        block_ancestor_loc: &DomLocation,
+        range: &Range,
+    ) -> ComposerUpdate<S> {
+        match block_ancestor_loc.kind {
+            DomNodeKind::List => {
+                // Find ListItem that's an ancestor of the leaf and a child of the List node
+                let list_item = range
+                    .locations
+                    .iter()
+                    .find(|l| {
+                        block_ancestor_loc
+                            .node_handle
+                            .is_parent_of(&l.node_handle)
+                            && l.node_handle.is_parent_of(&leaf.node_handle)
+                            && l.kind == ListItem
+                    })
+                    .unwrap();
+                let current_cursor_global_location =
+                    leaf.position + leaf.start_offset;
+                self.do_enter_in_list(
+                    &list_item.node_handle,
+                    current_cursor_global_location,
+                    list_item.end_offset,
+                )
+            }
+            DomNodeKind::CodeBlock => {
+                self.do_enter_in_code_block(leaf, block_ancestor_loc)
+            }
+            _ => panic!("Enter not implemented for this block node!"),
+        }
+    }
+
+    fn do_enter_in_code_block(
+        &mut self,
+        leaf: &DomLocation,
+        block_location: &DomLocation,
+    ) -> ComposerUpdate<S> {
+        let mut has_previous_line_break = false;
+        let mut selection_offset = 0;
+        if leaf.start_offset > 0 {
+            if let DomNode::Text(text_node) =
+                self.state.dom.lookup_node_mut(&leaf.node_handle)
+            {
+                let prev_offset = leaf.start_offset - 1;
+                let prev_char =
+                    text_node.data().chars().nth(prev_offset).clone();
+                if let Some(prev_char) = prev_char {
+                    if prev_char == '\n' {
+                        // Remove line break, we'll add another one outside the code block
+                        let mut new_data = text_node.data().to_owned();
+                        new_data.remove_at(prev_offset);
+                        text_node.set_data(new_data);
+                        // Adjust selection too
+                        self.state.start -= 1;
+                        self.state.end = self.state.start;
+                        has_previous_line_break = true;
+                        selection_offset += 1;
+                    }
+                }
+            }
+        }
+        if has_previous_line_break {
+            let DomNode::Container(sub_tree) = self.split_sub_tree(&leaf.node_handle, leaf.start_offset - selection_offset, block_location.node_handle.depth()) else {
+                panic!("Sub tree must start from a container node");
+            };
+            let DomNode::Container(block) = self.state.dom.lookup_node_mut(&block_location.node_handle) else {
+                panic!("Parent must be a block node");
+            };
+            if block.children().is_empty() {
+                self.state.dom.replace(
+                    &block_location.node_handle,
+                    vec![
+                        DomNode::new_line_break(),
+                        DomNode::new_code_block(sub_tree.children().clone()),
+                    ],
+                );
+            } else {
+                let next_handle = block_location.node_handle.next_sibling();
+                if !sub_tree.children().is_empty() {
+                    self.state.dom.insert_at(
+                        &next_handle,
+                        DomNode::new_code_block(sub_tree.children().clone()),
+                    );
+                }
+                self.state
+                    .dom
+                    .insert_at(&next_handle, DomNode::new_line_break());
+            }
+            self.state.start += 1;
+            self.state.end = self.state.start;
+            self.create_update_replace_all()
+        } else {
+            if let DomNode::Text(text_node) =
+                self.state.dom.lookup_node_mut(&leaf.node_handle)
+            {
+                let mut new_data = text_node.data().to_owned();
+                new_data.insert(leaf.start_offset, &S::from("\n"));
+                text_node.set_data(new_data);
+                self.state.start += 1;
+                self.state.end = self.state.start;
+                self.create_update_replace_all()
+            } else {
+                ComposerUpdate::keep()
             }
         }
     }
@@ -189,6 +297,7 @@ where
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
+
     use widestring::Utf16String;
 
     use crate::action_state::ActionState;

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -179,7 +179,7 @@ where
             }
         }
         if has_previous_line_break {
-            let DomNode::Container(sub_tree) = self.split_sub_tree(&leaf.node_handle, leaf.start_offset - selection_offset, block_location.node_handle.depth()) else {
+            let DomNode::Container(sub_tree) = self.state.dom.split_sub_tree(&leaf.node_handle, leaf.start_offset - selection_offset, block_location.node_handle.depth()) else {
                 panic!("Sub tree must start from a container node");
             };
             let DomNode::Container(block) = self.state.dom.lookup_node_mut(&block_location.node_handle) else {

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -228,6 +228,7 @@ mod test {
             (ComposerAction::UnorderedList, ActionState::Enabled),
             (ComposerAction::Indent, ActionState::Disabled),
             (ComposerAction::UnIndent, ActionState::Disabled),
+            (ComposerAction::CodeBlock, ActionState::Enabled),
         ])
     }
 }

--- a/crates/wysiwyg/src/dom/action_list.rs
+++ b/crates/wysiwyg/src/dom/action_list.rs
@@ -154,7 +154,7 @@ impl<S: UnicodeString> DomActionList<S> {
     ) -> Option<(DomHandle, DomHandle)> {
         self.actions.iter().find_map(|action| match action {
             DomAction::Move(a) => {
-                if a.from_handle.is_parent_of(handle)
+                if a.from_handle.is_ancestor_of(handle)
                     || a.from_handle == *handle
                 {
                     Some((a.from_handle.clone(), a.to_handle.clone()))

--- a/crates/wysiwyg/src/dom/dom_handle.rs
+++ b/crates/wysiwyg/src/dom/dom_handle.rs
@@ -136,7 +136,7 @@ impl DomHandle {
 
     /// Returns true if the passed handle is an ancestor of the current one, but false if it is
     /// either unrelated to it or it's the same handle.
-    pub fn is_parent_of(&self, other: &DomHandle) -> bool {
+    pub fn is_ancestor_of(&self, other: &DomHandle) -> bool {
         let own_path = self.raw();
         let other_path = other.raw();
         other_path.starts_with(own_path.as_slice()) && other_path != own_path
@@ -144,7 +144,7 @@ impl DomHandle {
 
     /// Replaces the sub-path shared with [old] handle with the same sub-path in [new].
     pub fn replace_ancestor(&mut self, old: DomHandle, new: DomHandle) {
-        assert!(old.is_parent_of(self) || old == *self);
+        assert!(old.is_ancestor_of(self) || old == *self);
         assert!(self.is_set());
         let mut new_path = self.path.as_ref().unwrap().clone();
         new_path.splice(0..old.raw().len(), new.into_raw());
@@ -160,8 +160,8 @@ mod test {
     fn creating_root_handle() {
         let root = DomHandle::root();
         assert!(root.is_root());
-        assert!(!root.is_parent_of(&DomHandle::root()));
-        assert!(root.is_parent_of(&DomHandle::from_raw(vec![0, 1, 2])));
+        assert!(!root.is_ancestor_of(&DomHandle::root()));
+        assert!(root.is_ancestor_of(&DomHandle::from_raw(vec![0, 1, 2])));
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -227,7 +227,7 @@ where
                 )
             {
                 // FIXME: need to join other types of node as well
-                self.join_nodes_in_parent(&ancestor_handle);
+                self.join_nodes_in_container(&ancestor_handle);
             }
         }
         deleted_handles
@@ -256,19 +256,22 @@ where
         parent_handle_in_list(list, node_handle)
     }
 
-    pub(crate) fn join_nodes_in_parent(&mut self, parent_handle: &DomHandle) {
-        let child_count = if let DomNode::Container(parent) =
-            self.lookup_node(parent_handle)
+    pub(crate) fn join_nodes_in_container(
+        &mut self,
+        container_handle: &DomHandle,
+    ) {
+        let child_count = if let DomNode::Container(container) =
+            self.lookup_node(container_handle)
         {
-            parent.children().len()
+            container.children().len()
         } else {
             panic!("Parent node should be a container");
         };
 
         if child_count > 0 {
             for i in (0..child_count - 1).rev() {
-                let handle = parent_handle.child_handle(i);
-                let next_handle = parent_handle.child_handle(i + 1);
+                let handle = container_handle.child_handle(i);
+                let next_handle = container_handle.child_handle(i + 1);
                 let next_node = self.lookup_node(&next_handle);
                 let node = self.lookup_node(&handle);
 

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -15,6 +15,8 @@
 //! Methods on Dom that modify its contents and are guaranteed to conform to
 //! our invariants e.g. no empty text nodes, no adjacent text nodes.
 
+use crate::dom::nodes::ContainerNodeKind;
+use crate::dom::unicode_string::UnicodeStr;
 use crate::{DomHandle, DomNode, UnicodeString};
 
 use super::action_list::{DomAction, DomActionList};
@@ -431,6 +433,118 @@ where
         #[cfg(any(test, feature = "assert-invariants"))]
         self.assert_invariants();
     }
+
+    pub(crate) fn split_sub_tree(
+        &mut self,
+        from_handle: &DomHandle,
+        offset: usize,
+        depth: usize,
+    ) -> DomNode<S> {
+        // Create new 'root' node to contain the split sub-tree
+        let mut new_subtree = DomNode::Container(ContainerNode::new(
+            S::default(),
+            ContainerNodeKind::Generic,
+            None,
+            Vec::new(),
+        ));
+        new_subtree.set_handle(DomHandle::root());
+
+        let path = from_handle.sub_handle_up_to(depth).raw().clone();
+        self.split_sub_tree_at(
+            path,
+            from_handle.raw()[depth],
+            depth,
+            offset,
+            from_handle,
+            &mut new_subtree,
+        );
+        new_subtree
+    }
+
+    fn split_sub_tree_at<'a>(
+        &'a mut self,
+        path: Vec<usize>,
+        index_in_parent: usize,
+        min_depth: usize,
+        offset: usize,
+        handle: &DomHandle,
+        result: &'a mut DomNode<S>,
+    ) {
+        let mut path = path;
+        let cur_handle = DomHandle::from_raw(path.clone());
+        path.push(index_in_parent);
+        let mut has_next_level = false;
+        let cur_subtree = self.lookup_node_mut(&cur_handle);
+        let mut removed_nodes = Vec::new();
+        if let DomNode::Container(container) = cur_subtree {
+            for idx in (index_in_parent..container.children().len()).rev() {
+                if idx == index_in_parent {
+                    let child = container.get_child_mut(idx).unwrap();
+                    match child {
+                        DomNode::Container(c) => {
+                            has_next_level = true;
+                            removed_nodes.insert(
+                                0,
+                                DomNode::Container(
+                                    c.copy_with_new_children(Vec::new()),
+                                ),
+                            );
+                        }
+                        DomNode::Text(text_node) => {
+                            if offset == 0 {
+                                removed_nodes.insert(0, child.clone());
+                            } else if offset >= text_node.data().chars().count()
+                            {
+                                // Do nothing
+                            } else {
+                                let left_data =
+                                    text_node.data()[..offset].to_owned();
+                                let right_data =
+                                    text_node.data()[offset..].to_owned();
+                                text_node.set_data(left_data);
+                                removed_nodes
+                                    .insert(0, DomNode::new_text(right_data));
+                            }
+                        }
+                        _ => {
+                            removed_nodes.insert(0, child.clone());
+                        }
+                    }
+                } else {
+                    removed_nodes.insert(0, container.remove_child(idx));
+                }
+            }
+        }
+        let mut new_subtree_at_prev_level = result;
+        if (path.len() - min_depth) > 1 {
+            if let DomNode::Container(c) = new_subtree_at_prev_level {
+                new_subtree_at_prev_level = c.get_child_mut(0).unwrap();
+            }
+        }
+        if let DomNode::Container(new_subtree) = new_subtree_at_prev_level {
+            if !removed_nodes.is_empty() {
+                for node in removed_nodes {
+                    new_subtree.append_child(node);
+                }
+            }
+        }
+
+        if has_next_level {
+            let index_at_level = if path.len() < handle.depth() {
+                handle.raw()[path.len()]
+            } else {
+                0
+            };
+            self.split_sub_tree_at(
+                path,
+                index_at_level,
+                min_depth,
+                offset,
+                &handle,
+                new_subtree_at_prev_level,
+            );
+        }
+    }
 }
 
 /// Look at the children of parent at index and index + 1. If they are both
@@ -534,6 +648,7 @@ fn adjust_handles_for_delete(
 mod test {
     use crate::dom::DomHandle;
     use crate::tests::testutils_composer_model::{cm, tx};
+    use crate::ToHtml;
 
     use super::*;
 
@@ -608,5 +723,80 @@ mod test {
             .dom
             .delete_nodes(vec![DomHandle::from_raw(vec![0])]);
         assert_eq!(tx(&model), "|")
+    }
+
+    #[test]
+    fn split_dom_simple() {
+        let mut model = cm("Text|<b>bold</b><i>italic</i>");
+        let ret = model.state.dom.split_sub_tree(
+            &DomHandle::from_raw(vec![1, 0]),
+            2,
+            0,
+        );
+        assert_eq!(ret.to_html().to_string(), "<b>ld</b><i>italic</i>");
+    }
+
+    #[test]
+    fn split_dom_with_nested_formatting() {
+        let mut model = cm("<u>Text|<b>bold</b><i>italic</i></u>");
+        let ret = model.state.dom.split_sub_tree(
+            &DomHandle::from_raw(vec![0, 1, 0]),
+            2,
+            0,
+        );
+        assert_eq!(ret.to_html().to_string(), "<u><b>ld</b><i>italic</i></u>");
+    }
+
+    #[test]
+    fn split_dom_with_nested_formatting_at_sub_level() {
+        let mut model = cm("<u>Text|<b>bold</b><i>italic</i></u>");
+        let ret = model.state.dom.split_sub_tree(
+            &DomHandle::from_raw(vec![0, 1, 0]),
+            2,
+            1,
+        );
+        assert_eq!(ret.to_html().to_string(), "<b>ld</b><i>italic</i>")
+    }
+
+    #[test]
+    fn split_dom_with_lists() {
+        let mut model =
+            cm("<ul><li>Text|</li><li><b>bold</b><i>italic</i></li></ul>");
+        let depth = 0;
+        let offset = 2;
+        let ret = model.state.dom.split_sub_tree(
+            &DomHandle::from_raw(vec![0, 1, 0, 0]),
+            offset,
+            depth,
+        );
+        assert_eq!(
+            ret.to_html().to_string(),
+            "<ul><li><b>ld</b><i>italic</i></li></ul>"
+        )
+    }
+
+    #[test]
+    fn split_dom_with_lists_at_sub_level() {
+        let mut model =
+            cm("<ul><li>Text|</li><li><b>bold</b><i>italic</i></li></ul>");
+        let depth = 1;
+        let offset = 2;
+        let ret = model.state.dom.split_sub_tree(
+            &DomHandle::from_raw(vec![0, 1, 0, 0]),
+            offset,
+            depth,
+        );
+        assert_eq!(ret.to_html().to_string(), "<li><b>ld</b><i>italic</i></li>")
+    }
+
+    #[test]
+    fn split_dom_with_partial_handle() {
+        let mut model = cm("<u>Text|<b>bold</b><i>italic</i></u>");
+        let ret = model.state.dom.split_sub_tree(
+            &DomHandle::from_raw(vec![0, 1]),
+            2,
+            0,
+        );
+        assert_eq!(ret.to_html().to_string(), "<u><b>ld</b><i>italic</i></u>");
     }
 }

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -411,7 +411,7 @@ where
             {
                 if let DomNode::Container(node) = node {
                     current = node;
-                } else {
+                } else if i != path_len {
                     return false;
                 }
             } else {

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -147,7 +147,7 @@ where
             return vec![]
         };
         let ret = self.replace(node_handle, parent.children().clone());
-        self.join_nodes_in_parent(&node_handle.parent_handle());
+        self.join_nodes_in_container(&node_handle.parent_handle());
         ret
     }
 

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -421,6 +421,12 @@ where
         true
     }
 
+    /// Checks if the passed handle is the last one in its parent.
+    pub fn is_last_in_parent(&self, handle: &DomHandle) -> bool {
+        return self.parent(handle).children().len()
+            == handle.index_in_parent() + 1;
+    }
+
     /// Gets the previous sibling of the node if exists.
     pub fn prev_sibling(&self, handle: &DomHandle) -> Option<&DomNode<S>> {
         if handle.index_in_parent() == 0 {

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -399,7 +399,7 @@ where
     }
 
     /// Checks if the passed [handle] exists in the DOM.
-    pub fn exists(&self, handle: &DomHandle) -> bool {
+    pub fn contains(&self, handle: &DomHandle) -> bool {
         let mut current = self.document();
         let path_len = handle.raw().len();
         for i in 0..=path_len {
@@ -427,7 +427,7 @@ where
             return None;
         }
         let prev_handle = handle.prev_sibling();
-        if self.exists(&prev_handle) {
+        if self.contains(&prev_handle) {
             Some(self.lookup_node(&prev_handle))
         } else {
             None
@@ -443,7 +443,7 @@ where
             return None;
         }
         let prev_handle = handle.prev_sibling();
-        if self.exists(&prev_handle) {
+        if self.contains(&prev_handle) {
             Some(self.lookup_node_mut(&prev_handle))
         } else {
             None
@@ -453,7 +453,7 @@ where
     /// Gets the next sibling of the node if exists.
     pub fn next_sibling(&self, handle: &DomHandle) -> Option<&DomNode<S>> {
         let next_handle = handle.next_sibling();
-        if self.exists(&next_handle) {
+        if self.contains(&next_handle) {
             Some(self.lookup_node(&next_handle))
         } else {
             None
@@ -466,7 +466,7 @@ where
         handle: &DomHandle,
     ) -> Option<&mut DomNode<S>> {
         let next_handle = handle.next_sibling();
-        if self.exists(&next_handle) {
+        if self.contains(&next_handle) {
             Some(self.lookup_node_mut(&next_handle))
         } else {
             None
@@ -783,7 +783,7 @@ mod test {
     fn node_exists_returns_true_if_exists() {
         let d = cm("<ul><li>b<strong>c</strong></li></ul>d|").state.dom;
         let handle = DomHandle::from_raw(vec![0, 0, 1, 0]);
-        assert!(d.exists(&handle));
+        assert!(d.contains(&handle));
     }
 
     #[test]
@@ -791,7 +791,7 @@ mod test {
         let d = cm("<ul><li>b<strong>c</strong></li></ul>d|").state.dom;
         // Last level doesn't exist, [0, 0, 1, 0] is a leaf node
         let handle = DomHandle::from_raw(vec![0, 0, 1, 0, 2]);
-        assert!(!d.exists(&handle));
+        assert!(!d.contains(&handle));
     }
 
     #[test]
@@ -799,7 +799,7 @@ mod test {
         let d = cm("<ul><li>b<strong>c</strong></li></ul>d|").state.dom;
         // Last level doesn't exist, [0, 0, 1] does not have 6 children
         let handle = DomHandle::from_raw(vec![0, 0, 1, 5]);
-        assert!(!d.exists(&handle));
+        assert!(!d.contains(&handle));
     }
 
     const NO_CHILDREN: &Vec<DomNode<Utf16String>> = &Vec::new();

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -393,6 +393,81 @@ where
             panic!("Parent node was not a container!");
         }
     }
+
+    /// Checks if the passed [handle] exists in the DOM.
+    pub fn exists(&self, handle: &DomHandle) -> bool {
+        let mut current = self.document();
+        let path_len = handle.raw().len();
+        for i in 0..=path_len {
+            let sub_handle = handle.sub_handle_up_to(i);
+            if sub_handle.is_root() {
+                continue;
+            } else if let Some(node) =
+                current.children().get(sub_handle.index_in_parent())
+            {
+                if let DomNode::Container(node) = node {
+                    current = node;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Gets the previous sibling of the node if exists.
+    pub fn prev_sibling(&self, handle: &DomHandle) -> Option<&DomNode<S>> {
+        if handle.index_in_parent() == 0 {
+            return None;
+        }
+        let prev_handle = handle.prev_sibling();
+        if self.exists(&prev_handle) {
+            Some(self.lookup_node(&prev_handle))
+        } else {
+            None
+        }
+    }
+
+    /// Gets the previous sibling of the node if exists as a mut ref.
+    pub fn prev_sibling_mut(
+        &mut self,
+        handle: &DomHandle,
+    ) -> Option<&mut DomNode<S>> {
+        if handle.index_in_parent() == 0 {
+            return None;
+        }
+        let prev_handle = handle.prev_sibling();
+        if self.exists(&prev_handle) {
+            Some(self.lookup_node_mut(&prev_handle))
+        } else {
+            None
+        }
+    }
+
+    /// Gets the next sibling of the node if exists.
+    pub fn next_sibling(&self, handle: &DomHandle) -> Option<&DomNode<S>> {
+        let next_handle = handle.next_sibling();
+        if self.exists(&next_handle) {
+            Some(self.lookup_node(&next_handle))
+        } else {
+            None
+        }
+    }
+
+    /// Gets the next sibling of the node if exists as a mut ref.
+    pub fn next_sibling_mut(
+        &mut self,
+        handle: &DomHandle,
+    ) -> Option<&mut DomNode<S>> {
+        let next_handle = handle.next_sibling();
+        if self.exists(&next_handle) {
+            Some(self.lookup_node_mut(&next_handle))
+        } else {
+            None
+        }
+    }
 }
 
 impl<S> ToHtml<S> for Dom<S>
@@ -698,6 +773,29 @@ mod test {
         let res =
             d.find_parent_list_item_or_self(&DomHandle::from_raw(vec![1]));
         assert!(res.is_none(), "Should not have found a list parent!")
+    }
+
+    #[test]
+    fn node_exists_returns_true_if_exists() {
+        let d = cm("<ul><li>b<strong>c</strong></li></ul>d|").state.dom;
+        let handle = DomHandle::from_raw(vec![0, 0, 1, 0]);
+        assert!(d.exists(&handle));
+    }
+
+    #[test]
+    fn node_exists_returns_false_if_child_does_not_exist() {
+        let d = cm("<ul><li>b<strong>c</strong></li></ul>d|").state.dom;
+        // Last level doesn't exist, [0, 0, 1, 0] is a leaf node
+        let handle = DomHandle::from_raw(vec![0, 0, 1, 0, 2]);
+        assert!(!d.exists(&handle));
+    }
+
+    #[test]
+    fn node_exists_returns_false_if_sibling_does_not_exist() {
+        let d = cm("<ul><li>b<strong>c</strong></li></ul>d|").state.dom;
+        // Last level doesn't exist, [0, 0, 1] does not have 6 children
+        let handle = DomHandle::from_raw(vec![0, 0, 1, 5]);
+        assert!(!d.exists(&handle));
     }
 
     const NO_CHILDREN: &Vec<DomNode<Utf16String>> = &Vec::new();

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -113,7 +113,11 @@ where
 
     /// Inserts the given [node] at the [node_handle] position, moving the node at that position
     /// forward, if any.
-    pub fn insert_at(&mut self, node_handle: &DomHandle, node: DomNode<S>) {
+    pub fn insert_at(
+        &mut self,
+        node_handle: &DomHandle,
+        node: DomNode<S>,
+    ) -> &DomNode<S> {
         let parent = self.parent_mut(node_handle);
         let index = node_handle.index_in_parent();
         parent.insert_child(index, node)

--- a/crates/wysiwyg/src/dom/join_nodes.rs
+++ b/crates/wysiwyg/src/dom/join_nodes.rs
@@ -93,7 +93,7 @@ where
         }
     }
 
-    fn join_format_nodes_at_level(
+    pub(crate) fn join_format_nodes_at_level(
         &mut self,
         handle: &DomHandle,
         level: usize,
@@ -316,7 +316,7 @@ where
     /// Deletes [from_handle] node appending its children nodes to [to_handle].
     /// Returns a tuple of the index where the children where inserted inside [to_handle] and a
     /// HashMap mapping the old handle of each moved children to its new one.
-    fn move_children_and_delete_parent(
+    pub(crate) fn move_children_and_delete_parent(
         &mut self,
         from_handle: &DomHandle,
         to_handle: &DomHandle,

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -46,6 +46,7 @@ where
     Link(S),
     List,
     ListItem,
+    CodeBlock,
 }
 
 impl<S> ContainerNode<S>
@@ -113,6 +114,16 @@ where
         Self {
             name: "li".into(),
             kind: ContainerNodeKind::ListItem,
+            attrs: None,
+            children,
+            handle: DomHandle::new_unset(),
+        }
+    }
+
+    pub fn new_code_block(children: Vec<DomNode<S>>) -> Self {
+        Self {
+            name: "pre".into(),
+            kind: ContainerNodeKind::CodeBlock,
             attrs: None,
             children,
             handle: DomHandle::new_unset(),
@@ -264,7 +275,7 @@ where
     pub(crate) fn is_block_node(&self) -> bool {
         use ContainerNodeKind::*;
 
-        matches!(self.kind, Generic | List)
+        matches!(self.kind, Generic | List | CodeBlock)
     }
 
     pub fn text_len(&self) -> usize {
@@ -478,6 +489,10 @@ where
 
             ListItem => {
                 fmt_list_item(self, buffer, &options)?;
+            }
+
+            CodeBlock => {
+                fmt_code_block(self, buffer, &options)?;
             }
         };
 
@@ -795,6 +810,22 @@ where
             S: UnicodeString,
         {
             fmt_children(this, buffer, options)?;
+
+            Ok(())
+        }
+
+        #[inline(always)]
+        fn fmt_code_block<S>(
+            this: &ContainerNode<S>,
+            buffer: &mut S,
+            options: &MarkdownOptions,
+        ) -> Result<(), MarkdownError<S>>
+        where
+            S: UnicodeString,
+        {
+            buffer.push("```\n");
+            fmt_children(this, buffer, &options)?;
+            buffer.push("\n```\n");
 
             Ok(())
         }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -193,7 +193,11 @@ where
         self.children.last_mut()
     }
 
-    pub fn insert_child(&mut self, index: usize, node: DomNode<S>) {
+    pub fn insert_child(
+        &mut self,
+        index: usize,
+        node: DomNode<S>,
+    ) -> &DomNode<S> {
         assert!(self.handle.is_set());
         assert!(index <= self.children().len());
 
@@ -203,6 +207,8 @@ where
             let new_handle = self.handle.child_handle(i);
             self.children[i].set_handle(new_handle);
         }
+
+        self.children.get(index).unwrap()
     }
 
     pub fn handle(&self) -> DomHandle {
@@ -343,6 +349,19 @@ where
         while !other_node.children().is_empty() {
             let child = other_node.remove_child(0);
             self.append_child(child);
+        }
+    }
+
+    pub(crate) fn copy_with_new_children(
+        &self,
+        new_children: Vec<DomNode<S>>,
+    ) -> Self {
+        Self {
+            name: self.name.clone(),
+            kind: self.kind.clone(),
+            attrs: self.attrs.clone(),
+            children: new_children,
+            handle: self.handle.clone(),
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -361,7 +361,7 @@ where
             kind: self.kind.clone(),
             attrs: self.attrs.clone(),
             children: new_children,
-            handle: self.handle.clone(),
+            handle: DomHandle::new_unset(),
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -80,6 +80,10 @@ where
         DomNode::Container(ContainerNode::new_list_item(children))
     }
 
+    pub fn new_code_block(children: Vec<DomNode<S>>) -> DomNode<S> {
+        DomNode::Container(ContainerNode::new_code_block(children))
+    }
+
     pub fn handle(&self) -> DomHandle {
         match self {
             DomNode::Container(n) => n.handle(),
@@ -311,6 +315,7 @@ pub enum DomNodeKind {
     Link,
     ListItem,
     List,
+    CodeBlock,
 }
 
 impl DomNodeKind {
@@ -325,7 +330,16 @@ impl DomNodeKind {
             ContainerNodeKind::List => DomNodeKind::List,
             ContainerNodeKind::ListItem => DomNodeKind::ListItem,
             ContainerNodeKind::Generic => DomNodeKind::Generic,
+            ContainerNodeKind::CodeBlock => DomNodeKind::CodeBlock,
         }
+    }
+
+    pub fn is_structure_kind(&self) -> bool {
+        matches!(self, Self::List | Self::ListItem)
+    }
+
+    pub fn is_block_kind(&self) -> bool {
+        matches!(self, Self::Generic | Self::List | Self::CodeBlock)
     }
 }
 

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -127,6 +127,14 @@ mod sys {
             DomNode::Container(ContainerNode::new_list_item(Vec::new()))
         }
 
+        /// Create a code block node
+        fn new_code_block<S>() -> DomNode<S>
+        where
+            S: UnicodeString,
+        {
+            DomNode::Container(ContainerNode::new_code_block(Vec::new()))
+        }
+
         /// Copy all panode's information into node (now we know it's a container).
         fn convert_container<S>(
             padom: &PaDom,
@@ -154,6 +162,10 @@ mod sys {
                 }
                 "a" => {
                     node.append_child(new_link(child));
+                    convert_children(padom, child, node.last_child_mut());
+                }
+                "pre" => {
+                    node.append_child(new_code_block());
                     convert_children(padom, child, node.last_child_mut());
                 }
                 "html" => {

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -228,6 +228,13 @@ impl Range {
     pub fn is_empty(&self) -> bool {
         self.locations.is_empty()
     }
+
+    pub fn contains(&self, handle: &DomHandle) -> bool {
+        self.locations
+            .iter()
+            .find(|l| l.node_handle == *handle)
+            .is_some()
+    }
 }
 
 impl IntoIterator for Range {

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -47,6 +47,7 @@ pub trait UnicodeString:
     type Str: UnicodeStr<CodeUnit = Self::CodeUnit, Owned = Self> + ?Sized;
 
     fn insert(&mut self, idx: usize, s: &Self::Str);
+    fn remove_at(&mut self, idx: usize);
 
     /// Creates a new unicode string consisting of a single ZWSP.
     fn zwsp() -> Self {
@@ -82,6 +83,9 @@ impl UnicodeString for String {
     fn insert(&mut self, idx: usize, s: &Self::Str) {
         self.insert_str(idx, s);
     }
+    fn remove_at(&mut self, idx: usize) {
+        self.remove(idx);
+    }
 }
 
 impl UnicodeStr for str {
@@ -104,6 +108,9 @@ impl UnicodeString for Utf16String {
     fn insert(&mut self, idx: usize, s: &Self::Str) {
         self.insert_utfstr(idx, s);
     }
+    fn remove_at(&mut self, idx: usize) {
+        self.remove(idx);
+    }
 }
 
 impl UnicodeStr for Utf16Str {
@@ -125,6 +132,9 @@ impl UnicodeString for Utf32String {
 
     fn insert(&mut self, idx: usize, s: &Self::Str) {
         self.insert_utfstr(idx, s);
+    }
+    fn remove_at(&mut self, idx: usize) {
+        self.remove(idx);
     }
 }
 

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -189,6 +189,12 @@ fn formatting_is_disabled_when_selection_covers_inline_code_node_and_others() {
     assert_formatting_actions_and_links_are_disabled(&model);
 }
 
+#[test]
+fn inline_code_is_disabled_when_selection_intersects_with_code_block() {
+    let model = cm("<pre>Some {code</pre> and}| text");
+    assert!(model.action_is_disabled(ComposerAction::InlineCode));
+}
+
 fn assert_formatting_actions_and_links_are_disabled(
     model: &ComposerModel<Utf16String>,
 ) {

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -178,3 +178,31 @@ fn backspace_merges_formatting_nodes() {
     model.backspace();
     assert_eq!(tx(&model), "<b>a|b</b>");
 }
+
+#[test]
+fn enter_in_code_block_in_text_node_adds_line_break_as_text() {
+    let mut model = cm("<pre>Test|</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre>Test\n|</pre>")
+}
+
+#[test]
+fn enter_in_code_block_after_line_break_at_end_ends_code_block() {
+    let mut model = cm("<pre>Test\n|</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre>Test</pre><br />|")
+}
+
+#[test]
+fn enter_in_code_block_after_line_break_in_middle_splits_code_block() {
+    let mut model = cm("<pre>Test\n|code blocks</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre>Test</pre><br />|<pre>code blocks</pre>")
+}
+
+#[test]
+fn enter_in_code_block_after_nested_line_break_in_middle_splits_code_block() {
+    let mut model = cm("<pre><b><i>Test\n|code blocks</i></b></pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre><b><i>Test</i></b></pre><br />|<pre><b><i>code blocks</i></b></pre>")
+}

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -214,3 +214,24 @@ fn enter_in_code_block_after_nested_line_break_in_middle_splits_code_block() {
     model.enter();
     assert_eq!(tx(&model), "<pre><b><i>Test</i></b></pre><br />|<pre><b><i>code blocks</i></b></pre>")
 }
+
+#[test]
+fn backspace_at_start_of_code_block_removes_previous_text() {
+    let mut model = cm("Test <pre>|code</pre>");
+    model.backspace();
+    assert_eq!(tx(&model), "Test|<pre>code</pre>");
+}
+
+#[test]
+fn backspace_at_end_of_code_block_deletes_its_last_character() {
+    let mut model = cm("Test <pre>code</pre>| and more");
+    model.backspace();
+    assert_eq!(tx(&model), "Test <pre>cod|</pre> and more");
+}
+
+#[test]
+fn backspace_emptying_code_block_removes_it() {
+    let mut model = cm("Test <pre>c|</pre>");
+    model.backspace();
+    assert_eq!(tx(&model), "Test&nbsp;|");
+}

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -187,6 +187,14 @@ fn enter_in_code_block_in_text_node_adds_line_break_as_text() {
 }
 
 #[test]
+#[ignore = "For some reason, the HTML parser returns '<pre>|Test</pre>', removing the leading line break. Might be a bug?"]
+fn enter_in_code_block_after_line_break_at_start_splits_code_block() {
+    let mut model = cm("<pre>\n|Test</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<br />|<pre>Test</pre>")
+}
+
+#[test]
 fn enter_in_code_block_after_line_break_at_end_ends_code_block() {
     let mut model = cm("<pre>Test\n|</pre>");
     model.enter();


### PR DESCRIPTION
Adds code blocks (`<pre>`) support for the text editor. It currently has the following issues:
1. When a code block covers a list item, it turns it into a simple text node and adds a new line after it. This new line is always added, even when not needed.
2. At the moment it's not possible to add only part of a list to a code block: if several ListItem nodes are selected, the whole list will get into the code block.
3. The HTML parser parses `<pre>\nSomething</pre>` as `<pre>Something</pre>` since when using code blocks in HTML, the first line can be used to just give some structure to the HTML. This could be a problem if we create an empty code block and add a new line in the clients, it could either create an index mismatch or just don't process the new line at all.

I'm thinking about possible solutions to these 3 issues, but I'd rather first merge the current version and then attempt to fix them one by one.

Also, the `split_sub_tree` and `slice_before/slice_after` implementations are kind of similar, so it might be a good idea to try to get them merged into a single method in the future.