### PR TITLE
Add rich/plain conversion functions

### DIFF
--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import init from '../generated/wysiwyg';
+import { richToPlain, plainToRich } from './conversion';
+
+const testCases = [
+    { rich: 'plain', plain: 'plain' },
+    { rich: '<strong>bold</strong>', plain: '__bold__' },
+    { rich: '<em>italic</em>', plain: '*italic*' },
+    { rich: '<u>underline</u>', plain: '<u>underline</u>' },
+    { rich: '<del>strike</del>', plain: '~~strike~~' },
+];
+
+beforeAll(async () => {
+    await init();
+});
+
+const mappedTestCases = testCases.map(({ rich, plain }) => [rich, plain]);
+
+test.each(mappedTestCases)('rich: `%s` - plain: `%s`', (rich, plain) => {
+    const convertedRichText = plainToRich(plain);
+    const convertedPlainText = richToPlain(rich);
+
+    expect(convertedRichText).toBe(rich);
+    expect(convertedPlainText).toBe(plain);
+});
+
+it('converts linebreaks for display rich => plain', () => {
+    const richText = 'multi<br />line';
+    const convertedPlainText = richToPlain(richText);
+    const expectedPlainText = `multi\nline`;
+
+    expect(convertedPlainText).toBe(expectedPlainText);
+});
+
+it('converts linebreaks for display plain => rich', () => {
+    const plainText = 'multi\nline';
+    const convertedRichText = plainToRich(plainText);
+    const expectedRichText = 'multi<br />line';
+
+    expect(convertedRichText).toBe(expectedRichText);
+});

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// rust generated bindings
+import {
+    // eslint-disable-next-line camelcase
+    new_composer_model,
+} from '../generated/wysiwyg.js';
+
+// const backslash = String.fromCharCode(0x005c);
+export function richToPlain(richText: string) {
+    if (richText.length === 0) {
+        return '';
+    }
+    const model = new_composer_model();
+    model.set_content_from_html(richText);
+
+    // in plain text, newlines will be represented as \n for display
+    // as the display box can not interpret markdown
+    const markdown = model.get_content_as_markdown();
+    const plainText = markdown.replaceAll(/\\/g, '');
+
+    return plainText;
+}
+
+export function plainToRich(plainText: string) {
+    if (plainText.length === 0) {
+        return '';
+    }
+    // in plain text, newlines will be represented as \n if input
+    // by the user pressing enter, so we want to convert these to
+    // valid markdown for parsing by MarkdownHTMLParser::to_html
+    const markdown = plainText.replaceAll(/\n/g, '<br />\n');
+    const model = new_composer_model();
+    model.set_content_from_markdown(markdown);
+    const richText = model.get_content_as_html();
+
+    return richText;
+}

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -20,7 +20,6 @@ import {
     new_composer_model,
 } from '../generated/wysiwyg.js';
 
-// const backslash = String.fromCharCode(0x005c);
 export function richToPlain(richText: string) {
     if (richText.length === 0) {
         return '';

--- a/platforms/web/lib/useComposerModel.ts
+++ b/platforms/web/lib/useComposerModel.ts
@@ -32,7 +32,7 @@ let initFinished = false;
 /**
  * Initialise the WASM module, or do nothing if it is already initialised.
  */
-async function initOnce() {
+export async function initOnce() {
     if (initFinished) {
         return Promise.resolve();
     }

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -22,6 +22,8 @@ import { useComposerModel } from './useComposerModel';
 import { useListeners } from './useListeners';
 import { useTestCases } from './useTestCases';
 
+export { richToPlain, plainToRich } from './conversion';
+
 function useEditorFocus(
     editorRef: RefObject<HTMLElement | null>,
     isAutoFocusEnabled = false,


### PR DESCRIPTION
We need to be able to convert between rich and plain modes consistently when moving between composers on web.

These functions allow us to get the rich/plain text in the format required for transitioning between the composers. They achieve this by creating a model purely to generate the output. The model is not used after this initial conversion.