### PR TITLE
Change Rust panic behaviour from abort to unwind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,8 @@ resolver = "2"
 opt-level = 'z'     # Optimize for size.
 lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
-panic = 'abort'     # Abort on panic
+# Unwind on panic to allow error handling at the FFI boundary. Note this 
+# imposes a small performance/size cost and it could be worth switching 
+# the behaviour to 'abort' once the library is stable.
+panic = 'unwind'    
 debug = true        # Enable debug symbols. For example, we can use `dwarfdump` to check crash traces.


### PR DESCRIPTION
## What?
Change the behaviour of Rust panics so that, instead of aborting, they unwind.

## Why?
When Rust panics, if it is configured to abort, the host application has no way to continue and must crash.

Changing this behaviour to instead unwind allows Rust panics to be caught at the FFI boundary so that the host application catch and rethrow the error in the host language (`InternalException` in Kotlin for example), and continue without crashing.

Note this imposes a small performance/size impact and it could be worth reverting this once the library is stable.