### PR TITLE
[iOS] Fix for a bug where attributed string keeps format style for links and inline code after deletion

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -215,7 +215,8 @@ public extension WysiwygComposerViewModel {
             return true
         }
         
-        // This fixes a bug where the attributed string keeps link and inline code formatting when they are the last formatting to be deleted
+        // This fixes a bug where the attributed string keeps link and inline code formatting
+        // when they are the last formatting to be deleted
         if textView.attributedText.length == 0 {
             textView.typingAttributes = defaultTextAttributes
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -116,12 +116,16 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
                 maxCompressedHeight: CGFloat = 200,
                 maxExpandedHeight: CGFloat = 300,
                 textColor: UIColor = .label,
-                linkColor: UIColor = .link) {
+                linkColor: UIColor = .link,
+                shouldUnderlineLinks: Bool = false) {
         self.minHeight = minHeight
         self.maxCompressedHeight = maxCompressedHeight
         self.maxExpandedHeight = maxExpandedHeight
         self.textColor = textColor
         self.linkColor = linkColor
+        if !shouldUnderlineLinks {
+            textView.linkTextAttributes[.underlineStyle] = 0
+        }
         model = newComposerModel()
         // Publish composer empty state.
         $attributedContent.sink { [unowned self] content in

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -214,6 +214,11 @@ public extension WysiwygComposerViewModel {
         guard !plainTextMode else {
             return true
         }
+        
+        // This fixes a bug where the attributed string keeps link and inline code formatting when they are the last formatting to be deleted
+        if textView.attributedText.length == 0 {
+            textView.typingAttributes = defaultTextAttributes
+        }
 
         let update: ComposerUpdate
         let shouldAcceptChange: Bool

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -116,16 +116,12 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
                 maxCompressedHeight: CGFloat = 200,
                 maxExpandedHeight: CGFloat = 300,
                 textColor: UIColor = .label,
-                linkColor: UIColor = .link,
-                shouldUnderlineLinks: Bool = false) {
+                linkColor: UIColor = .link) {
         self.minHeight = minHeight
         self.maxCompressedHeight = maxCompressedHeight
         self.maxExpandedHeight = maxExpandedHeight
         self.textColor = textColor
         self.linkColor = linkColor
-        if !shouldUnderlineLinks {
-            textView.linkTextAttributes[.underlineStyle] = 0
-        }
         model = newComposerModel()
         // Publish composer empty state.
         $attributedContent.sink { [unowned self] content in


### PR DESCRIPTION
Happens when these formats are at the start of the textview and get deleted/fully cleared

Also added an init parameter that allows the TextView to either have links with the underline or not.