### PR TITLE
Create lists from multiline selection

### DIFF
--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -217,6 +217,7 @@ where
         let end_correction;
         let handles: Vec<&DomHandle> = range
             .top_level_locations()
+            // FIXME: filtering positions that are before start, these shouldn't be returned from a > 0 range
             .filter(|l| !(l.relative_position() == DomLocationPosition::Before))
             .map(|l| &l.node_handle)
             .collect();

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::ops::AddAssign;
 
+use crate::dom::nodes::dom_node::DomNodeKind;
 use crate::dom::nodes::{ContainerNode, DomNode};
 use crate::dom::range::DomLocationPosition;
 use crate::dom::to_raw_text::ToRawText;
@@ -201,8 +202,10 @@ where
             } else {
                 self.create_list(list_type, range)
             }
+        } else if range.locations.iter().any(|l| l.kind == DomNodeKind::List) {
+            // TODO: handle cases where a list is already present in the extended selection.
+            panic!("Partially creating/removing list is not handled yet")
         } else {
-            // TODO: handle other cases
             self.create_list_from_range(list_type, range)
         }
     }

--- a/crates/wysiwyg/src/dom.rs
+++ b/crates/wysiwyg/src/dom.rs
@@ -16,6 +16,7 @@ pub mod action_list;
 pub mod dom_creation_error;
 pub mod dom_handle;
 pub mod dom_invariants;
+pub mod dom_list_methods;
 pub mod dom_methods;
 pub mod dom_struct;
 pub mod find_extended_range;

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -44,6 +44,8 @@ where
         let mut list_items = Vec::new();
         let mut line_break_positions = list_item.line_break_positions();
 
+        // Slice the list item on each line break position from last to
+        // first position and create a new list item for each slice.
         while let Some(position) = line_break_positions.pop() {
             let mut sliced = list_item.slice_after(position);
             sliced.slice_before(1);

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -1,0 +1,99 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Methods on Dom that modify its contents and are guaranteed to conform to
+//! our invariants e.g. no empty text nodes, no adjacent text nodes.
+
+use crate::{DomHandle, DomNode, ListType, ToHtml, UnicodeString};
+
+use super::nodes::ContainerNode;
+use super::Dom;
+
+impl<S> Dom<S>
+where
+    S: UnicodeString,
+{
+    pub fn wrap_nodes_in_list(
+        &mut self,
+        list_type: ListType,
+        handles: Vec<&DomHandle>,
+        offset_before: usize,
+        _offset_after: usize,
+    ) -> (usize, usize) {
+        let offset_before_correction = if offset_before == 0 { 0 } else { 1 };
+        // Always equal to 1 ?
+        let offset_after_correction = 1;
+        let first_handle = handles[0];
+        let mut removed_nodes = Vec::new();
+        for handle in handles.iter().rev() {
+            removed_nodes.push(self.remove(handle));
+        }
+        removed_nodes.reverse();
+
+        let mut list_item = ContainerNode::new_list_item(removed_nodes);
+        // Set an arbitrary handle allows us to transform this while detached from DOM.
+        list_item.set_handle(DomHandle::root());
+        let mut list_items = Vec::new();
+        let mut line_break_positions = list_item.line_break_positions();
+
+        while let Some(position) = line_break_positions.pop() {
+            println!("{}", list_item.to_html());
+            let prev_length = list_item.text_len();
+            let mut sliced = list_item.slice_after(position);
+            assert!(list_item.text_len() == position);
+            println!("{}", list_item.to_html());
+            assert!(sliced.text_len() == prev_length - position);
+            sliced.slice_before(1);
+            sliced.add_leading_zwsp();
+            assert!(sliced.text_len() == prev_length - position);
+            list_items.insert(0, DomNode::Container(sliced));
+        }
+
+        if list_item.text_len() > 0 {
+            list_item.add_leading_zwsp();
+            list_items.insert(0, DomNode::Container(list_item));
+        }
+
+        let list = ContainerNode::new_list(list_type, list_items);
+        self.insert_at(first_handle, DomNode::Container(list));
+
+        (offset_before_correction, offset_after_correction)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::tests::testutils_composer_model::{cm, tx};
+
+    use crate::{DomHandle, ListType};
+
+    #[test]
+    fn wrap_consecutive_nodes_in_list() {
+        let mut model = cm("abc<strong>de<em>f<br />gh</em>i</strong>jkl|");
+        model.state.dom.wrap_nodes_in_list(
+            ListType::Ordered,
+            vec![
+                &DomHandle::from_raw(vec![0]),
+                &DomHandle::from_raw(vec![1]),
+                &DomHandle::from_raw(vec![2]),
+            ],
+            0,
+            0,
+        );
+        assert_eq!(
+             tx(&model),
+             "<ol><li>~abc<strong>de<em>f</em></strong></li><li><strong><em>~gh</em>i</strong>jk|l</li></ol>",
+        )
+    }
+}

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -58,6 +58,10 @@ where
 
         let list = ContainerNode::new_list(list_type, list_items);
         self.insert_at(first_handle, DomNode::Container(list));
+
+        if first_handle.has_parent() {
+            self.join_nodes_in_container(&first_handle.parent_handle());
+        }
     }
 
     pub fn remove_list(&mut self, handle: &DomHandle) {

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -68,7 +68,7 @@ where
         let list = self.remove(handle);
         let mut nodes_to_insert = Vec::new();
         let DomNode::Container(mut list) = list else {
-            panic!("List ndoe is not a container")
+            panic!("List node is not a container")
         };
         while !list.children().is_empty() {
             let list_item = list.remove_child(0);

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -86,12 +86,7 @@ where
             }
         }
 
-        nodes_to_insert.reverse();
-
-        for node in nodes_to_insert {
-            self.insert_at(handle, node);
-        }
-
+        self.insert(handle, nodes_to_insert);
         self.join_nodes_in_container(&handle.parent_handle());
     }
 }

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -123,8 +123,20 @@ where
         parent.insert_child(index, node)
     }
 
+    /// Insert given [nodes] in order at the [node_handle] position,
+    /// moving the node at that position forward, if any.
+    pub fn insert(
+        &mut self,
+        node_handle: &DomHandle,
+        nodes: Vec<DomNode<S>>,
+    ) -> Vec<DomHandle> {
+        let parent = self.parent_mut(node_handle);
+        let index = node_handle.index_in_parent();
+        parent.insert_children(index, nodes)
+    }
+
     /// Replaces the node at [node_handle] with the list of [nodes]. Returns the list of new handles
-    /// added to the Dom for these nodes.
+    /// added to the Dom for moved nodes.
     pub fn replace(
         &mut self,
         node_handle: &DomHandle,

--- a/crates/wysiwyg/src/dom/iter.rs
+++ b/crates/wysiwyg/src/dom/iter.rs
@@ -93,7 +93,20 @@ where
         iter.next()
     }
 
-    /// Return the handle of the previous node in the DOM, if exists, in depth-first order.
+    /// Return the next text node in the DOM, if exists, in depth-first order.
+    pub fn next_text_node(
+        &mut self,
+        handle: &DomHandle,
+    ) -> Option<&TextNode<S>> {
+        let mut iter = self.iter_from_handle(handle);
+        iter.next(); // Current node
+        let Some(node) = iter.find(|n| n.is_text_node()) else {
+            return None;
+        };
+        node.as_text()
+    }
+
+    /// Return the handle of the next node in the DOM, if exists, in depth-first order.
     pub fn next_handle(&mut self, handle: &DomHandle) -> Option<DomHandle> {
         let mut iter = self.iter_from_handle(handle);
         iter.next(); // Current node
@@ -101,6 +114,19 @@ where
             return None;
         };
         Some(next.handle())
+    }
+
+    /// Return the handle of the next text node in the DOM, if exists, in depth-first order.
+    pub fn next_text_node_handle(
+        &mut self,
+        handle: &DomHandle,
+    ) -> Option<DomHandle> {
+        let mut iter = self.iter_from_handle(handle);
+        iter.next(); // Current node
+        let Some(node) = iter.find(|n| n.is_text_node()) else {
+            return None;
+        };
+        Some(node.handle())
     }
 }
 

--- a/crates/wysiwyg/src/dom/iter.rs
+++ b/crates/wysiwyg/src/dom/iter.rs
@@ -93,19 +93,6 @@ where
         iter.next()
     }
 
-    /// Return the next text node in the DOM, if exists, in depth-first order.
-    pub fn next_text_node(
-        &mut self,
-        handle: &DomHandle,
-    ) -> Option<&TextNode<S>> {
-        let mut iter = self.iter_from_handle(handle);
-        iter.next(); // Current node
-        let Some(node) = iter.find(|n| n.is_text_node()) else {
-            return None;
-        };
-        node.as_text()
-    }
-
     /// Return the handle of the next node in the DOM, if exists, in depth-first order.
     pub fn next_handle(&mut self, handle: &DomHandle) -> Option<DomHandle> {
         let mut iter = self.iter_from_handle(handle);
@@ -114,19 +101,6 @@ where
             return None;
         };
         Some(next.handle())
-    }
-
-    /// Return the handle of the next text node in the DOM, if exists, in depth-first order.
-    pub fn next_text_node_handle(
-        &mut self,
-        handle: &DomHandle,
-    ) -> Option<DomHandle> {
-        let mut iter = self.iter_from_handle(handle);
-        iter.next(); // Current node
-        let Some(node) = iter.find(|n| n.is_text_node()) else {
-            return None;
-        };
-        Some(node.handle())
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -156,17 +156,15 @@ where
         ret
     }
 
-    pub fn replace_child(
+    /// Insert an array of children [nodes] at given [index].
+    /// Returns new handles for moved nodes.
+    pub fn insert_children(
         &mut self,
         index: usize,
         nodes: Vec<DomNode<S>>,
     ) -> Vec<DomHandle> {
-        assert!(self.handle.is_set());
-        assert!(index < self.children().len());
-
         let mut handles = Vec::new();
 
-        self.children.remove(index);
         let mut current_index = index;
         for mut node in nodes {
             let child_handle = self.handle.child_handle(current_index);
@@ -181,6 +179,20 @@ where
             handles.push(new_handle);
         }
         handles
+    }
+
+    /// Replace child at given [index] with an array of children [nodes].
+    /// Returns new handles for moved nodes.
+    pub fn replace_child(
+        &mut self,
+        index: usize,
+        nodes: Vec<DomNode<S>>,
+    ) -> Vec<DomHandle> {
+        assert!(self.handle.is_set());
+        assert!(index < self.children().len());
+
+        self.children.remove(index);
+        self.insert_children(index, nodes)
     }
 
     pub fn get_child_mut(&mut self, idx: usize) -> Option<&mut DomNode<S>> {
@@ -1058,6 +1070,53 @@ mod test {
     }
 
     #[test]
+    fn inserting_children_updates_the_relevant_handles() {
+        let mut node = container_with_handle(&[4, 5, 4]);
+
+        node.append_child(text_node("0"));
+        node.append_child(text_node("2"));
+        node.append_child(text_node("3"));
+
+        // Insert three new children before the second node
+        let moved_handles = node.insert_children(
+            1,
+            vec![text_node("1a"), text_node("1b"), text_node("1c")],
+        );
+
+        let text_node0 = &node.children[0];
+        let text_node1a = &node.children[1];
+        let text_node1b = &node.children[2];
+        let text_node1c = &node.children[3];
+        let text_node2 = &node.children[4];
+        let text_node3 = &node.children[5];
+
+        // The new nodes got inserted in the right places
+        assert_eq!(text_node0.to_html(), utf16("0"));
+        assert_eq!(text_node1a.to_html(), utf16("1a"));
+        assert_eq!(text_node1b.to_html(), utf16("1b"));
+        assert_eq!(text_node1c.to_html(), utf16("1c"));
+        assert_eq!(text_node2.to_html(), utf16("2"));
+        assert_eq!(text_node3.to_html(), utf16("3"));
+
+        assert_eq!(text_node0.handle().raw(), &[4, 5, 4, 0]);
+
+        // The new children got inserted with the right handles
+        assert_eq!(text_node1a.handle().raw(), &[4, 5, 4, 1]);
+        assert_eq!(text_node1b.handle().raw(), &[4, 5, 4, 2]);
+        assert_eq!(text_node1c.handle().raw(), &[4, 5, 4, 3]);
+
+        // The previous node 2 & 3 were updated because it has moved to the right
+        assert_eq!(text_node2.handle().raw(), &[4, 5, 4, 4]);
+        assert_eq!(text_node3.handle().raw(), &[4, 5, 4, 5]);
+
+        // Returned vec matches moved handles.
+        assert_eq!(
+            moved_handles,
+            vec![text_node2.handle(), text_node3.handle()]
+        );
+    }
+
+    #[test]
     fn replacing_child_updates_the_relevant_handles() {
         let mut node = container_with_handle(&[4, 5, 4]);
 
@@ -1066,7 +1125,7 @@ mod test {
         node.append_child(text_node("2"));
 
         // Replace the middle child with three new ones
-        node.replace_child(
+        let moved_handles = node.replace_child(
             1,
             vec![text_node("1a"), text_node("1b"), text_node("1c")],
         );
@@ -1093,6 +1152,9 @@ mod test {
 
         // The previous node 2 was updated because it has moved to the right
         assert_eq!(text_node2.handle().raw(), &[4, 5, 4, 4]);
+
+        // Returned vec matches moved handles.
+        assert_eq!(moved_handles, vec![text_node2.handle()]);
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -357,6 +357,35 @@ where
         first_child.add_leading_zwsp()
     }
 
+    /// Remove leading ZWSP char from this container.
+    /// Returns false if no updates was done.
+    /// e.g. first text-like node is a line break
+    /// or a text node that doesn't start with a ZWSP.
+    pub fn remove_leading_zwsp(&mut self) -> bool {
+        let Some(first_child) = self.children.get_mut(0) else {
+            return false;
+        };
+        first_child.remove_leading_zwsp()
+    }
+
+    pub fn replace_leading_zwsp_with_linebreak(&mut self) -> bool {
+        let Some(first_child) = self.children.get_mut(0) else {
+            return false;
+        };
+        match first_child {
+            DomNode::Container(c) => c.replace_leading_zwsp_with_linebreak(),
+            DomNode::Text(t) => {
+                if t.remove_leading_zwsp() {
+                    self.children.insert(0, DomNode::new_line_break());
+                    true
+                } else {
+                    false
+                }
+            }
+            DomNode::LineBreak(_) => false,
+        }
+    }
+
     /// Push content of the given container node into self. Panics
     /// if given container node is not of the same kind.
     pub(crate) fn push(&mut self, other_node: &mut ContainerNode<S>) {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -368,6 +368,15 @@ where
         first_child.remove_leading_zwsp()
     }
 
+    /// Returns whether this continer first text-like
+    /// child starts with a ZWSP.
+    pub fn has_leading_zwsp(&self) -> bool {
+        let Some(first_child) = self.children.get(0) else {
+            return false;
+        };
+        first_child.has_leading_zwsp()
+    }
+
     pub fn replace_leading_zwsp_with_linebreak(&mut self) -> bool {
         let Some(first_child) = self.children.get_mut(0) else {
             return false;

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -220,6 +220,18 @@ where
         }
     }
 
+    /// Remove leading ZWSP char from this node.
+    /// Returns false if no updates was done.
+    /// e.g. first text-like node is a line break
+    /// or a text node that doesn't start with a ZWSP.
+    pub fn remove_leading_zwsp(&mut self) -> bool {
+        match self {
+            DomNode::Container(c) => c.remove_leading_zwsp(),
+            DomNode::Text(t) => t.remove_leading_zwsp(),
+            DomNode::LineBreak(_) => false,
+        }
+    }
+
     /// Returns true if given node can be pushed into self without any specific change.
     pub(crate) fn can_push(&self, other_node: &DomNode<S>) -> bool {
         match (self, other_node) {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -232,6 +232,16 @@ where
         }
     }
 
+    /// Returns whether this node, or it's first text-like
+    /// child starts with a ZWSP.
+    pub fn has_leading_zwsp(&self) -> bool {
+        match self {
+            DomNode::Container(c) => c.has_leading_zwsp(),
+            DomNode::Text(t) => t.data().to_string().starts_with(char::zwsp()),
+            DomNode::LineBreak(_) => false,
+        }
+    }
+
     /// Returns true if given node can be pushed into self without any specific change.
     pub(crate) fn can_push(&self, other_node: &DomNode<S>) -> bool {
         match (self, other_node) {

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -237,10 +237,25 @@ impl Range {
         self.locations.iter().filter(|loc| loc.is_leaf())
     }
 
-    pub fn top_level_locations(&self) -> impl Iterator<Item = &DomLocation> {
+    pub fn top_level_depth(&self) -> usize {
         self.locations
             .iter()
-            .filter(|l| l.node_handle.raw().len() == 1)
+            .map(|l| l.node_handle.depth())
+            .min()
+            .expect("Should always have at least one set handle")
+    }
+
+    pub fn locations_at_depth(
+        &self,
+        depth: usize,
+    ) -> impl Iterator<Item = &DomLocation> {
+        self.locations
+            .iter()
+            .filter(move |l| l.node_handle.depth() == depth)
+    }
+
+    pub fn top_level_locations(&self) -> impl Iterator<Item = &DomLocation> {
+        self.locations_at_depth(self.top_level_depth())
     }
 
     pub fn is_cursor(&self) -> bool {

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -237,6 +237,12 @@ impl Range {
         self.locations.iter().filter(|loc| loc.is_leaf())
     }
 
+    pub fn top_level_locations(&self) -> impl Iterator<Item = &DomLocation> {
+        self.locations
+            .iter()
+            .filter(|l| l.node_handle.raw().len() == 1)
+    }
+
     pub fn is_cursor(&self) -> bool {
         self.start() == self.end()
     }

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -343,6 +343,63 @@ fn replacing_cross_list_item_selection_with_text_containing_newline_works() {
     assert_eq!(tx(&model), "<ul><li>~aghi</li><li>~jkl|f</li></ul>");
 }
 
+#[test]
+fn creating_list_from_multiline_selection() {
+    let mut model = cm("{abc<br />def}|");
+    model.ordered_list();
+    assert_eq!(tx(&model), "<ol><li>{~abc</li><li>~def}|</li></ol>")
+}
+
+#[test]
+fn creating_list_from_multiline_selection_with_formatting() {
+    let mut model = cm("{a<strong>b</strong>c<br />def}|");
+    model.ordered_list();
+    assert_eq!(
+        tx(&model),
+        "<ol><li>{~a<strong>b</strong>c</li><li>~def}|</li></ol>"
+    )
+}
+
+#[test]
+fn creating_list_from_multiline_selection_with_leading_formatting() {
+    let mut model = cm("{<strong>ab</strong>c<br />def}|");
+    model.ordered_list();
+    assert_eq!(
+        tx(&model),
+        "<ol><li><strong>{~ab</strong>c</li><li>~def}|</li></ol>"
+    )
+}
+
+#[test]
+fn creating_list_from_multiline_selection_with_trailing_formatting() {
+    let mut model = cm("{abc<br />d<strong>ef</strong>}|");
+    model.ordered_list();
+    assert_eq!(
+        tx(&model),
+        "<ol><li>{~abc</li><li>~d<strong>ef}|</strong></li></ol>"
+    )
+}
+
+#[test]
+fn creating_list_from_multiline_selection_with_cross_trailing_formatting() {
+    let mut model = cm("{abc<br />d<strong>e}|f</strong>");
+    model.ordered_list();
+    assert_eq!(
+        tx(&model),
+        "<ol><li>{~abc</li><li>~d<strong>e}|f</strong></li></ol>"
+    )
+}
+
+#[test]
+fn creating_list_from_multiline_selection_with_cross_leading_formatting() {
+    let mut model = cm("a<em>b{c</em><br />def}|");
+    model.ordered_list();
+    assert_eq!(
+        tx(&model),
+        "<ol><li>~a<em>b{c</em></li><li>~def}|</li></ol>"
+    )
+}
+
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {
     model.replace_text(utf16(new_text));
 }


### PR DESCRIPTION
Allows creating lists from multiline selection and extend range appropriately.
Also remove some of the legacy list code to use new functions