### PR TITLE
Add `DomLocationPosition` helper

### DIFF
--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -17,6 +17,7 @@ use strum::IntoEnumIterator;
 use crate::action_state::ActionState;
 use crate::dom::nodes::dom_node::DomNodeKind;
 use crate::dom::nodes::{ContainerNode, ContainerNodeKind};
+use crate::dom::range::DomLocationPosition;
 use crate::dom::{DomLocation, Range};
 use crate::menu_state::MenuStateUpdate;
 use crate::ComposerAction::{Indent, UnIndent};
@@ -92,7 +93,9 @@ where
             range
                 .leaves()
                 // do not need locations after the cursor for next logic
-                .filter(|loc| loc.position < range.end())
+                .filter(|loc| {
+                    !(loc.relative_position() == DomLocationPosition::After)
+                })
                 .fold(
                     // Init with reversed_actions from the first leave.
                     self.compute_reversed_actions(&l.node_handle),

--- a/crates/wysiwyg/src/dom/find_extended_range.rs
+++ b/crates/wysiwyg/src/dom/find_extended_range.rs
@@ -15,6 +15,7 @@
 use crate::{DomHandle, UnicodeString};
 
 use super::nodes::dom_node::DomNodeKind;
+use super::range::DomLocationPosition;
 use super::{find_range, Dom, DomLocation, Range};
 
 impl<S> Dom<S>
@@ -38,7 +39,9 @@ where
         let range = find_range::find_range(self, start, end);
         let leaves: Vec<&DomLocation> = range
             .leaves()
-            .filter(|loc| loc.position < range.end())
+            .filter(|loc| {
+                !(loc.relative_position() == DomLocationPosition::After)
+            })
             .collect();
         if leaves.is_empty() {
             return (start, end);

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -16,6 +16,19 @@ use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::dom_node::DomNodeKind;
 use std::cmp::Ordering;
 
+/// Represents the relative position of a DomLocation towards
+/// the range start and end.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DomLocationPosition {
+    /// Targeted node is before the start of the range (and at the border).
+    Before,
+    /// Targeted node is after the end of the range (and at the border).
+    After,
+    /// Targeted node is at least partially within the
+    /// range, or cursor is strictly inside the node.
+    Inside,
+}
+
 /// Represents a part of a Range.
 /// This is made up of a node (we hold a handle to it), and which part of
 /// that node is within the range.
@@ -86,9 +99,17 @@ impl DomLocation {
     /// True if this is a node which is not a container i.e. a text node or
     /// a text-like node like a line break.
     pub fn is_leaf(&self) -> bool {
-        match self.kind {
-            DomNodeKind::Text | DomNodeKind::LineBreak => true,
-            _ => false,
+        matches!(self.kind, DomNodeKind::Text | DomNodeKind::LineBreak)
+    }
+
+    /// Returns the relative position of this DomLocation towards the range.
+    pub fn relative_position(&self) -> DomLocationPosition {
+        if self.start_offset == self.length {
+            DomLocationPosition::Before
+        } else if self.end_offset == 0 {
+            DomLocationPosition::After
+        } else {
+            DomLocationPosition::Inside
         }
     }
 
@@ -163,7 +184,7 @@ impl Ord for DomLocation {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Range {
     pub locations: Vec<DomLocation>,
 }
@@ -230,10 +251,7 @@ impl Range {
     }
 
     pub fn contains(&self, handle: &DomHandle) -> bool {
-        self.locations
-            .iter()
-            .find(|l| l.node_handle == *handle)
-            .is_some()
+        self.locations.iter().any(|l| l.node_handle == *handle)
     }
 }
 
@@ -252,7 +270,7 @@ mod test {
         dom::DomLocation, tests::testutils_composer_model::cm, DomHandle,
     };
 
-    use super::Range;
+    use super::{DomLocationPosition, Range};
 
     #[test]
     fn range_start_and_end_for_cursor_at_beginning() {
@@ -382,7 +400,7 @@ mod test {
         let model = cm("<em>abcd|</em>");
         let (s, e) = model.safe_selection();
         let range = model.state.dom.find_range(s, e);
-        assert_eq!(range.locations[1].position_is_end_of_list_item(4), false);
+        assert!(!range.locations[1].position_is_end_of_list_item(4));
     }
 
     #[test]
@@ -390,7 +408,7 @@ mod test {
         let model = cm("<ol><li>abcd|</li></ol>");
         let (s, e) = model.safe_selection();
         let range = model.state.dom.find_range(s, e);
-        assert_eq!(range.locations[1].position_is_end_of_list_item(2), false);
+        assert!(!range.locations[1].position_is_end_of_list_item(2));
     }
 
     #[test]
@@ -398,7 +416,39 @@ mod test {
         let model = cm("<ol><li>abcd|</li></ol>");
         let (s, e) = model.safe_selection();
         let range = model.state.dom.find_range(s, e);
-        assert_eq!(range.locations[1].position_is_end_of_list_item(4), true);
+        assert!(range.locations[1].position_is_end_of_list_item(4));
+    }
+
+    #[test]
+    fn node_on_border_is_before_or_after_cursor() {
+        let range = range_of("<strong>abc</strong>|def");
+        let strong_loc = range.locations.first().unwrap();
+        assert!(strong_loc.relative_position() == DomLocationPosition::Before);
+        let def_loc = range.locations.last().unwrap();
+        assert!(def_loc.relative_position() == DomLocationPosition::After);
+    }
+
+    #[test]
+    fn partially_contained_node_is_inside_of_range() {
+        let range = range_of("<strong>abc</strong>{de}|f");
+        let def_loc = range.locations.last().unwrap();
+        assert!(def_loc.relative_position() == DomLocationPosition::Inside);
+    }
+
+    #[test]
+    fn cursor_is_inside_all_nodes() {
+        let range = range_of("<em><strong>ab|cd</strong></em>");
+        range.locations.iter().for_each(|l| {
+            assert!(l.relative_position() == DomLocationPosition::Inside)
+        })
+    }
+
+    #[test]
+    fn selection_is_inside_all_nodes() {
+        let range = range_of("<em><strong>{ab}|cd</strong></em>");
+        range.locations.iter().for_each(|l| {
+            assert!(l.relative_position() == DomLocationPosition::Inside)
+        })
     }
 
     fn range_of(model: &str) -> Range {


### PR DESCRIPTION
* Add a helper that computes a DomLocation relative position towards its Range
* Also replaced two filters with it that now don't need to compute the `range.end()` with an iterator anymore.
* Fixed some clippy issues within `range.rs`