### PR TITLE
Fix: disable inline code and then type text re-orders nodes

### DIFF
--- a/crates/wysiwyg/src/composer_model/format.rs
+++ b/crates/wysiwyg/src/composer_model/format.rs
@@ -128,8 +128,12 @@ where
         format: &InlineFormatType,
     ) {
         assert!(start != end);
-        let range = self.state.dom.find_range(start, end);
-        self.format_several_nodes(&range, format);
+        if *format == InlineFormatType::InlineCode {
+            self.add_inline_code_in(start, end);
+        } else {
+            let range = self.state.dom.find_range(start, end);
+            self.format_several_nodes(&range, format);
+        }
     }
 
     fn unformat(&mut self, format: InlineFormatType) -> ComposerUpdate<S> {
@@ -295,6 +299,7 @@ where
         let mut action_list = DomActionList::default();
         let mut sorted_locations = locations;
         sorted_locations.sort();
+
         // Go through the locations in reverse order to prevent Dom modification issues
         for loc in sorted_locations.into_iter().rev() {
             let mut loc = loc.clone();

--- a/crates/wysiwyg/src/composer_model/format_inline_code.rs
+++ b/crates/wysiwyg/src/composer_model/format_inline_code.rs
@@ -367,4 +367,15 @@ mod test {
         model.replace_text(" plain".into());
         assert_eq!(tx(&model), "<i>Test&nbsp;</i><code>code</code> plain|");
     }
+
+    #[test]
+    fn test_inline_code_disables_current_formatting() {
+        let mut model = cm("|");
+        model.bold();
+        model.replace_text("bold".into());
+        model.italic();
+        model.inline_code();
+        model.replace_text("code".into());
+        assert_eq!(tx(&model), "<strong>bold</strong><code>code|</code>");
+    }
 }


### PR DESCRIPTION
I didn't realise that when we unformat we actually remove the whole formatting node and the re-apply formatting to the part that should be formatted.

That, and a bug when working with nodes in `depth = 0` caused this weird issue where:

```
<i>Test</i><code>code|</code>
```

Disabling inline code and then typing would result in:

```
<code>code</code><i>Test</i>New text|
```