### PR TITLE
Lookup and join ancestor on join nodes

### DIFF
--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -103,7 +103,8 @@ where
         let mut has_found_link = false;
         let (s, e) = self.safe_selection();
         let range = self.state.dom.find_range(s, e);
-        for loc in range.locations {
+        let iter = range.locations.into_iter().rev();
+        for loc in iter {
             if loc.kind == DomNodeKind::Link {
                 if !has_found_link {
                     has_found_link = true;

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -256,7 +256,7 @@ where
         parent_handle_in_list(list, node_handle)
     }
 
-    fn join_nodes_in_parent(&mut self, parent_handle: &DomHandle) {
+    pub(crate) fn join_nodes_in_parent(&mut self, parent_handle: &DomHandle) {
         let child_count = if let DomNode::Container(parent) =
             self.lookup_node(parent_handle)
         {

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -222,7 +222,7 @@ where
         } else if let Some(first_leave) = range.leaves().next() {
             if let Some(ancestor_handle) = self
                 .find_first_non_matching_ancestor_in(
-                    deleted_handles.clone(),
+                    &deleted_handles,
                     &first_leave.node_handle,
                 )
             {
@@ -235,11 +235,11 @@ where
 
     fn find_first_non_matching_ancestor_in(
         &self,
-        list: Vec<DomHandle>,
+        list: &Vec<DomHandle>,
         node_handle: &DomHandle,
     ) -> Option<DomHandle> {
         fn parent_handle_in_list(
-            list: Vec<DomHandle>,
+            list: &Vec<DomHandle>,
             handle: &DomHandle,
         ) -> Option<DomHandle> {
             if handle.has_parent() {

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -15,7 +15,6 @@
 //! Methods on Dom that modify its contents and are guaranteed to conform to
 //! our invariants e.g. no empty text nodes, no adjacent text nodes.
 
-use crate::char::CharExt;
 use crate::{DomHandle, DomNode, UnicodeString};
 
 use super::action_list::{DomAction, DomActionList};
@@ -273,28 +272,12 @@ where
                 let next_node = self.lookup_node(&next_handle);
                 let node = self.lookup_node(&handle);
 
-                if self.can_directly_join_nodes(node, next_node) {
+                if node.can_push(next_node) {
                     let mut next_node = self.remove(&next_handle);
                     let node_mut = self.lookup_node_mut(&handle);
                     node_mut.push(&mut next_node);
                 }
             }
-        }
-    }
-
-    fn can_directly_join_nodes(
-        &self,
-        n1: &DomNode<S>,
-        n2: &DomNode<S>,
-    ) -> bool {
-        match (n1, n2) {
-            (DomNode::Container(c1), DomNode::Container(c2)) => {
-                c1.kind() == c2.kind() && !c1.is_list_item() && !c1.is_list()
-            }
-            (DomNode::Text(_), DomNode::Text(t2)) => {
-                !t2.data().to_string().starts_with(char::zwsp())
-            }
-            _ => false,
         }
     }
 

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -142,7 +142,9 @@ where
         let Some(parent) = node.as_container() else {
             return vec![]
         };
-        self.replace(node_handle, parent.children().clone())
+        let ret = self.replace(node_handle, parent.children().clone());
+        self.join_nodes_in_parent(&node_handle.parent_handle());
+        ret
     }
 
     /// Removes the node at [node_handle] and returns it.

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -36,7 +36,7 @@ where
     handle: DomHandle,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ContainerNodeKind<S>
 where
     S: UnicodeString,
@@ -522,7 +522,7 @@ where
             // trend to avoid unexpected behaviours for our users.
 
             buffer.push("*");
-            fmt_children(this, buffer, &options)?;
+            fmt_children(this, buffer, options)?;
             buffer.push("*");
 
             Ok(())
@@ -548,7 +548,7 @@ where
             // there. Instead, it will produce `*__…__*`.
 
             buffer.push("__");
-            fmt_children(this, buffer, &options)?;
+            fmt_children(this, buffer, options)?;
             buffer.push("__");
 
             Ok(())
@@ -570,7 +570,7 @@ where
             // do not support this format extension.
 
             buffer.push("~~");
-            fmt_children(this, buffer, &options)?;
+            fmt_children(this, buffer, options)?;
             buffer.push("~~");
 
             Ok(())
@@ -589,7 +589,7 @@ where
             // use raw HTML.
 
             buffer.push("<u>");
-            fmt_children(this, buffer, &options)?;
+            fmt_children(this, buffer, options)?;
             buffer.push("</u>");
 
             Ok(())
@@ -619,7 +619,7 @@ where
             buffer.push("`` ");
 
             options.insert(MarkdownOptions::IGNORE_LINE_BREAK);
-            fmt_children(this, buffer, &options)?;
+            fmt_children(this, buffer, options)?;
 
             buffer.push(" ``");
 
@@ -638,7 +638,7 @@ where
         {
             buffer.push('[');
 
-            fmt_children(this, buffer, &options)?;
+            fmt_children(this, buffer, options)?;
 
             // A link destination can be delimited by `<` and
             // `>`.
@@ -751,7 +751,7 @@ where
                 {
                     // Let's create a new buffer for the child formatting.
                     let mut child_buffer = S::default();
-                    child.fmt_markdown(&mut child_buffer, &options)?;
+                    child.fmt_markdown(&mut child_buffer, options)?;
 
                     // Generate the indentation of form `\n` followed by
                     // $x$ spaces where $x$ is `indentation`.
@@ -794,7 +794,7 @@ where
         where
             S: UnicodeString,
         {
-            fmt_children(this, buffer, &options)?;
+            fmt_children(this, buffer, options)?;
 
             Ok(())
         }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -317,18 +317,17 @@ where
         Some(link)
     }
 
+    /// Push content of the given container node into self. Panics
+    /// if given container node is not of the same kind.
     pub(crate) fn push(&mut self, other_node: &mut ContainerNode<S>) {
         if other_node.kind != self.kind {
-            panic!("Trying to push a non-matching node kind");
+            panic!("Trying to push a non-matching container kind");
         }
         let last_child = self.children.last().unwrap();
-        let first_pushed_child = other_node.get_child_mut(0).unwrap();
-        if last_child.kind() == first_pushed_child.kind()
-            && !last_child.is_list_item()
-            && !last_child.is_line_break()
-        {
-            self.last_child_mut().unwrap().push(first_pushed_child);
-            other_node.remove_child(0);
+        let other_node_first_child = other_node.get_child(0).unwrap();
+        if last_child.can_push(other_node_first_child) {
+            let mut next_child = other_node.remove_child(0);
+            self.last_child_mut().unwrap().push(&mut next_child);
         }
         while !other_node.children().is_empty() {
             let child = other_node.remove_child(0);

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -316,6 +316,25 @@ where
         };
         Some(link)
     }
+
+    pub(crate) fn push(&mut self, other_node: &mut ContainerNode<S>) {
+        if other_node.kind != self.kind {
+            panic!("Trying to push a non-matching node kind");
+        }
+        let last_child = self.children.last().unwrap();
+        let first_pushed_child = other_node.get_child_mut(0).unwrap();
+        if last_child.kind() == first_pushed_child.kind()
+            && !last_child.is_list_item()
+            && !last_child.is_line_break()
+        {
+            self.last_child_mut().unwrap().push(first_pushed_child);
+            other_node.remove_child(0);
+        }
+        while !other_node.children().is_empty() {
+            let child = other_node.remove_child(0);
+            self.append_child(child);
+        }
+    }
 }
 
 impl<S> ToHtml<S> for ContainerNode<S>

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -895,6 +895,38 @@ mod test {
         assert_eq!(text_node2.handle().raw(), &[4, 5, 4, 4]);
     }
 
+    #[test]
+    fn pushing_container_of_same_kind() {
+        let mut c1 =
+            format_container_with_handle(InlineFormatType::Bold, &[0, 0]);
+        c1.append_child(text_node("abc"));
+        let mut c2 =
+            format_container_with_handle(InlineFormatType::Bold, &[0, 1]);
+        c2.append_child(text_node("def"));
+        c2.append_child(DomNode::new_line_break());
+        c1.push(&mut c2);
+        assert!(c2.children().is_empty());
+
+        let mut expected =
+            format_container_with_handle(InlineFormatType::Bold, &[0, 0]);
+        expected.append_child(text_node("abcdef"));
+        expected.append_child(DomNode::new_line_break());
+
+        assert_eq!(c1, expected)
+    }
+
+    #[test]
+    #[should_panic]
+    fn pushing_container_of_different_kind_panics() {
+        let mut c1 =
+            format_container_with_handle(InlineFormatType::Bold, &[0, 0]);
+        c1.append_child(text_node("abc"));
+        let mut c2 =
+            format_container_with_handle(InlineFormatType::Italic, &[0, 1]);
+        c2.append_child(text_node("def"));
+        c1.push(&mut c2);
+    }
+
     fn container_with_handle<'a>(
         raw_handle: impl IntoIterator<Item = &'a usize>,
     ) -> ContainerNode<Utf16String> {
@@ -904,6 +936,17 @@ mod test {
             None,
             Vec::new(),
         );
+        let handle =
+            DomHandle::from_raw(raw_handle.into_iter().cloned().collect());
+        node.set_handle(handle);
+        node
+    }
+
+    fn format_container_with_handle<'a>(
+        format: InlineFormatType,
+        raw_handle: impl IntoIterator<Item = &'a usize>,
+    ) -> ContainerNode<Utf16String> {
+        let mut node = ContainerNode::new_formatting(format, vec![]);
         let handle =
             DomHandle::from_raw(raw_handle.into_iter().cloned().collect());
         node.set_handle(handle);

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -173,12 +173,42 @@ where
         }
     }
 
+    pub(crate) fn as_container_mut(&mut self) -> Option<&mut ContainerNode<S>> {
+        if let Self::Container(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     pub fn kind(&self) -> DomNodeKind {
         match self {
             DomNode::Text(_) => DomNodeKind::Text,
             DomNode::LineBreak(_) => DomNodeKind::LineBreak,
             DomNode::Container(n) => DomNodeKind::from_container_kind(n.kind()),
         }
+    }
+
+    pub(crate) fn push(&mut self, other_node: &mut DomNode<S>) {
+        if self.kind() != other_node.kind() {
+            panic!("Trying to push a non-matching node kind")
+        }
+
+        match self {
+            DomNode::Container(c) => {
+                c.push(other_node.as_container_mut().unwrap())
+            }
+            DomNode::Text(t) => t.push(other_node.as_text().unwrap()),
+            DomNode::LineBreak(_) => panic!("Can't merge linebreaks"),
+        }
+    }
+
+    /// Returns `true` if the dom node is [`LineBreak`].
+    ///
+    /// [`LineBreak`]: DomNode::LineBreak
+    #[must_use]
+    pub fn is_line_break(&self) -> bool {
+        matches!(self, Self::LineBreak(..))
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -49,7 +49,7 @@ where
     }
 
     pub fn new_line_break() -> DomNode<S> {
-        DomNode::LineBreak(LineBreakNode::new())
+        DomNode::LineBreak(LineBreakNode::default())
     }
 
     pub fn new_formatting(

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -31,21 +31,26 @@ where
     handle: DomHandle,
 }
 
-impl<S> LineBreakNode<S>
+impl<S> Default for LineBreakNode<S>
 where
     S: UnicodeString,
 {
-    /// Create a new LineBreakNode
+    /// Create a new default LineBreakNode
     ///
     /// NOTE: Its handle() will be unset until you call set_handle() or
     /// append() it to another node.
-    pub fn new() -> Self {
+    fn default() -> Self {
         Self {
             _phantom_data: PhantomData {},
             handle: DomHandle::new_unset(),
         }
     }
+}
 
+impl<S> LineBreakNode<S>
+where
+    S: UnicodeString,
+{
     pub fn name(&self) -> S {
         "br".into()
     }

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -147,6 +147,15 @@ where
     pub fn is_empty(&self) -> bool {
         self.data().len() != 0
     }
+
+    pub(crate) fn push(&mut self, other_node: &TextNode<S>) {
+        let mut text_data = self.data().to_owned();
+        let other_text_data = other_node.data();
+        if !other_text_data.is_empty() && other_text_data != "\u{200B}" {
+            text_data.push(other_text_data.to_owned());
+        }
+        self.set_data(text_data);
+    }
 }
 
 /// Given a character, determine its type

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -250,10 +250,13 @@ where
 }
 #[cfg(test)]
 mod test {
+    use widestring::Utf16String;
+
     use crate::char::CharExt;
     use crate::composer_model::delete_text::Direction;
     use crate::dom::nodes::text_node::CharType;
     use crate::tests::testutils_conversion::utf16;
+    use crate::UnicodeString;
 
     use super::{get_char_type, TextNode};
 
@@ -305,5 +308,29 @@ mod test {
         let test_node = TextNode::from(utf16("test"));
         assert!(test_node.offset_is_inside_node(2, &Direction::Forwards));
         assert!(test_node.offset_is_inside_node(2, &Direction::Backwards));
+    }
+
+    #[test]
+    fn pushing_text_node() {
+        let mut t1 = TextNode::from(utf16("abc"));
+        let t2 = TextNode::from(utf16("def"));
+        t1.push(&t2);
+        assert_eq!(t1, TextNode::from(utf16("abcdef")));
+    }
+
+    #[test]
+    fn pushing_empty_text_node_does_nothing() {
+        let mut t1 = TextNode::from(utf16("abc"));
+        let t2 = TextNode::from(utf16(""));
+        t1.push(&t2);
+        assert_eq!(t1, TextNode::from(utf16("abc")));
+    }
+
+    #[test]
+    fn pushing_zwsp_text_node_does_nothing() {
+        let mut t1 = TextNode::from(utf16("abc"));
+        let t2 = TextNode::from(Utf16String::zwsp());
+        t1.push(&t2);
+        assert_eq!(t1, TextNode::from(utf16("abc")));
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -148,6 +148,8 @@ where
         self.data().len() != 0
     }
 
+    /// Push content of the given text node into self. If given
+    /// node is empty or a single ZWSP, nothing is pushed.
     pub(crate) fn push(&mut self, other_node: &TextNode<S>) {
         let mut text_data = self.data().to_owned();
         let other_text_data = other_node.data();

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -361,3 +361,22 @@ fn deleting_selection_of_a_container_in_multiple_containers() {
     model.backspace();
     assert_eq!(tx(&model), "<i>| test</i>");
 }
+
+#[test]
+fn deleting_selection_of_a_container_with_text_node_neighbors() {
+    let mut model = cm(
+        "<em>abc<del>{def}|</del>ghi</em>",
+    );
+    model.backspace();
+    assert_eq!(tx(&model), "<em>abc|ghi</em>");
+}
+
+
+#[test]
+fn deleting_selection_of_a_container_with_matching_neighbors() {
+    let mut model = cm(
+        "<em><strong>abc</strong><del>{def}|</del><strong>ghi</strong></em>",
+    );
+    model.backspace();
+    assert_eq!(tx(&model), "<em><strong>abc|ghi</strong></em>");
+}

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -304,6 +304,7 @@ fn deleting_initial_text_node_removes_it_completely_without_crashing() {
     let mut model = cm("abc<br />def<br />gh|");
     model.delete_in(4, 10);
     assert_eq!(tx(&model), "abc<br />|",);
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -311,6 +312,7 @@ fn deleting_initial_text_node_via_selection_removes_it_completely() {
     let mut model = cm("abc<br />{def<br />gh}|");
     model.delete();
     assert_eq!(tx(&model), "abc<br />|",);
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -318,6 +320,7 @@ fn deleting_all_initial_text_and_merging_later_text_produces_one_text_node() {
     let mut model = cm("abc<br />{def<br />gh}|ijk");
     model.delete();
     assert_eq!(tx(&model), "abc<br />|ijk",);
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -325,6 +328,7 @@ fn deleting_all_initial_text_within_a_tag_preserves_the_tag() {
     let mut model = cm("abc<br /><strong>{def<br />gh}|ijk</strong>");
     model.delete();
     assert_eq!(tx(&model), "abc<br />|<strong>ijk</strong>",);
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -332,6 +336,7 @@ fn deleting_all_text_within_a_tag_deletes_the_tag() {
     let mut model = cm("abc<br /><strong>{def<br />gh}|</strong>ijk");
     model.delete();
     assert_eq!(tx(&model), "abc<br />|ijk",);
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -339,6 +344,7 @@ fn deleting_last_character_in_a_container() {
     let mut model = cm("<b>t|</b>");
     model.backspace();
     assert_eq!(tx(&model), "|");
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -346,6 +352,7 @@ fn deleting_selection_in_a_container() {
     let mut model = cm("<b>{test}|</b>");
     model.backspace();
     assert_eq!(tx(&model), "|");
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -353,6 +360,7 @@ fn deleting_selection_in_multiple_containers() {
     let mut model = cm("<i><b>{test}|</b></i>");
     model.backspace();
     assert_eq!(tx(&model), "|");
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -360,6 +368,7 @@ fn deleting_selection_of_a_container_in_multiple_containers() {
     let mut model = cm("<i><b>{test}|</b> test</i>");
     model.backspace();
     assert_eq!(tx(&model), "<i>| test</i>");
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -367,6 +376,7 @@ fn deleting_selection_of_a_container_with_text_node_neighbors() {
     let mut model = cm("<em>abc<del>{def}|</del>ghi</em>");
     model.backspace();
     assert_eq!(tx(&model), "<em>abc|ghi</em>");
+    model.state.dom.explicitly_assert_invariants();
 }
 
 #[test]
@@ -376,4 +386,5 @@ fn deleting_selection_of_a_container_with_matching_neighbors() {
     );
     model.backspace();
     assert_eq!(tx(&model), "<em><strong>abc|ghi</strong></em>");
+    model.state.dom.explicitly_assert_invariants();
 }

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -364,13 +364,10 @@ fn deleting_selection_of_a_container_in_multiple_containers() {
 
 #[test]
 fn deleting_selection_of_a_container_with_text_node_neighbors() {
-    let mut model = cm(
-        "<em>abc<del>{def}|</del>ghi</em>",
-    );
+    let mut model = cm("<em>abc<del>{def}|</del>ghi</em>");
     model.backspace();
     assert_eq!(tx(&model), "<em>abc|ghi</em>");
 }
-
 
 #[test]
 fn deleting_selection_of_a_container_with_matching_neighbors() {

--- a/crates/wysiwyg/src/tests/test_remove_links.rs
+++ b/crates/wysiwyg/src/tests/test_remove_links.rs
@@ -108,3 +108,11 @@ fn remove_multiple_partially_selected_links_in_different_containers() {
         "<b>test_{link_bold</b> <i>test}|_link_italic</i>"
     );
 }
+
+#[test]
+fn remove_link_between_text_nodes_joins() {
+    let mut model = cm("abc{<a href=\"https://matrix.org\">def</a>}|ghi");
+    model.remove_links();
+    assert_eq!(tx(&model), "abc{def}|ghi");
+    model.state.dom.explicitly_assert_invariants();
+}


### PR DESCRIPTION
* Fixes some delete text cases by looking up ancestors from an entirely removed text node until finding a non-removed ancestor.
* Now joins all compatible nodes in the ancestor and not only text nodes
* Add some `push` functions to append the content of another mutable node into a dom node and ease up joining nodes. (since we can't borrow multiple mutable nodes of the tree by design, it should be rather safe to use because the node to join should removed from the tree first, and will be inserted without any duplication - unless explicitly cloning).
* Add a `can_push` helper to check if a node can safely be removed from the tree in order to be pushed into its (usually) previous neighbour.
* Also, fixes some clippy issues in updated files.