### PR TITLE
Set Link With Text

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -13,12 +13,6 @@ pub struct ComposerModel {
     inner: Mutex<wysiwyg::ComposerModel<Utf16String>>,
 }
 
-impl Default for ComposerModel {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ComposerModel {
     pub fn new() -> Self {
         Self {

--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -13,6 +13,12 @@ pub struct ComposerModel {
     inner: Mutex<wysiwyg::ComposerModel<Utf16String>>,
 }
 
+impl Default for ComposerModel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ComposerModel {
     pub fn new() -> Self {
         Self {
@@ -177,6 +183,18 @@ impl ComposerModel {
         let link = Utf16String::from_str(&link);
         Arc::new(ComposerUpdate::from(
             self.inner.lock().unwrap().set_link(link),
+        ))
+    }
+
+    pub fn set_link_with_text(
+        self: &Arc<Self>,
+        link: String,
+        text: String,
+    ) -> Arc<ComposerUpdate> {
+        let link = Utf16String::from_str(&link);
+        let text = Utf16String::from_str(&text);
+        Arc::new(ComposerUpdate::from(
+            self.inner.lock().unwrap().set_link_with_text(link, text),
         ))
     }
 

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -41,6 +41,7 @@ interface ComposerModel {
     ComposerUpdate indent();
     ComposerUpdate un_indent();
     ComposerUpdate set_link(string new_text);
+    ComposerUpdate set_link_with_text(string link, string text);
     string to_tree();
     ComposerState get_current_dom_state();
     record<ComposerAction, ActionState> action_states();

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -65,7 +65,7 @@ trait IntoFfi {
 impl IntoFfi for &HashMap<wysiwyg::ComposerAction, wysiwyg::ActionState> {
     fn into_ffi(self) -> js_sys::Map {
         let ret = js_sys::Map::new();
-        for (k, v) in self.into_iter() {
+        for (k, v) in self.iter() {
             ret.set(&k.as_ref().into(), &v.as_ref().into());
         }
         ret
@@ -75,6 +75,12 @@ impl IntoFfi for &HashMap<wysiwyg::ComposerAction, wysiwyg::ActionState> {
 #[wasm_bindgen]
 pub struct ComposerModel {
     inner: wysiwyg::ComposerModel<Utf16String>,
+}
+
+impl Default for ComposerModel {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[wasm_bindgen]
@@ -217,6 +223,21 @@ impl ComposerModel {
     pub fn get_link_action(&self) -> LinkAction {
         self.inner.get_link_action().into()
     }
+
+    pub fn set_link(&mut self, link: &str) -> ComposerUpdate {
+        ComposerUpdate::from(self.inner.set_link(Utf16String::from_str(link)))
+    }
+
+    pub fn set_link_with_text(
+        &mut self,
+        link: &str,
+        text: &str,
+    ) -> ComposerUpdate {
+        ComposerUpdate::from(self.inner.set_link_with_text(
+            Utf16String::from_str(link),
+            Utf16String::from_str(text),
+        ))
+    }
 }
 
 #[wasm_bindgen]
@@ -326,10 +347,7 @@ impl MenuState {
 #[wasm_bindgen]
 impl MenuState {
     pub fn keep(&self) -> bool {
-        match self.inner {
-            wysiwyg::MenuState::Keep => true,
-            _ => false,
-        }
+        matches!(self.inner, wysiwyg::MenuState::Keep)
     }
 
     pub fn update(&self) -> Option<MenuStateUpdate> {
@@ -426,6 +444,7 @@ impl DomChildren {
         }
     }
 
+    // Clippy suggests that this name is ambiguous
     pub fn next(&mut self) -> Option<DomHandle> {
         self.inner.pop_front()
     }

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -77,12 +77,6 @@ pub struct ComposerModel {
     inner: wysiwyg::ComposerModel<Utf16String>,
 }
 
-impl Default for ComposerModel {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[wasm_bindgen]
 impl ComposerModel {
     pub fn new() -> Self {

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -58,13 +58,8 @@ where
 
     pub fn set_link(&mut self, link: S) -> ComposerUpdate<S> {
         // push_state_to_history is after this check:
-        let (s, e) = self.safe_selection();
-        // Can't add a link to an empty selection
-        if s == e {
-            return ComposerUpdate::keep();
-        }
         self.push_state_to_history();
-
+        let (s, e) = self.safe_selection();
         let range = self.state.dom.find_range(s, e);
         self.set_link_range(range, link)
     }
@@ -88,10 +83,12 @@ where
                     if !before.is_empty() {
                         new_nodes.push(DomNode::new_text(before));
                     }
-                    new_nodes.push(DomNode::new_link(
-                        link.clone(),
-                        vec![DomNode::new_text(during)],
-                    ));
+                    if !during.is_empty() {
+                        new_nodes.push(DomNode::new_link(
+                            link.clone(),
+                            vec![DomNode::new_text(during)],
+                        ));
+                    }
                     if !after.is_empty() {
                         new_nodes.push(DomNode::new_text(after));
                     }

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -39,6 +39,23 @@ where
         }
     }
 
+    pub fn set_link_with_text(
+        &mut self,
+        link: S,
+        text: S,
+    ) -> ComposerUpdate<S> {
+        let (s, mut e) = self.safe_selection();
+        if s != e {
+            // This function is made to be used only when s == e
+            return ComposerUpdate::keep();
+        }
+        self.push_state_to_history();
+        self.do_replace_text(text.clone());
+        e += text.len();
+        let range = self.state.dom.find_range(s, e);
+        self.set_link_range(range, link)
+    }
+
     pub fn set_link(&mut self, link: S) -> ComposerUpdate<S> {
         // push_state_to_history is after this check:
         let (s, e) = self.safe_selection();

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -57,7 +57,6 @@ where
     }
 
     pub fn set_link(&mut self, link: S) -> ComposerUpdate<S> {
-        // push_state_to_history is after this check:
         self.push_state_to_history();
         let (s, e) = self.safe_selection();
         let range = self.state.dom.find_range(s, e);

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -343,8 +343,5 @@ fn set_link_with_text_and_undo() {
         "test<a href=\"https://element.io\">added_link|</a>"
     );
     model.undo();
-    assert_eq!(
-        tx(&model),
-        "test|"
-    );
+    assert_eq!(tx(&model), "test|");
 }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -323,3 +323,28 @@ fn replace_text_in_a_link_inside_a_list_partially_selected_starting_inside_endin
     model.replace_text(utf16("added_text"));
     assert_eq!(tx(&model), "<ul><li>list_element</li><li><a href=\"https://element.io\">linkadded_text|list</a></li></ul>");
 }
+
+#[test]
+fn set_link_with_text() {
+    let mut model = cm("test|");
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    assert_eq!(
+        tx(&model),
+        "test<a href=\"https://element.io\">added_link|</a>"
+    );
+}
+
+#[test]
+fn set_link_with_text_and_undo() {
+    let mut model = cm("test|");
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    assert_eq!(
+        tx(&model),
+        "test<a href=\"https://element.io\">added_link|</a>"
+    );
+    model.undo();
+    assert_eq!(
+        tx(&model),
+        "test|"
+    );
+}


### PR DESCRIPTION
A function that should be used only when there is no highlighted text, that allows the client to add text and then a link to it.