### PR TITLE
Fix dom location length with nested tags

### DIFF
--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -133,7 +133,7 @@ where
     }
     // If container node is completely selected, include it
     let container_end = *offset;
-    let container_node_len = container_end - container_start;
+    let container_node_len = node.text_len();
     // We never want to return the root node
     if container_end >= start
         && container_start <= end
@@ -244,7 +244,7 @@ mod test {
     use crate::tests::testutils_composer_model::{cm, restore_whitespace_u16};
     use crate::tests::testutils_conversion::utf16;
     use crate::tests::testutils_dom::{b, dom, tn};
-    use crate::{InlineFormatType, ToHtml};
+    use crate::{InlineFormatType, InlineFormatType::Italic, ToHtml};
 
     fn found_single_node(
         handle: DomHandle,
@@ -494,5 +494,43 @@ mod test {
         assert_eq!(utf16("<i>a </i>"), html_of_ranges[1]);
         assert_eq!(utf16("<b>ing <i>a </i></b>"), html_of_ranges[2]);
         assert_eq!(utf16("new feature"), html_of_ranges[3]);
+    }
+
+    #[test]
+    fn find_range_builds_dom_location_with_expected_length() {
+        let model = cm("<em>remains |<em>all<em>of<em>the<em>rest</em>goes</em>away</em>x</em>y</em>");
+        let (s, e) = model.safe_selection();
+        let range = model.state.dom.find_range(s, e);
+        assert_eq!(
+            range,
+            Range {
+                locations: vec![
+                    DomLocation {
+                        node_handle: DomHandle::from_raw(vec![0, 0]),
+                        start_offset: 8,
+                        end_offset: 8,
+                        position: 0,
+                        length: 8,
+                        kind: DomNodeKind::Text
+                    },
+                    DomLocation {
+                        node_handle: DomHandle::from_raw(vec![0, 1]),
+                        start_offset: 0,
+                        end_offset: 0,
+                        position: 8,
+                        length: 21,
+                        kind: DomNodeKind::Formatting(Italic)
+                    },
+                    DomLocation {
+                        node_handle: DomHandle::from_raw(vec![0]),
+                        start_offset: 8,
+                        end_offset: 8,
+                        position: 0,
+                        length: 30,
+                        kind: DomNodeKind::Formatting(Italic)
+                    },
+                ]
+            }
+        )
     }
 }

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -88,6 +88,7 @@ where
     let node = dom.lookup_node(node_handle);
     let mut locations = Vec::new();
     if *offset > end {
+        *offset += node.text_len();
         return locations;
     }
     match node {
@@ -133,7 +134,7 @@ where
     }
     // If container node is completely selected, include it
     let container_end = *offset;
-    let container_node_len = node.text_len();
+    let container_node_len = container_end - container_start;
     // We never want to return the root node
     if container_end >= start
         && container_start <= end


### PR DESCRIPTION
Now uses the container node text_len() to get the correct length