### PR TITLE
[iOS] Inline code background colour is shown in the composer

### DIFF
--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -204,6 +204,20 @@ class WysiwygUITests: XCTestCase {
             """
         )
     }
+    
+    func testTypingInlineCodeDisablesOtherFormatters() {
+        button(.inlineCodeButton).tap()
+        textView.typeTextCharByChar("code")
+        let reactiveButtonsIdentifiers: [WysiwygSharedAccessibilityIdentifier] = [
+            .boldButton,
+            .italicButton,
+            .strikeThroughButton,
+            .linkButton,
+        ]
+        for identifier in reactiveButtonsIdentifiers {
+            XCTAssertFalse(button(identifier).isEnabled)
+        }
+    }
 }
 
 private extension WysiwygUITests {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -69,6 +69,16 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
         }
     }
     
+    /// The color that will be used for the background of code blocks
+    public var codeBackgroundColor: UIColor {
+        didSet {
+            // In case of a color change, this will refresh the attributed text
+            let update = model.setContentFromHtml(html: content.html)
+            applyUpdate(update)
+            updateTextView()
+        }
+    }
+    
     /// The current max allowed height for the textView when maximised
     public var maxExpandedHeight: CGFloat {
         didSet {
@@ -116,12 +126,14 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
                 maxCompressedHeight: CGFloat = 200,
                 maxExpandedHeight: CGFloat = 300,
                 textColor: UIColor = .label,
-                linkColor: UIColor = .link) {
+                linkColor: UIColor = .link,
+                codeBackgroundColor: UIColor = .systemGray) {
         self.minHeight = minHeight
         self.maxCompressedHeight = maxCompressedHeight
         self.maxExpandedHeight = maxExpandedHeight
         self.textColor = textColor
         self.linkColor = linkColor
+        self.codeBackgroundColor = codeBackgroundColor
         model = newComposerModel()
         // Publish composer empty state.
         $attributedContent.sink { [unowned self] content in
@@ -358,7 +370,7 @@ private extension WysiwygComposerViewModel {
     func applyReplaceAll(codeUnits: [UInt16], start: UInt32, end: UInt32) {
         do {
             let html = String(utf16CodeUnits: codeUnits, count: codeUnits.count)
-            let attributed = try HTMLParser.parse(html: html, textColor: textColor, linkColor: linkColor)
+            let attributed = try HTMLParser.parse(html: html, textColor: textColor, linkColor: linkColor, codeBackgroundColor: codeBackgroundColor)
             // FIXME: handle error for out of bounds index
             let htmlSelection = NSRange(location: Int(start), length: Int(end - start))
             // FIXME: temporary workaround as trailing newline should be ignored but are now replacing ZWSP from Rust model

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -215,7 +215,8 @@ public extension WysiwygComposerViewModel {
             return true
         }
         
-        // This fixes a bug where the attributed string keeps link and inline code formatting when they are the last formatting to be deleted
+        // This fixes a bug where the attributed string keeps link and inline code formatting
+        // when they are the last formatting to be deleted
         if textView.attributedText.length == 0 {
             textView.typingAttributes = defaultTextAttributes
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -127,7 +127,7 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
                 maxExpandedHeight: CGFloat = 300,
                 textColor: UIColor = .label,
                 linkColor: UIColor = .link,
-                codeBackgroundColor: UIColor = .systemGray) {
+                codeBackgroundColor: UIColor = .systemGray5) {
         self.minHeight = minHeight
         self.maxCompressedHeight = maxCompressedHeight
         self.maxExpandedHeight = maxExpandedHeight

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -214,6 +214,11 @@ public extension WysiwygComposerViewModel {
         guard !plainTextMode else {
             return true
         }
+        
+        // This fixes a bug where the attributed string keeps link and inline code formatting when they are the last formatting to be deleted
+        if textView.attributedText.length == 0 {
+            textView.typingAttributes = defaultTextAttributes
+        }
 
         let update: ComposerUpdate
         let shouldAcceptChange: Bool

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -370,7 +370,12 @@ private extension WysiwygComposerViewModel {
     func applyReplaceAll(codeUnits: [UInt16], start: UInt32, end: UInt32) {
         do {
             let html = String(utf16CodeUnits: codeUnits, count: codeUnits.count)
-            let attributed = try HTMLParser.parse(html: html, textColor: textColor, linkColor: linkColor, codeBackgroundColor: codeBackgroundColor)
+            let attributed = try HTMLParser.parse(
+                html: html,
+                textColor: textColor,
+                linkColor: linkColor,
+                codeBackgroundColor: codeBackgroundColor
+            )
             // FIXME: handle error for out of bounds index
             let htmlSelection = NSRange(location: Int(start), length: Int(end - start))
             // FIXME: temporary workaround as trailing newline should be ignored but are now replacing ZWSP from Rust model

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
@@ -78,7 +78,7 @@ extension NSAttributedString {
         }
         
         // Adding background to inline code
-        mutableAttributed.enumerateTypedAttribute(.font) { (font: UIFont, range: NSRange, _: UnsafeMutablePointer<ObjCBool>) in
+        mutableAttributed.enumerateTypedAttribute(.font) { (font: UIFont, range, _) in
             if font.familyName == "Courier" {
                 mutableAttributed.addAttributes([.backgroundColor: codeBackgroundColor], range: range)
             }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
@@ -64,7 +64,7 @@ extension NSAttributedString {
     ///   - linkColor: the new UIColor for links inside the attributed string
     ///   - codeBackgroundColor: the new UIColor for the background of code blocks
     /// - Returns: a new attributed string with the same content and attributes, but its foregroundColor is changed
-    func changeColor(to color: UIColor, linkColor: UIColor, codeBackgroundColor: UIColor) -> NSAttributedString {
+    func changeColor(to color: UIColor, linkColor: UIColor) -> NSAttributedString {
         let mutableAttributed = NSMutableAttributedString(attributedString: self)
         mutableAttributed.addAttributes(
             [.foregroundColor: color], range: NSRange(location: 0, length: mutableAttributed.length)
@@ -74,13 +74,6 @@ extension NSAttributedString {
         mutableAttributed.enumerateAttribute(.link, in: NSRange(location: 0, length: mutableAttributed.length)) { value, range, _ in
             if value != nil {
                 mutableAttributed.addAttributes([.foregroundColor: linkColor], range: range)
-            }
-        }
-        
-        // Adding background to inline code
-        mutableAttributed.enumerateTypedAttribute(.font) { (font: UIFont, range, _) in
-            if font.familyName == "Courier" {
-                mutableAttributed.addAttributes([.backgroundColor: codeBackgroundColor], range: range)
             }
         }
         let newSelf = NSAttributedString(attributedString: mutableAttributed)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
@@ -62,16 +62,25 @@ extension NSAttributedString {
     /// - Parameters:
     ///   - color: the new UIColor to update the attributed string
     ///   - linkColor: the new UIColor for links inside the attributed string
+    ///   - codeBackgroundColor: the new UIColor for the background of code blocks
     /// - Returns: a new attributed string with the same content and attributes, but its foregroundColor is changed
-    func changeColor(to color: UIColor, linkColor: UIColor) -> NSAttributedString {
+    func changeColor(to color: UIColor, linkColor: UIColor, codeBackgroundColor: UIColor) -> NSAttributedString {
         let mutableAttributed = NSMutableAttributedString(attributedString: self)
         mutableAttributed.addAttributes(
             [.foregroundColor: color], range: NSRange(location: 0, length: mutableAttributed.length)
         )
+        
         // This fixes an iOS bug where if some text is typed after a link, and then a whitespace is added the link color is overridden.
         mutableAttributed.enumerateAttribute(.link, in: NSRange(location: 0, length: mutableAttributed.length)) { value, range, _ in
             if value != nil {
                 mutableAttributed.addAttributes([.foregroundColor: linkColor], range: range)
+            }
+        }
+        
+        // Adding background to inline code
+        mutableAttributed.enumerateTypedAttribute(.font) { (font: UIFont, range: NSRange, _: UnsafeMutablePointer<ObjCBool>) in
+            if font.familyName == "Courier" {
+                mutableAttributed.addAttributes([.backgroundColor: codeBackgroundColor], range: range)
             }
         }
         let newSelf = NSAttributedString(attributedString: mutableAttributed)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
@@ -62,8 +62,9 @@ extension NSAttributedString {
     /// - Parameters:
     ///   - color: the new UIColor to update the attributed string
     ///   - linkColor: the new UIColor for links inside the attributed string
+    ///   - codeBackgroundColor: color to apply to the background of code blocks
     /// - Returns: a new attributed string with the same content and attributes, but its foregroundColor is changed
-    func changeColor(to color: UIColor, linkColor: UIColor) -> NSAttributedString {
+    func changeColor(to color: UIColor, linkColor: UIColor, codeBackgroundColor: UIColor) -> NSAttributedString {
         let mutableAttributed = NSMutableAttributedString(attributedString: self)
         mutableAttributed.addAttributes(
             [.foregroundColor: color], range: NSRange(location: 0, length: mutableAttributed.length)
@@ -73,6 +74,15 @@ extension NSAttributedString {
         mutableAttributed.enumerateAttribute(.link, in: NSRange(location: 0, length: mutableAttributed.length)) { value, range, _ in
             if value != nil {
                 mutableAttributed.addAttributes([.foregroundColor: linkColor], range: range)
+            }
+        }
+        
+        // This a temporary workaround, since inline code should not contain newlines
+        // iOS removes the background color when a newline is added
+        // This will be removed when inline code will avoid newlines
+        mutableAttributed.enumerateTypedAttribute(.font) { (font: UIFont, range, _) in
+            if font.fontDescriptor.symbolicTraits.contains(.traitMonoSpace) {
+                mutableAttributed.addAttributes([.backgroundColor: codeBackgroundColor], range: range)
             }
         }
         let newSelf = NSAttributedString(attributedString: mutableAttributed)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/NSAttributedString+Attributes.swift
@@ -62,7 +62,6 @@ extension NSAttributedString {
     /// - Parameters:
     ///   - color: the new UIColor to update the attributed string
     ///   - linkColor: the new UIColor for links inside the attributed string
-    ///   - codeBackgroundColor: the new UIColor for the background of code blocks
     /// - Returns: a new attributed string with the same content and attributes, but its foregroundColor is changed
     func changeColor(to color: UIColor, linkColor: UIColor) -> NSAttributedString {
         let mutableAttributed = NSMutableAttributedString(attributedString: self)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UIColor.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UIColor.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+extension UIColor {
+    func toHexString(shouldIncludeAlpha: Bool = false) -> String {
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        let hexValue: Int
+        if shouldIncludeAlpha {
+            hexValue = Int(r * 255) << 24 | Int(g * 255) << 16 | Int(b * 255) << 8 | Int(a * 255) << 0
+        } else {
+            hexValue = Int(r * 255) << 16 | Int(g * 255) << 8 | Int(b * 255) << 0
+        }
+        return String(format: "#%06x", hexValue)
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UIColor.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UIColor.swift
@@ -26,9 +26,10 @@ extension UIColor {
         let hexValue: Int
         if shouldIncludeAlpha {
             hexValue = Int(r * 255) << 24 | Int(g * 255) << 16 | Int(b * 255) << 8 | Int(a * 255) << 0
+            return String(format: "#%08x", hexValue)
         } else {
             hexValue = Int(r * 255) << 16 | Int(g * 255) << 8 | Int(b * 255) << 0
+            return String(format: "#%06x", hexValue)
         }
-        return String(format: "#%06x", hexValue)
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
@@ -34,9 +34,11 @@ final class HTMLParser {
     static func parse(html: String,
                       encoding: String.Encoding = .utf16,
                       textColor: UIColor,
-                      linkColor: UIColor) throws -> NSAttributedString {
+                      linkColor: UIColor,
+                      codeBackgroundColor: UIColor) throws -> NSAttributedString {
         let htmlWithStyle = generateHtmlBodyWithStyle(htmlFragment: html)
-        let attributed = try NSAttributedString(html: htmlWithStyle).changeColor(to: textColor, linkColor: linkColor)
+        let attributed = try NSAttributedString(html: htmlWithStyle)
+            .changeColor(to: textColor, linkColor: linkColor, codeBackgroundColor: codeBackgroundColor)
         return attributed
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
@@ -36,9 +36,9 @@ final class HTMLParser {
                       textColor: UIColor,
                       linkColor: UIColor,
                       codeBackgroundColor: UIColor) throws -> NSAttributedString {
-        let htmlWithStyle = generateHtmlBodyWithStyle(htmlFragment: html)
+        let htmlWithStyle = generateHtmlBodyWithStyle(htmlFragment: html, codeBackgroundColorHex: codeBackgroundColor.toHexString())
         let attributed = try NSAttributedString(html: htmlWithStyle)
-            .changeColor(to: textColor, linkColor: linkColor, codeBackgroundColor: codeBackgroundColor)
+            .changeColor(to: textColor, linkColor: linkColor)
         return attributed
     }
 }
@@ -48,7 +48,24 @@ private extension HTMLParser {
     ///
     /// - Parameter htmlFragment: HTML fragment
     /// - Returns: HTML body
-    static func generateHtmlBodyWithStyle(htmlFragment: String) -> String {
-        "<html><head><style>body {font-family:-apple-system;font:-apple-system-body;}</style></head><body>\(htmlFragment)</body></html>"
+    static func generateHtmlBodyWithStyle(htmlFragment: String, codeBackgroundColorHex: String) -> String {
+        """
+        <html>\
+        <head>\
+        <style>\
+        body{\
+        font-family:-apple-system;\
+        font:-apple-system-body;\
+        }\
+        code{\
+        font-family:Menlo,monospace;\
+        font-size:inherit;\
+        background:\(codeBackgroundColorHex);\
+        }\
+        </style>\
+        </head>\
+        <body>\(htmlFragment)</body>\
+        </html>
+        """
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
@@ -30,6 +30,7 @@ final class HTMLParser {
     ///   - html: HTML to parse
     ///   - encoding: string encoding to use
     ///   - textColor: text color to apply to the result string
+    ///   - codeBackgroundColor: color to apply to the background of code blocks
     /// - Returns: an attributed string representation of the HTML content
     static func parse(html: String,
                       encoding: String.Encoding = .utf16,
@@ -46,7 +47,9 @@ final class HTMLParser {
 private extension HTMLParser {
     /// Generate an HTML body with standard style from given fragment.
     ///
-    /// - Parameter htmlFragment: HTML fragment
+    /// - Parameters:
+    ///    - htmlFragment: HTML fragment
+    ///    - codeBackgroundColorHex: the background color for code blocks as hex
     /// - Returns: HTML body
     static func generateHtmlBodyWithStyle(htmlFragment: String, codeBackgroundColorHex: String) -> String {
         """

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
@@ -30,6 +30,7 @@ final class HTMLParser {
     ///   - html: HTML to parse
     ///   - encoding: string encoding to use
     ///   - textColor: text color to apply to the result string
+    ///   - linkColor: text color to apply to the links
     ///   - codeBackgroundColor: color to apply to the background of code blocks
     /// - Returns: an attributed string representation of the HTML content
     static func parse(html: String,

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/HTMLParser.swift
@@ -40,7 +40,7 @@ final class HTMLParser {
                       codeBackgroundColor: UIColor) throws -> NSAttributedString {
         let htmlWithStyle = generateHtmlBodyWithStyle(htmlFragment: html, codeBackgroundColorHex: codeBackgroundColor.toHexString())
         let attributed = try NSAttributedString(html: htmlWithStyle)
-            .changeColor(to: textColor, linkColor: linkColor)
+            .changeColor(to: textColor, linkColor: linkColor, codeBackgroundColor: codeBackgroundColor)
         return attributed
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/UIColorExtensionsTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/UIColorExtensionsTests.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2022 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import WysiwygComposer
+import XCTest
+
+final class UIColorExtensionsTests: XCTestCase {
+    func testConversionInHexWithoutAlpha() {
+        let red = UIColor.red
+        XCTAssertEqual(red.toHexString(), "#ff0000")
+        let blue = UIColor.blue
+        XCTAssertEqual(blue.toHexString(), "#0000ff")
+        let green = UIColor.green
+        XCTAssertEqual(green.toHexString(), "#00ff00")
+        let black = UIColor.black
+        XCTAssertEqual(black.toHexString(), "#000000")
+        let white = UIColor.white
+        XCTAssertEqual(white.toHexString(), "#ffffff")
+        let color = UIColor(red: 17.0 / 255.0, green: 11.0 / 255.0, blue: 64.0 / 255.0, alpha: 1.0)
+        XCTAssertEqual(color.toHexString(), "#110b40")
+    }
+    
+    func testConversionInHexWithAlpha() {
+        let black = UIColor.black
+        XCTAssertEqual(black.toHexString(shouldIncludeAlpha: true), "#000000ff")
+        let clear = UIColor.clear
+        XCTAssertEqual(clear.toHexString(shouldIncludeAlpha: true), "#00000000")
+        let color = UIColor(red: 17.0 / 255.0, green: 11.0 / 255, blue: 64.0 / 255.0, alpha: 32 / 255.0)
+        XCTAssertEqual(color.toHexString(shouldIncludeAlpha: true), "#110b4020")
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
@@ -218,4 +218,41 @@ final class WysiwygComposerTests: XCTestCase {
             """
         )
     }
+    
+    func testInlineCode() {
+        let composer = newComposerModel()
+        _ = composer.inlineCode()
+        _ = composer.replaceText(newText: "code")
+        XCTAssertEqual(
+            composer.toTree(),
+            """
+            
+            └>code
+              └>\"code\"
+            
+            """
+        )
+    }
+    
+    func testInlineCodeWithFormatting() {
+        let composer = newComposerModel()
+        _ = composer.bold()
+        _ = composer.replaceText(newText: "bold")
+        // This should get ignored
+        _ = composer.italic()
+        _ = composer.inlineCode()
+        _ = composer.replaceText(newText: "code")
+        print(composer.toTree())
+        XCTAssertEqual(
+            composer.toTree(),
+            """
+            
+            ├>strong
+            │ └>"bold"
+            └>code
+              └>"code"
+            
+            """
+        )
+    }
 }


### PR DESCRIPTION
Also, can be customised.

![simulator_screenshot_EFFEC735-599E-4EB7-954A-BD513EA6FBD6](https://user-images.githubusercontent.com/34335419/207915419-c07b9122-e074-46e2-aff8-cfae502bdbc3.png)

