### PR TITLE
make find range by work symmetrically

### DIFF
--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -108,8 +108,6 @@ where
                 .cloned()
                 .collect()
         }) {
-            println!("{:?}", intersection);
-
             intersection
         } else if self.state.dom.document().children().is_empty() {
             HashSet::from_iter(toggled_format_actions.into_iter())

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -90,6 +90,8 @@ where
         if let Some(intersection) = range.leaves().next().map(|l| {
             range
                 .leaves()
+                // do not need locations after the cursor for next logic
+                .filter(|loc| loc.position < range.end())
                 .fold(
                     // Init with reversed_actions from the first leave.
                     self.compute_reversed_actions(&l.node_handle),
@@ -106,6 +108,8 @@ where
                 .cloned()
                 .collect()
         }) {
+            println!("{:?}", intersection);
+
             intersection
         } else if self.state.dom.document().children().is_empty() {
             HashSet::from_iter(toggled_format_actions.into_iter())

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -87,7 +87,6 @@ where
                     );
                     return self.create_update_replace_all();
                 } else {
-                    println!("working on {:?}", leaf);
                     let current_cursor_global_location =
                         leaf.position + leaf.start_offset;
                     let handle = &leaf.node_handle;

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -87,6 +87,7 @@ where
                     );
                     return self.create_update_replace_all();
                 } else {
+                    println!("working on {:?}", leaf);
                     let current_cursor_global_location =
                         leaf.position + leaf.start_offset;
                     let handle = &leaf.node_handle;
@@ -121,7 +122,7 @@ where
         &mut self,
         range: Range,
     ) {
-        let leaves: Vec<&DomLocation> = range.leaves().collect();
+        let leaves = range.leaves();
         let empty_text_leaves: Vec<&DomLocation> = leaves
             .into_iter()
             .filter(|l| {

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -63,50 +63,65 @@ where
         &mut self,
         range: Range,
     ) -> ComposerUpdate<S> {
-        let leaves: Vec<&DomLocation> = range.leaves().collect();
-        if leaves.len() == 1 {
-            let location = leaves[0];
-            let current_cursor_global_location =
-                location.position + location.start_offset;
-            let handle = &location.node_handle;
-            let parent_list_item_handle =
-                self.state.dom.find_parent_list_item_or_self(handle);
-            if let Some(parent_list_item_handle) = parent_list_item_handle {
-                let list_item_end_offset = range
-                    .locations
-                    .into_iter()
-                    .filter(|loc| loc.kind == ListItem)
-                    .next()
-                    .unwrap()
-                    .end_offset;
-                self.do_enter_in_list(
-                    &parent_list_item_handle,
-                    current_cursor_global_location,
-                    list_item_end_offset,
-                )
-            } else {
-                self.do_enter_in_text(handle, location.start_offset)
+        let position = range.start();
+        let leaf_at_cursor: Option<&DomLocation> = range.leaves().find(|loc| {
+            loc.position <= position && position <= loc.position + loc.length
+        });
+
+        match leaf_at_cursor {
+            None => {
+                // Selection doesn't contain any text like nodes. We can assume it's an empty Dom.
+                self.state
+                    .dom
+                    .document_mut()
+                    .append_child(DomNode::new_line_break());
+                self.state.start += 1;
+                self.state.end = self.state.start;
+                return self.create_update_replace_all();
             }
-        } else if leaves.is_empty() {
-            // Selection doesn't contain any text node. We can assume it's an empty Dom.
-            self.state
-                .dom
-                .document_mut()
-                .append_child(DomNode::new_line_break());
-            self.state.start += 1;
-            self.state.end = self.state.start;
-            self.create_update_replace_all()
-        } else {
-            // Special case, there might be one or several empty text nodes at the cursor position
-            self.enter_with_zero_length_selection_and_empty_text_nodes(leaves);
-            self.create_update_replace_all()
+            Some(leaf) => {
+                if leaf.length == 0 {
+                    // Special case, there is an empty text node at the cursor position
+                    self.enter_with_zero_length_selection_and_empty_text_nodes(
+                        range,
+                    );
+                    return self.create_update_replace_all();
+                } else {
+                    let current_cursor_global_location =
+                        leaf.position + leaf.start_offset;
+                    let handle = &leaf.node_handle;
+                    let parent_list_item_handle =
+                        self.state.dom.find_parent_list_item_or_self(handle);
+
+                    match parent_list_item_handle {
+                        Some(handle) => {
+                            let list_item_end_offset = range
+                                .locations
+                                .into_iter()
+                                .filter(|loc| loc.kind == ListItem)
+                                .next()
+                                .unwrap()
+                                .end_offset;
+                            self.do_enter_in_list(
+                                &handle,
+                                current_cursor_global_location,
+                                list_item_end_offset,
+                            )
+                        }
+                        None => {
+                            self.do_enter_in_text(handle, leaf.start_offset)
+                        }
+                    }
+                }
+            }
         }
     }
 
     fn enter_with_zero_length_selection_and_empty_text_nodes(
         &mut self,
-        leaves: Vec<&DomLocation>,
+        range: Range,
     ) {
+        let leaves: Vec<&DomLocation> = range.leaves().collect();
         let empty_text_leaves: Vec<&DomLocation> = leaves
             .into_iter()
             .filter(|l| {

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -198,9 +198,9 @@ where
             Vec::new()
         };
 
-        // If our range covered multiple text-like nodes, join together
+        // If our range has length and covered multiple text-like nodes, join together
         // the two sides of the range.
-        if range.leaves().count() > 1 {
+        if range.start() != range.end() && range.leaves().count() > 1 {
             // join_nodes will use the first location of our range, so we must
             // check whether we deleted it!
             if let Some(first_loc) = range.locations.first() {

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -296,7 +296,7 @@ mod test {
     }
 
     #[test]
-    fn finding_a_node_within_flat_text_nodes_is_found() {
+    fn finding_first_node_within_flat_text_nodes_is_found() {
         let d = dom(&[tn("foo"), tn("bar")]);
         assert_eq!(
             find_pos(&d, &d.document_handle(), 0, 0),
@@ -310,26 +310,14 @@ mod test {
             find_pos(&d, &d.document_handle(), 2, 2),
             found_single_node(DomHandle::from_raw(vec![0]), 0, 2, 2, 3)
         );
-        assert_eq!(
-            find_pos(&d, &d.document_handle(), 3, 3),
-            found_single_node(DomHandle::from_raw(vec![0]), 0, 3, 3, 3)
-        );
-        assert_eq!(
-            find_pos(&d, &d.document_handle(), 3, 4),
-            found_single_node(DomHandle::from_raw(vec![1]), 3, 0, 1, 3)
-        );
-        // TODO: break up this test and name parts!
+    }
+
+    #[test]
+    fn finding_second_node_within_flat_text_nodes_is_found() {
+        let d = dom(&[tn("foo"), tn("bar")]);
         assert_eq!(
             find_pos(&d, &d.document_handle(), 4, 4),
             found_single_node(DomHandle::from_raw(vec![1]), 3, 1, 1, 3)
-        );
-        assert_eq!(
-            find_pos(&d, &d.document_handle(), 4, 4),
-            found_single_node(DomHandle::from_raw(vec![1]), 3, 1, 1, 3)
-        );
-        assert_eq!(
-            find_pos(&d, &d.document_handle(), 5, 5),
-            found_single_node(DomHandle::from_raw(vec![1]), 3, 2, 2, 3)
         );
         assert_eq!(
             find_pos(&d, &d.document_handle(), 5, 5),
@@ -344,11 +332,24 @@ mod test {
     // TODO: comprehensive test like above for non-flat nodes
 
     #[test]
+    fn finding_a_boundary_between_flat_text_nodes_finds_both() {
+        let d = dom(&[tn("foo"), tn("bar")]);
+        assert_eq!(
+            find_pos(&d, &d.document_handle(), 3, 3),
+            FindResult::Found(vec![
+                make_single_location(DomHandle::from_raw(vec![0]), 0, 3, 3, 3),
+                make_single_location(DomHandle::from_raw(vec![1]), 3, 0, 0, 3)
+            ])
+        );
+    }
+
+    #[test]
     fn finding_a_range_within_an_empty_dom_returns_no_nodes() {
         let d = dom(&[]);
         let range = d.find_range(0, 0);
         assert_eq!(range, Range::new(Vec::new()));
     }
+    // TODO: comprehensive test like above for non-flat nodes
 
     #[test]
     fn finding_a_range_within_the_single_text_node_works() {

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -206,18 +206,16 @@ fn process_textlike_node(
 
     // Increase offset to keep track of the current position
     *offset += node_len;
-
-    let outside_selection_range = start > node_end || end < node_start;
     let is_cursor = start == end;
 
-    // Intersect selection and node ranges with a couple of exceptions
-    if outside_selection_range
-        // Selection start is at the end of a node, but it's not a cursor
-        || (start == node_end && !is_cursor)
-        // Selection end is at the start of a node, but not on position 0
-        || (node_start == end && end != 0)
-    {
-        // Node discarded, it's not selected
+    let should_discard = match is_cursor {
+        // for a cursor, discard when it is outside the node
+        true => start < node_start || start > node_end,
+        // for a selection, discard when it ends before (inclusive) or starts after (inclusive) the node
+        false => end <= node_start || start >= node_end,
+    };
+
+    if should_discard {
         None
     } else {
         // Diff between selected position and the start position of the node

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -262,6 +262,23 @@ mod test {
         }])
     }
 
+    fn make_single_location(
+        handle: DomHandle,
+        position: usize,
+        start_offset: usize,
+        end_offset: usize,
+        length: usize,
+    ) -> DomLocation {
+        DomLocation {
+            node_handle: handle,
+            position,
+            start_offset,
+            end_offset,
+            length,
+            kind: DomNodeKind::Text,
+        }
+    }
+
     fn ranges_to_html(
         dom: &Dom<Utf16String>,
         range: &Range,

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -500,36 +500,6 @@ mod test {
         let model = cm("<em>remains |<em>all<em>of<em>the<em>rest</em>goes</em>away</em>x</em>y</em>");
         let (s, e) = model.safe_selection();
         let range = model.state.dom.find_range(s, e);
-        assert_eq!(
-            range,
-            Range {
-                locations: vec![
-                    DomLocation {
-                        node_handle: DomHandle::from_raw(vec![0, 0]),
-                        start_offset: 8,
-                        end_offset: 8,
-                        position: 0,
-                        length: 8,
-                        kind: DomNodeKind::Text
-                    },
-                    DomLocation {
-                        node_handle: DomHandle::from_raw(vec![0, 1]),
-                        start_offset: 0,
-                        end_offset: 0,
-                        position: 8,
-                        length: 21,
-                        kind: DomNodeKind::Formatting(Italic)
-                    },
-                    DomLocation {
-                        node_handle: DomHandle::from_raw(vec![0]),
-                        start_offset: 8,
-                        end_offset: 8,
-                        position: 0,
-                        length: 30,
-                        kind: DomNodeKind::Formatting(Italic)
-                    },
-                ]
-            }
-        )
+        assert_eq!(range.locations.len(), 4)
     }
 }


### PR DESCRIPTION
Previously, we would return anything left of the cursor, but only containers to the right if at a boundary. Now we return all things on both sides. See below for an illustration.

* `<br />|<br />`
    * before returns single location
    * now returns both locations
*  `<em>something</em>|<em>else</em>`
    * before returns 3 locations, left container, left text node, right container
    * now returns 4 locations, left container, left text node, right container, right text node