### PR TITLE
Fix issues with line breaks at the start and end of code blocks

### DIFF
--- a/crates/wysiwyg/src/composer_model/format_inline_code.rs
+++ b/crates/wysiwyg/src/composer_model/format_inline_code.rs
@@ -122,7 +122,7 @@ where
         location: &DomLocation,
         ancestor_child_handle: &DomHandle,
     ) -> (S, Option<DomHandle>) {
-        let mut insert_text_at = None;
+        let insert_text_at;
         // Get the selected text from the TextNode
         let text = text_node.data()[location.start_offset..location.end_offset]
             .to_owned();

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -179,6 +179,7 @@ where
                 }
             }
         }
+
         if has_previous_line_break {
             let DomNode::Container(sub_tree) = self.state.dom.split_sub_tree(&leaf.node_handle, leaf.start_offset - selection_offset, block_location.node_handle.depth()) else {
                 panic!("Sub tree must start from a container node");
@@ -210,7 +211,18 @@ where
             self.state.end = self.state.start;
             self.create_update_replace_all()
         } else {
-            if let DomNode::Text(text_node) =
+            let DomNode::Container(block) = self.state.dom.lookup_node(&block_location.node_handle) else {
+                panic!("Parent must be a block node");
+            };
+            if block.children().is_empty() {
+                self.state.dom.insert_at(
+                    &leaf.node_handle,
+                    DomNode::new_text("\n\n".into()),
+                );
+                self.state.start += 2;
+                self.state.end = self.state.start;
+                self.create_update_replace_all()
+            } else if let DomNode::Text(text_node) =
                 self.state.dom.lookup_node_mut(&leaf.node_handle)
             {
                 let mut new_data = text_node.data().to_owned();

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -491,7 +491,8 @@ where
                         }
                         DomNode::Text(text_node) => {
                             if offset == 0 {
-                                removed_nodes.insert(0, child.clone());
+                                removed_nodes
+                                    .insert(0, container.remove_child(idx));
                             } else if offset >= text_node.data().chars().count()
                             {
                                 // Do nothing

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -23,6 +23,7 @@ use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::{UnicodeStr, UnicodeStrExt, UnicodeStringExt};
 use crate::dom::UnicodeString;
 use html_escape;
+use std::ops::Range;
 
 // categories of character for backspace/delete word
 #[derive(PartialEq, Eq, Debug)]
@@ -104,6 +105,19 @@ where
         } else {
             false
         }
+    }
+
+    pub fn remove_trailing_line_break(&mut self) -> bool {
+        if self.data.chars().last() == Some('\n') {
+            self.data.pop_last();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn clone_with_range(&self, range: Range<usize>) -> TextNode<S> {
+        TextNode::from(self.data[range].to_owned())
     }
 
     /// This gets the character at the cursor offset, considering the

--- a/crates/wysiwyg/src/dom/unicode_string.rs
+++ b/crates/wysiwyg/src/dom/unicode_string.rs
@@ -48,6 +48,7 @@ pub trait UnicodeString:
 
     fn insert(&mut self, idx: usize, s: &Self::Str);
     fn remove_at(&mut self, idx: usize);
+    fn pop_last(&mut self) -> Option<char>;
 
     /// Creates a new unicode string consisting of a single ZWSP.
     fn zwsp() -> Self {
@@ -86,6 +87,9 @@ impl UnicodeString for String {
     fn remove_at(&mut self, idx: usize) {
         self.remove(idx);
     }
+    fn pop_last(&mut self) -> Option<char> {
+        self.pop()
+    }
 }
 
 impl UnicodeStr for str {
@@ -111,6 +115,9 @@ impl UnicodeString for Utf16String {
     fn remove_at(&mut self, idx: usize) {
         self.remove(idx);
     }
+    fn pop_last(&mut self) -> Option<char> {
+        self.pop()
+    }
 }
 
 impl UnicodeStr for Utf16Str {
@@ -135,6 +142,9 @@ impl UnicodeString for Utf32String {
     }
     fn remove_at(&mut self, idx: usize) {
         self.remove(idx);
+    }
+    fn pop_last(&mut self) -> Option<char> {
+        self.pop()
     }
 }
 

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -196,7 +196,7 @@ fn enter_in_code_block_at_start_adds_the_line_break() {
 #[test]
 fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_code_block(
 ) {
-    // The initial line break will be removed, so it's the as having a single line break at the start
+    // The initial line break will be removed, so it's the same as having a single line break at the start
     let mut model = cm("<pre>\n\n|Test</pre>");
     model.enter();
     assert_eq!(tx(&model), "<br />|<pre>Test</pre>")
@@ -204,7 +204,7 @@ fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_co
 
 #[test]
 fn enter_in_code_block_at_start_with_a_line_break_after_it_adds_another_one() {
-    // The initial line break will be removed, so it's the as having a single line break at the start
+    // The initial line break will be removed, so it's the same as having a single line break at the start
     let mut model = cm("<pre>\n|\nTest</pre>");
     model.enter();
     assert_eq!(tx(&model), "<pre>\n|\nTest</pre>")

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -187,11 +187,27 @@ fn enter_in_code_block_in_text_node_adds_line_break_as_text() {
 }
 
 #[test]
-#[ignore = "For some reason, the HTML parser returns '<pre>|Test</pre>', removing the leading line break. Might be a bug?"]
-fn enter_in_code_block_after_line_break_at_start_splits_code_block() {
-    let mut model = cm("<pre>\n|Test</pre>");
+fn enter_in_code_block_at_start_adds_the_line_break() {
+    let mut model = cm("<pre>|Test</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre>\n|Test</pre>")
+}
+
+#[test]
+fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_code_block(
+) {
+    // The initial line break will be removed, so it's the as having a single line break at the start
+    let mut model = cm("<pre>\n\n|Test</pre>");
     model.enter();
     assert_eq!(tx(&model), "<br />|<pre>Test</pre>")
+}
+
+#[test]
+fn enter_in_code_block_at_start_with_a_line_break_after_it_adds_another_one() {
+    // The initial line break will be removed, so it's the as having a single line break at the start
+    let mut model = cm("<pre>\n|\nTest</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre>\n|\nTest</pre>")
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_set_content.rs
+++ b/crates/wysiwyg/src/tests/test_set_content.rs
@@ -46,3 +46,11 @@ fn clear() {
     model.clear();
     assert_eq!(tx(&model), "|");
 }
+
+#[test]
+fn set_contents_with_line_break_in_code_block() {
+    // The first line break inside a block node will be removed as it can be used to just give
+    // structure to the node
+    let model = cm("<pre>\n|Test</pre>");
+    assert_eq!(tx(&model), "<pre>|Test</pre>");
+}


### PR DESCRIPTION
* Removes the last line break in a `<pre>` tag if not needed.
* Allows `ComposerModel` to properly set a selection in code blocks starting with a line break.