### PR TITLE
Char extension for ZWSP

### DIFF
--- a/crates/wysiwyg/src/char.rs
+++ b/crates/wysiwyg/src/char.rs
@@ -1,0 +1,28 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub trait CharExt: Sized {
+    fn is_zwsp(&self) -> bool;
+    fn zwsp() -> Self;
+}
+
+impl CharExt for char {
+    fn is_zwsp(&self) -> bool {
+        self == &char::zwsp()
+    }
+
+    fn zwsp() -> Self {
+        '\u{200B}'
+    }
+}

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -17,6 +17,7 @@ use std::ops::Not;
 
 use widestring::Utf16String;
 
+use crate::char::CharExt;
 use crate::composer_model::menu_state::MenuStateComputeType;
 use crate::dom::nodes::{LineBreakNode, TextNode};
 use crate::dom::parser::parse;
@@ -179,7 +180,7 @@ impl ComposerModel<Utf16String> {
         }
 
         // Replace characters with visible ones
-        html.replace('\u{200b}', "~").replace('\u{A0}', "&nbsp;")
+        html.replace(char::zwsp(), "~").replace('\u{A0}', "&nbsp;")
     }
 }
 

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -80,7 +80,7 @@ impl ComposerModel<Utf16String> {
     /// assert_eq!(model.to_example_format(), "a{abbc}|c");
     /// ```
     pub fn from_example_format(text: &str) -> Self {
-        let text = text.replace('~', "\u{200b}");
+        let text = text.replace('~', &char::zwsp().to_string());
         let text_u16 = Utf16String::from_str(&text).into_vec();
 
         let curs = find_char(&text_u16, "|").unwrap_or_else(|| {
@@ -422,7 +422,10 @@ mod test {
     use crate::dom::{parser, Dom, DomLocation};
     use crate::tests::testutils_composer_model::{cm, restore_whitespace, tx};
     use crate::tests::testutils_conversion::utf16;
-    use crate::{ComposerModel, ComposerState, DomHandle, DomNode, Location};
+    use crate::{
+        ComposerModel, ComposerState, DomHandle, DomNode, Location,
+        UnicodeString,
+    };
 
     use super::SelectionWritingState;
 
@@ -666,7 +669,7 @@ mod test {
         assert_eq!(model.state.end, 1);
 
         if let DomNode::Text(node) = &model.state.dom.document().children()[0] {
-            assert_eq!(node.data(), "\u{200b}");
+            assert_eq!(node.data(), Utf16String::zwsp());
         } else {
             panic!("Expected a text node!");
         }

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::ops::AddAssign;
 
+use crate::char::CharExt;
 use crate::dom::nodes::{ContainerNode, DomNode};
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
@@ -280,7 +281,7 @@ where
             if let DomNode::Text(t) = node {
                 let text = t.data();
                 let index_in_parent = handle.index_in_parent();
-                let add_zwsp = !text.to_string().starts_with("\u{200b}");
+                let add_zwsp = !text.to_string().starts_with(char::zwsp());
                 let list_item =
                     DomNode::Container(ContainerNode::new_list_item(
                         "li".into(),

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::char::CharExt;
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::dom_node::DomNode;
@@ -284,7 +285,7 @@ where
         match self.kind {
             ContainerNodeKind::ListItem => {
                 let raw_text = self.to_raw_text().to_string();
-                raw_text.is_empty() || raw_text == "\u{200b}"
+                raw_text.is_empty() || raw_text == char::zwsp().to_string()
             }
             _ => false,
         }

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use crate::char::CharExt;
 use std::fmt;
 use std::iter;
 use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
@@ -48,7 +50,7 @@ pub trait UnicodeString:
 
     /// Creates a new unicode string consisting of a single ZWSP.
     fn zwsp() -> Self {
-        "\u{200B}".into()
+        char::zwsp().to_string().into()
     }
 }
 

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod action_state;
+mod char;
 mod composer_action;
 mod composer_model;
 mod composer_state;


### PR DESCRIPTION
* Add extension to character to create ZWSP easily
* Use it for UnicodeString ZWSP string creation
* Replace most isolated usages
* Fix some clippy warnings on `text_node.rs`