### PR TITLE
[Android] Fix crashes in ElementX on config changes

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -31,15 +31,17 @@ import uniffi.wysiwyg_composer.newComposerModel
 class EditorEditText : TextInputEditText {
 
     private var inputConnection: InterceptInputConnection? = null
-    private val viewModel: EditorViewModel by viewModel(viewModelInitializer = {
-        val applicationContext = context.applicationContext as Application
-        val resourcesProvider = AndroidResourcesProvider(applicationContext)
-        val htmlConverter = AndroidHtmlConverter(
-            provideHtmlToSpansParser = { html -> HtmlToSpansParser(resourcesProvider, html) },
-        )
-        val composer = if (!isInEditMode) newComposerModel() else null
-        EditorViewModel(composer, htmlConverter)
-    })
+    private val viewModel: EditorViewModel by viewModel(
+        viewModelInitializer = {
+            val applicationContext = context.applicationContext as Application
+            val resourcesProvider = AndroidResourcesProvider(applicationContext)
+            val htmlConverter = AndroidHtmlConverter(
+                provideHtmlToSpansParser = { html -> HtmlToSpansParser(resourcesProvider, html) },
+            )
+            val composer = if (!isInEditMode) newComposerModel() else null
+            EditorViewModel(composer, htmlConverter)
+        }
+    )
 
     private val spannableFactory = object : Spannable.Factory() {
         override fun newSpannable(source: CharSequence?): Spannable {


### PR DESCRIPTION
There are several crashes on Element X because the lazy ViewModel is instantiated when it's still not attached to the parent view. This happens both in `AndroidView.factory` and the `EditText.onRestoreInstanceState()` method when it's inside an `AndroidView` in Compose component.