### PR TITLE
Set default toolchain via rust-toolchain.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,5 @@ coverage:
 	cargo llvm-cov --open
 
 setup:
-	rustup override set 1.65
 	cargo install uniffi_bindgen --version 0.21.0
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.65"
+components = ["rustfmt"]


### PR DESCRIPTION
This allows users to have their own overrides while defaulting to the specified toolchain. The same config file could also be users to have rustup automatically download standard libraries for specific targets (e.g. wasm) automatically, see the docs for details:

https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file