### PR TITLE
Change link interface to use string

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
@@ -3,7 +3,7 @@ use widestring::Utf16String;
 pub enum LinkAction {
     CreateWithText,
     Create,
-    Edit { link: Vec<u16> },
+    Edit { link: String },
 }
 
 impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
@@ -12,7 +12,7 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
             wysiwyg::LinkAction::CreateWithText => Self::CreateWithText,
             wysiwyg::LinkAction::Create => Self::Create,
             wysiwyg::LinkAction::Edit(link) => Self::Edit {
-                link: link.into_vec(),
+                link: link.to_string(),
             },
         }
     }

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -108,6 +108,6 @@ interface LinkAction {
     CreateWithText();
     Create();
     Edit(
-        sequence<u16> link
+        string link
     );
 };


### PR DESCRIPTION
## What?

Update the interface for link actions to use `String` instead of `Vec<u16>`.

## Why?

So that the Kotlin/Swift bindings generated for this class use the native string types and do not need conversion.

After this change, the Kotlin binding looks like this:

```
sealed class LinkAction {
...
    
    data class Edit(
        val `link`: String
    ) : LinkAction()
}