### PR TITLE
Add list_type to `ContainerNodeKind::List`

### DIFF
--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -190,7 +190,7 @@ where
                 self.state.dom.find_parent_list_item_or_self(handle);
             if let Some(list_item_handle) = parent_list_item_handle {
                 let list = self.state.dom.parent(&list_item_handle);
-                if list.is_list_of_type(list_type.clone()) {
+                if list.is_list_of_type(&list_type) {
                     self.move_list_item_content_to_list_parent(
                         &list_item_handle,
                     )
@@ -302,7 +302,7 @@ where
                     let previous_node =
                         self.state.dom.lookup_node_mut(&previous_handle);
                     if let DomNode::Container(previous) = previous_node {
-                        if previous.is_list_of_type(list_type.clone()) {
+                        if previous.is_list_of_type(&list_type) {
                             previous.append_child(list_item);
                             let parent = self.state.dom.parent_mut(handle);
                             parent.remove_child(index_in_parent);
@@ -442,7 +442,7 @@ where
             let parent_list_type = if let DomNode::Container(list) =
                 self.state.dom.lookup_node(parent_handle)
             {
-                if list.is_list_of_type(ListType::Ordered) {
+                if list.is_list_of_type(&ListType::Ordered) {
                     ListType::Ordered
                 } else {
                     ListType::Unordered
@@ -510,7 +510,7 @@ where
                 {
                     sub_node.insert_child(0, removed_list_item);
                 }
-            } else if into_node.is_list_of_type(parent_list_type.clone()) {
+            } else if into_node.is_list_of_type(parent_list_type) {
                 into_node.insert_child(at_index, removed_list_item);
             } else {
                 let new_list = DomNode::new_list(
@@ -535,8 +535,7 @@ where
                     .get_child_mut(prev_sibling.children().len() - 1)
                     .unwrap()
                 {
-                    if prev_sibling_last_item.is_list_of_type(list_type.clone())
-                    {
+                    if prev_sibling_last_item.is_list_of_type(list_type) {
                         return Some(prev_sibling_last_item);
                     }
                 }

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -157,14 +157,10 @@ where
                 }
             },
             ContainerNodeKind::Link(_) => Some(ComposerAction::Link),
-            ContainerNodeKind::List => {
-                let list_type =
-                    ListType::try_from(container.name().to_owned()).unwrap();
-                match list_type {
-                    ListType::Ordered => Some(ComposerAction::OrderedList),
-                    ListType::Unordered => Some(ComposerAction::UnorderedList),
-                }
-            }
+            ContainerNodeKind::List(list_type) => match list_type {
+                ListType::Ordered => Some(ComposerAction::OrderedList),
+                ListType::Unordered => Some(ComposerAction::UnorderedList),
+            },
             ContainerNodeKind::CodeBlock => Some(ComposerAction::CodeBlock),
             _ => None,
         }
@@ -214,7 +210,7 @@ where
     }
 }
 
-fn contains_inline_code(locations: &Vec<DomLocation>) -> bool {
+fn contains_inline_code(locations: &[DomLocation]) -> bool {
     locations.iter().any(|l| {
         matches!(
             l.kind,
@@ -223,6 +219,6 @@ fn contains_inline_code(locations: &Vec<DomLocation>) -> bool {
     })
 }
 
-fn contains_code_block(locations: &Vec<DomLocation>) -> bool {
+fn contains_code_block(locations: &[DomLocation]) -> bool {
     locations.iter().any(|l| l.kind == DomNodeKind::CodeBlock)
 }

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -539,7 +539,7 @@ where
                 index_at_level,
                 min_depth,
                 offset,
-                &handle,
+                handle,
                 new_subtree_at_prev_level,
             );
         }

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -192,7 +192,7 @@ where
         if handle.has_parent() {
             let parent = self.parent(handle);
             let parent_handle = parent.handle();
-            if *parent.kind() == ContainerNodeKind::List {
+            if parent.is_list() {
                 return Some(parent_handle);
             } else if parent_handle.has_parent() {
                 return self.find_closest_list_ancestor(&parent_handle);

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -224,7 +224,7 @@ where
     pub(crate) fn can_push(&self, other_node: &DomNode<S>) -> bool {
         match (self, other_node) {
             (DomNode::Container(c1), DomNode::Container(c2)) => {
-                c1.kind() == c2.kind() && !c1.is_list_item() && !c1.is_list()
+                c1.kind() == c2.kind() && !c1.is_list_item()
             }
             (DomNode::Text(_), DomNode::Text(t2)) => {
                 !t2.data().to_string().starts_with(char::zwsp())
@@ -367,7 +367,7 @@ impl DomNodeKind {
                 DomNodeKind::Formatting(f.clone())
             }
             ContainerNodeKind::Link(_) => DomNodeKind::Link,
-            ContainerNodeKind::List => DomNodeKind::List,
+            ContainerNodeKind::List(_) => DomNodeKind::List,
             ContainerNodeKind::ListItem => DomNodeKind::ListItem,
             ContainerNodeKind::Generic => DomNodeKind::Generic,
             ContainerNodeKind::CodeBlock => DomNodeKind::CodeBlock,

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -357,7 +357,7 @@ mod test {
         let r = range_of(
             "\
             <ul><li>{a</li><li>b</li></ul>\
-            <ul><li>c</li><li>d</li><li>e</li></ul>fgh}|",
+            <ol><li>c</li><li>d</li><li>e</li></ol>fgh}|",
         );
 
         assert_eq!(


### PR DESCRIPTION
* Ease up comparing ContainerNodeKind for lists
* Removed some unnecessary cloning
* Removed a few clippy issues
* Joining subsequent lists of same kind is allowed
* Effectively testing joining lists will be added by upcoming PRs