### PR TITLE
Remove word utils

### DIFF
--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -17,6 +17,27 @@ use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{DomHandle, DomLocation, Range};
 use crate::{ComposerModel, ComposerUpdate, Location, UnicodeString};
 
+#[derive(PartialEq, Debug)]
+pub enum Direction {
+    Forwards,
+    Backwards,
+}
+
+impl Direction {
+    pub fn increment(&self, index: usize) -> usize {
+        match self {
+            Direction::Forwards => index + 1,
+            Direction::Backwards => index - 1,
+        }
+    }
+    pub fn get_index_from_cursor(&self, index: usize) -> usize {
+        match self {
+            Direction::Forwards => index,
+            Direction::Backwards => index - 1,
+        }
+    }
+}
+
 impl<S> ComposerModel<S>
 where
     S: UnicodeString,

--- a/crates/wysiwyg/src/composer_model/selection.rs
+++ b/crates/wysiwyg/src/composer_model/selection.rs
@@ -77,14 +77,11 @@ where
     }
 
     /// Return a boolean to let us know if we are touching the edge of the DOM
-    pub fn has_selected_to_end_of_dom(&self) -> bool {
-        let (s, e) = self.safe_selection();
-        s == 0 || e == self.state.dom.text_len()
-    }
-
-    /// Return a boolean to let us know if we are touching the edge of the DOM
     /// when moving in a specific direction
-    pub fn has_selected_end_of_dom(&self, direction: &Direction) -> bool {
+    pub fn selection_touches_start_or_end_of_dom(
+        &self,
+        direction: &Direction,
+    ) -> bool {
         let (s, e) = self.safe_selection();
         match direction {
             Direction::Forwards => e == self.state.dom.text_len(),

--- a/crates/wysiwyg/src/composer_model/selection.rs
+++ b/crates/wysiwyg/src/composer_model/selection.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::composer_model::delete_text::Direction;
 use crate::composer_model::menu_state::MenuStateComputeType;
 use crate::{ComposerModel, ComposerUpdate, Location, UnicodeString};
 
@@ -60,6 +61,34 @@ where
             (e, s)
         } else {
             (s, e)
+        }
+    }
+
+    /// Return a boolean to let us know if we have a selection
+    pub fn has_selection(&self) -> bool {
+        let (s, e) = self.safe_selection();
+        s != e
+    }
+
+    /// Return a boolean to let us know if we have a cursor, ie a zero length selection
+    pub fn has_cursor(&self) -> bool {
+        let (s, e) = self.safe_selection();
+        s == e
+    }
+
+    /// Return a boolean to let us know if we are touching the edge of the DOM
+    pub fn has_selected_to_end_of_dom(&self) -> bool {
+        let (s, e) = self.safe_selection();
+        s == 0 || e == self.state.dom.text_len()
+    }
+
+    /// Return a boolean to let us know if we are touching the edge of the DOM
+    /// when moving in a specific direction
+    pub fn has_selected_end_of_dom(&self, direction: &Direction) -> bool {
+        let (s, e) = self.safe_selection();
+        match direction {
+            Direction::Forwards => e == self.state.dom.text_len(),
+            Direction::Backwards => s == 0,
         }
     }
 }

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -361,6 +361,31 @@ mod test {
         );
     }
 
+    // position_is_end_of_list_item tests
+    #[test]
+    fn location_method_returns_false_for_end_of_non_list_item() {
+        let model = cm("<em>abcd|</em>");
+        let (s, e) = model.safe_selection();
+        let range = model.state.dom.find_range(s, e);
+        assert_eq!(range.locations[1].position_is_end_of_list_item(4), false);
+    }
+
+    #[test]
+    fn location_method_returns_false_for_inside_list_item() {
+        let model = cm("<ol><li>abcd|</li></ol>");
+        let (s, e) = model.safe_selection();
+        let range = model.state.dom.find_range(s, e);
+        assert_eq!(range.locations[1].position_is_end_of_list_item(2), false);
+    }
+
+    #[test]
+    fn location_method_returns_true_for_end_of_list_item() {
+        let model = cm("<ol><li>abcd|</li></ol>");
+        let (s, e) = model.safe_selection();
+        let range = model.state.dom.find_range(s, e);
+        assert_eq!(range.locations[1].position_is_end_of_list_item(4), true);
+    }
+
     fn range_of(model: &str) -> Range {
         let model = cm(model);
         let (s, e) = model.safe_selection();

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -134,6 +134,21 @@ impl DomLocation {
     pub fn is_covered(&self) -> bool {
         self.is_start() && self.is_end()
     }
+
+    /// Allows us to check whether a location is both a list item and the
+    /// passed position is at the end of it, we need this to handle adjacent
+    /// similar nodes within a list item
+    pub fn position_is_end_of_list_item(&self, position: usize) -> bool {
+        let is_list_item = self.kind == DomNodeKind::ListItem;
+
+        let location_start = self.position;
+        let location_end = self.position + self.length;
+
+        let position_is_at_end_of_location =
+            position == location_start || position == location_end;
+
+        is_list_item && position_is_at_end_of_location
+    }
 }
 
 impl PartialOrd<Self> for DomLocation {


### PR DESCRIPTION
A selection of small utils and enums required for use in the remove/backspace word work. Hopefully nothing too controversial.

Introduces:
* an enum to express direction
* an enum to express the type of a character
* a couple of selection utils on the ComposerModel
* some utils on the TextNode to allow us to figure out character types (including tests)
* a util method on DomLocation to allow us to figure out if we're at the end of a linebreak containing multiple adjacent text nodes
