### PR TITLE
Add `insert_parent` DOM method

### DIFF
--- a/crates/wysiwyg/src/dom.rs
+++ b/crates/wysiwyg/src/dom.rs
@@ -22,6 +22,7 @@ pub mod dom_struct;
 pub mod find_extended_range;
 pub mod find_range;
 pub mod find_result;
+pub mod insert_parent;
 pub mod iter;
 pub mod join_nodes;
 pub mod nodes;

--- a/crates/wysiwyg/src/dom/dom_handle.rs
+++ b/crates/wysiwyg/src/dom/dom_handle.rs
@@ -90,6 +90,16 @@ impl DomHandle {
         DomHandle::from_raw(new_path.to_vec())
     }
 
+    /// Returns a DomHandle with the 'sub-path' down to the passed 'depth'.
+    /// i.e.: a DomHandle with path `[0, 1, 2, 3]` with `at_depth(2)` will return a DomHandle
+    /// with path `[3]`.
+    pub fn sub_handle_down_from(&self, depth: usize) -> DomHandle {
+        assert!(&self.path.is_some());
+        let path = self.path.clone().unwrap();
+        let (_, new_path) = path.split_at(depth);
+        DomHandle::from_raw(new_path.to_vec())
+    }
+
     /// Return true if this handle has a parent i.e. it is not the root. If
     /// this returns true, it is safe to call index_in_parent() and
     /// parent_handle().

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -17,7 +17,7 @@
 
 use crate::dom::nodes::ContainerNodeKind;
 use crate::dom::unicode_string::UnicodeStr;
-use crate::{DomHandle, DomNode, UnicodeString};
+use crate::{DomHandle, DomNode, ToHtml, UnicodeString};
 
 use super::action_list::{DomAction, DomActionList};
 use super::nodes::dom_node::DomNodeKind;
@@ -434,6 +434,73 @@ where
         self.assert_invariants();
     }
 
+    /// Returns two new subtrees as the result of splitting the Dom symetrically without mutating
+    /// itself. Also returns the new handles of node that was split.
+    ///
+    /// Only returns nodes that are modified by the split and ignores any nodes which were not
+    /// either split or contain a node that was split.
+    pub(crate) fn split_new_sub_trees(
+        &self,
+        from_handle: &DomHandle,
+        offset: usize,
+        depth: usize,
+    ) -> (DomNode<S>, DomHandle, DomNode<S>, DomHandle) {
+        let mut clone = self.clone();
+        let right = clone.split_sub_tree(from_handle, offset, depth);
+
+        // Remove unmodified children of the right split
+        // TODO: create a utility for this
+        let mut right = DomNode::Container(ContainerNode::new(
+            S::default(),
+            ContainerNodeKind::Generic,
+            None,
+            vec![right
+                .as_container()
+                .unwrap()
+                .children()
+                .first()
+                .unwrap()
+                .clone()],
+        ));
+        right.set_handle(DomHandle::root());
+
+        // Remove unmodified children of the left split
+        // TODO: create a utility for this
+        let mut left = DomNode::Container(ContainerNode::new(
+            S::default(),
+            ContainerNodeKind::Generic,
+            None,
+            vec![clone
+                .lookup_node(&from_handle.sub_handle_up_to(depth))
+                .as_container()
+                .unwrap()
+                .children()
+                .last()
+                .unwrap()
+                .clone()],
+        ));
+        left.set_handle(DomHandle::root());
+
+        // Reset the root unmodified siblings were removed
+        let mut right_handle =
+            from_handle.sub_handle_down_from(depth).raw().to_owned();
+        right_handle[0] = 0;
+        let right_handle = DomHandle::from_raw(right_handle);
+
+        let mut left_handle =
+            from_handle.sub_handle_down_from(depth).raw().to_owned();
+        left_handle[0] = 0;
+        let left_handle = DomHandle::from_raw(left_handle);
+
+        (left, left_handle, right, right_handle)
+    }
+
+    /// Splits the tree at a given node into two parts. The first part stays in the tree and this
+    /// function returns the second part.
+    ///
+    /// * `from_handle` - the position of the node to split.
+    /// * `offset` - the position within the given node to split.
+    /// * `depth` - the depth within the original tree at which to make the returned tree's root
     pub(crate) fn split_sub_tree(
         &mut self,
         from_handle: &DomHandle,
@@ -498,13 +565,14 @@ where
                             {
                                 // Do nothing
                             } else {
-                                let left_data =
-                                    text_node.data()[..offset].to_owned();
-                                let right_data =
+                                // TODO: Figure out how to make this all less verbose
+                                let to_remove =
                                     text_node.data()[offset..].to_owned();
-                                text_node.set_data(left_data);
+                                let to_keep =
+                                    text_node.data()[..offset].to_owned();
+                                text_node.set_data(to_keep);
                                 removed_nodes
-                                    .insert(0, DomNode::new_text(right_data));
+                                    .insert(0, DomNode::new_text(to_remove));
                             }
                         }
                         _ => {
@@ -632,6 +700,7 @@ fn adjust_handles_for_delete(
 mod test {
     use crate::dom::DomHandle;
     use crate::tests::testutils_composer_model::{cm, tx};
+    use crate::tests::testutils_conversion::utf16;
     use crate::ToHtml;
 
     use super::*;
@@ -702,6 +771,7 @@ mod test {
             2,
             0,
         );
+        assert_eq!(model.state.dom.to_html(), "Text<b>bo</b>");
         assert_eq!(ret.to_html().to_string(), "<b>ld</b><i>italic</i>");
     }
 
@@ -713,6 +783,7 @@ mod test {
             2,
             0,
         );
+        assert_eq!(model.state.dom.to_html(), "<u>Text<b>bo</b></u>");
         assert_eq!(ret.to_html().to_string(), "<u><b>ld</b><i>italic</i></u>");
     }
 
@@ -724,6 +795,7 @@ mod test {
             2,
             1,
         );
+        assert_eq!(model.state.dom.to_html(), "<u>Text<b>bo</b></u>");
         assert_eq!(ret.to_html().to_string(), "<b>ld</b><i>italic</i>")
     }
 
@@ -737,6 +809,10 @@ mod test {
             &DomHandle::from_raw(vec![0, 1, 0, 0]),
             offset,
             depth,
+        );
+        assert_eq!(
+            model.state.dom.to_html(),
+            "<ul><li>Text</li><li><b>bo</b></li></ul>"
         );
         assert_eq!(
             ret.to_html().to_string(),
@@ -755,17 +831,53 @@ mod test {
             offset,
             depth,
         );
+        assert_eq!(
+            model.state.dom.to_html(),
+            "<ul><li>Text</li><li><b>bo</b></li></ul>"
+        );
         assert_eq!(ret.to_html().to_string(), "<li><b>ld</b><i>italic</i></li>")
     }
 
     #[test]
-    fn split_dom_with_partial_handle() {
+    fn split_dom_with_parent_handle() {
         let mut model = cm("<u>Text|<b>bold</b><i>italic</i></u>");
         let ret = model.state.dom.split_sub_tree(
-            &DomHandle::from_raw(vec![0, 1]),
+            &DomHandle::from_raw(vec![0, 1]), // Handle of <b>
             2,
             0,
         );
+        assert_eq!(model.state.dom.to_html(), "<u>Text<b>bo</b></u>");
         assert_eq!(ret.to_html().to_string(), "<u><b>ld</b><i>italic</i></u>");
+    }
+
+    #[test]
+    fn split_new_sub_trees() {
+        let model = cm("Text|<b>bold</b><i>italic</i>");
+        let (left, left_handle, right, right_handle) = model
+            .state
+            .dom
+            .split_new_sub_trees(&DomHandle::from_raw(vec![1, 0]), 2, 0);
+        assert_eq!(right.to_html(), "<b>ld</b>");
+        assert_eq!(right_handle, DomHandle::from_raw(vec![0, 0]));
+        assert_eq!(right.lookup_node(&right_handle).to_html(), "ld");
+        assert_eq!(left.to_html(), "<b>bo</b>");
+        assert_eq!(left_handle, DomHandle::from_raw(vec![0, 0]));
+        assert_eq!(left.lookup_node(&left_handle).to_html(), "bo");
+    }
+
+    #[test]
+    fn split_new_sub_trees_at_depth() {
+        let model = cm("<u>Text|<b>bold</b><i>italic</i></u>");
+        let (left, left_handle, right, right_handle) = model
+            .state
+            .dom
+            .split_new_sub_trees(&DomHandle::from_raw(vec![0, 1, 0]), 2, 1);
+        println!("RIGHT: {:?}", right);
+        assert_eq!(right.to_html(), "<b>ld</b>");
+        assert_eq!(right_handle, DomHandle::from_raw(vec![0, 0]));
+        assert_eq!(right.lookup_node(&right_handle).to_html(), "ld");
+        assert_eq!(left.to_html(), "<b>bo</b>");
+        assert_eq!(left_handle, DomHandle::from_raw(vec![0, 0]));
+        assert_eq!(left.lookup_node(&left_handle).to_html(), "bo");
     }
 }

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -450,21 +450,14 @@ where
 
         // Remove unmodified children of the right split
         // TODO: create a utility for this
-        let mut right = DomNode::Container(ContainerNode::new(
-            S::default(),
-            ContainerNodeKind::Generic,
-            None,
-            vec![right
-                .as_container()
-                .unwrap()
-                .children()
-                .first()
-                .unwrap()
-                .clone()],
-        ));
+        let right = right.as_container().unwrap();
+        let mut right = DomNode::Container({
+            let children = vec![right.children().first().unwrap().clone()];
+            right.clone_with_new_children(children)
+        });
         right.set_handle(DomHandle::root());
 
-        // Remove unmodified children of the left split
+        // Remove unmodified children of the left split and apply a generic container
         // TODO: create a utility for this
         let mut left = DomNode::Container(ContainerNode::new(
             S::default(),

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -17,7 +17,7 @@
 
 use crate::dom::nodes::ContainerNodeKind;
 use crate::dom::unicode_string::UnicodeStr;
-use crate::{DomHandle, DomNode, ToHtml, UnicodeString};
+use crate::{DomHandle, DomNode, UnicodeString};
 
 use super::action_list::{DomAction, DomActionList};
 use super::nodes::dom_node::DomNodeKind;
@@ -481,7 +481,7 @@ where
         ));
         left.set_handle(DomHandle::root());
 
-        // Reset the root unmodified siblings were removed
+        // Reset the handle roots after unmodified siblings were removed
         let mut right_handle =
             from_handle.sub_handle_down_from(depth).raw().to_owned();
         right_handle[0] = 0;
@@ -565,14 +565,13 @@ where
                             {
                                 // Do nothing
                             } else {
-                                // TODO: Figure out how to make this all less verbose
-                                let to_remove =
-                                    text_node.data()[offset..].to_owned();
-                                let to_keep =
+                                let left_data =
                                     text_node.data()[..offset].to_owned();
-                                text_node.set_data(to_keep);
+                                let right_data =
+                                    text_node.data()[offset..].to_owned();
+                                text_node.set_data(left_data);
                                 removed_nodes
-                                    .insert(0, DomNode::new_text(to_remove));
+                                    .insert(0, DomNode::new_text(right_data));
                             }
                         }
                         _ => {
@@ -700,7 +699,6 @@ fn adjust_handles_for_delete(
 mod test {
     use crate::dom::DomHandle;
     use crate::tests::testutils_composer_model::{cm, tx};
-    use crate::tests::testutils_conversion::utf16;
     use crate::ToHtml;
 
     use super::*;
@@ -872,7 +870,6 @@ mod test {
             .state
             .dom
             .split_new_sub_trees(&DomHandle::from_raw(vec![0, 1, 0]), 2, 1);
-        println!("RIGHT: {:?}", right);
         assert_eq!(right.to_html(), "<b>ld</b>");
         assert_eq!(right_handle, DomHandle::from_raw(vec![0, 0]));
         assert_eq!(right.lookup_node(&right_handle).to_html(), "ld");

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -216,44 +216,7 @@ where
     /// Find the node based on its handle.
     /// Panics if the handle is unset or invalid
     pub fn lookup_node(&self, node_handle: &DomHandle) -> &DomNode<S> {
-        fn nth_child<S>(element: &ContainerNode<S>, idx: usize) -> &DomNode<S>
-        where
-            S: UnicodeString,
-        {
-            element.children().get(idx).unwrap_or_else(|| {
-                panic!(
-                    "Handle is invalid: it refers to a child index ({}) which \
-                is too large for the number of children in this node ({:?}).",
-                    idx, element
-                )
-            })
-        }
-
-        let mut node = &self.document;
-        if !node_handle.is_set() {
-            panic!(
-                "Attempting to lookup a node using an unset DomHandle ({:?})",
-                node_handle.raw()
-            );
-        }
-        for idx in node_handle.raw() {
-            node = match node {
-                DomNode::Container(n) => nth_child(n, *idx),
-                DomNode::LineBreak(_) => panic!(
-                    "Handle is invalid: refers to the child of a line break, \
-                    but line breaks cannot have children."
-                ),
-                DomNode::Text(_) => panic!(
-                    "Handle {:?} is invalid: refers to the child of a text node, \
-                    but text nodes cannot have children.", node_handle
-                ),
-                DomNode::Zwsp(_) => panic!(
-                    "Handle {:?} is invalid: refers to the child of a zwsp node, \
-                    but zwsp nodes cannot have children.", node_handle
-                ),
-            }
-        }
-        node
+        &self.document_node().lookup_node(node_handle)
     }
 
     /// Find the node based on its handle and returns a mutable reference.

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -70,23 +70,20 @@ where
                 let (left, left_handle, right, right_handle) =
                     self.split_new_sub_trees(node, offset, shared_depth);
 
-                let mut inner = if location.ends_inside() {
-                    left.clone()
+                let mut outers = if location.ends_inside() {
+                    vec![right.lookup_node(&right_handle).clone()]
                 } else {
-                    right.clone()
+                    vec![left.lookup_node(&left_handle).clone()]
                 };
 
-                let outers =
-                    if location.ends_inside() && location.starts_inside() {
-                        let outer = right.lookup_node(&right_handle).clone();
-                        let offset = location.start_offset;
-                        let before = inner.slice_before(offset);
-                        vec![before, outer]
-                    } else if location.ends_inside() {
-                        vec![right.lookup_node(&right_handle).clone()]
-                    } else {
-                        vec![left.lookup_node(&left_handle).clone()]
-                    };
+                let mut inner =
+                    if location.ends_inside() { left } else { right };
+
+                if location.ends_inside() && location.starts_inside() {
+                    let offset = location.start_offset;
+                    let before = inner.slice_before(offset);
+                    outers.insert(0, before)
+                }
 
                 container.insert_child(0, inner);
                 self.replace(node, outers);

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -1,0 +1,271 @@
+use crate::{DomHandle, DomNode, UnicodeString};
+
+use super::{Dom, Range};
+
+impl<S> Dom<S>
+where
+    S: UnicodeString,
+{
+    #[allow(dead_code)]
+    /// Insert a node and make this node the parent of a given range.
+    pub fn insert_parent(&mut self, range: &Range, mut new_node: DomNode<S>) {
+        #[cfg(any(test, feature = "assert-invariants"))]
+        self.assert_invariants();
+
+        if range.is_empty() {
+            panic!("Cannot add a parent to an empty range");
+        }
+
+        if !matches!(new_node, DomNode::Container(_)) {
+            panic!("New node is not a container");
+        }
+        // Check if the range has shared ancestry. The new parent node should not contain
+        // these nodes, so filter them from the range.
+        let shared_depth = range.shared_parent().depth();
+        let range = Range::new(range.locations_from_depth(shared_depth));
+
+        // Prepare the new parent node to have the selected range moved into it:
+        // - Set the new node's handle to the start of the range
+        // - Get the mutable container node to move the selected range into
+        let new_handle: DomHandle = range.node_handles().min().unwrap().clone();
+        let new_handle = if range.leaves().min().unwrap().is_covered() {
+            new_handle
+        } else {
+            // If the first leaf in the range is completely covered, then leave space
+            // for the first part of the existing split leaf.
+            new_handle.next_sibling()
+        };
+        new_node.set_handle(new_handle.clone());
+        let container = new_node.as_container_mut().unwrap();
+
+        // Remove the selected nodes from the DOM and add them to the new container
+        for location in range.locations.iter().rev() {
+            let node = &location.node_handle;
+
+            // If the location is covered, it can be moved to the container.
+            if location.is_covered() {
+                // Ignore children of covered nodes which are moved in their parents.
+                if node.depth() != shared_depth + 1 {
+                    continue;
+                }
+                let node = self.remove(node);
+                container.insert_child(0, node);
+            }
+            // ... else handle partially covered nodes
+            else {
+                // If the a leaf is partially included at the start of the range, split the tree
+                // and add the end part to the new container.
+                // If the leaf is partially included at the end of the range, split the tree and
+                // add the start part to the new container.
+                if !self.lookup_node(node).is_leaf() {
+                    continue;
+                }
+
+                let offset = if location.ends_inside() {
+                    location.end_offset
+                } else {
+                    location.start_offset
+                };
+
+                let (left, left_handle, right, right_handle) =
+                    self.split_new_sub_trees(node, offset, shared_depth);
+
+                let mut inner = if location.ends_inside() {
+                    left.clone()
+                } else {
+                    right.clone()
+                };
+
+                let outers =
+                    if location.ends_inside() && location.starts_inside() {
+                        let outer = right.lookup_node(&right_handle).clone();
+                        let offset = location.start_offset;
+                        let before = inner.slice_before(offset);
+                        vec![before, outer]
+                    } else if location.ends_inside() {
+                        vec![right.lookup_node(&right_handle).clone()]
+                    } else {
+                        vec![left.lookup_node(&left_handle).clone()]
+                    };
+
+                container.insert_child(0, inner);
+                self.replace(node, outers);
+            }
+        }
+
+        // Insert the new container into the DOM
+        self.insert_at(&new_handle, new_node);
+
+        #[cfg(any(test, feature = "assert-invariants"))]
+        self.assert_invariants();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        tests::{testutils_composer_model::cm, testutils_conversion::utf16},
+        DomNode, ToHtml,
+    };
+
+    #[test]
+    fn insert_parent_flat_part() {
+        let mut model = cm("A{B}|C");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(model.state.dom.to_html(), r#"A<a href="link">B</a>C"#)
+    }
+
+    #[test]
+    fn insert_parent_flat_whole() {
+        let mut model = cm("{ABC}|");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(model.state.dom.to_html(), r#"<a href="link">ABC</a>"#)
+    }
+
+    #[test]
+    fn insert_parent_simple() {
+        let mut model = cm("{<b>AB</b><i><u>C</u></i>}|");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(
+            model.state.dom.to_html(),
+            r#"<a href="link"><b>AB</b><i><u>C</u></i></a>"#
+        )
+    }
+
+    #[test]
+    fn insert_parent_ignores_adjacent_nodes() {
+        let mut model = cm("X{<b>AB</b><i><u>C</u></i>}|<u>D</u>");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(
+            model.state.dom.to_html(),
+            r#"X<a href="link"><b>AB</b><i><u>C</u></i></a><u>D</u>"#
+        )
+    }
+
+    #[test]
+    fn insert_parent_splits_single_partially_covered_node() {
+        let mut model = cm("<b><u>XX{ABC}|YY</u></b>");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(
+            model.state.dom.to_html(),
+            r#"<b><u>XX<a href="link">ABC</a>YY</u></b>"#
+        )
+    }
+
+    #[test]
+    fn insert_parent_splits_multiple_partially_covered_nodes() {
+        let mut model = cm("XX{A<b>B</b><u>C}|YY</u>");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(
+            model.state.dom.to_html(),
+            r#"XX<a href="link">A<b>B</b><u>C</u></a><u>YY</u>"#
+        )
+    }
+
+    #[test]
+    fn insert_parent_splits_multiple_nested_partially_covered_nodes() {
+        let mut model = cm("<i><u>X{X</u>ABC<b>Y}|Y</b></i>");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(
+            model.state.dom.to_html(),
+            r#"<i><u>X</u><a href="link"><u>X</u>ABC<b>Y</b></a><b>Y</b></i>"#
+        )
+    }
+
+    #[test]
+    fn insert_parent_ignores_shared_parent_nodes() {
+        let mut model = cm("<i><em>XX{A<b>B</b><u>C}|YY</u></em></i>");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(
+            model.state.dom.to_html(),
+            r#"<i><em>XX<a href="link">A<b>B</b><u>C</u></a><u>YY</u></em></i>"#
+        )
+    }
+
+    #[test]
+    fn insert_parent_ignores_shared_parent_nodes_with_siblings() {
+        let mut model =
+            cm("<u>U</u><i><em>XX{A<b>B</b><u>C}|YY</u></em></i><u>W</u>");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(
+            model.state.dom.to_html(),
+            r#"<u>U</u><i><em>XX<a href="link">A<b>B</b><u>C</u></a><u>YY</u></em></i><u>W</u>"#
+        )
+    }
+
+    #[test]
+    #[should_panic]
+    fn insert_parent_panics_if_new_is_not_container() {
+        let mut model = cm("{X}|");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_text(utf16("not a container")));
+    }
+}

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -311,6 +311,49 @@ where
             DomNode::Zwsp(_) => panic!("Can't slice a zwsp"),
         }
     }
+
+    /// Find the node based on its handle.
+    /// Panics if the handle is unset or invalid
+    pub fn lookup_node(&self, node_handle: &DomHandle) -> &DomNode<S> {
+        fn nth_child<S>(element: &ContainerNode<S>, idx: usize) -> &DomNode<S>
+        where
+            S: UnicodeString,
+        {
+            element.children().get(idx).unwrap_or_else(|| {
+                panic!(
+                    "Handle is invalid: it refers to a child index ({}) which \
+                is too large for the number of children in this node ({:?}).",
+                    idx, element
+                )
+            })
+        }
+
+        let mut node = self;
+        if !node_handle.is_set() {
+            panic!(
+                "Attempting to lookup a node using an unset DomHandle ({:?})",
+                node_handle.raw()
+            );
+        }
+        for idx in node_handle.raw() {
+            node = match node {
+                DomNode::Container(n) => nth_child(n, *idx),
+                DomNode::LineBreak(_) => panic!(
+                    "Handle is invalid: refers to the child of a line break, \
+                    but line breaks cannot have children."
+                ),
+                DomNode::Text(_) => panic!(
+                    "Handle {:?} is invalid: refers to the child of a text node, \
+                    but text nodes cannot have children.", node_handle
+                ),
+                DomNode::Zwsp(_) => panic!(
+                    "Handle {:?} is invalid: refers to the child of a zwsp node, \
+                    but zwsp nodes cannot have children.", node_handle
+                ),
+            }
+        }
+        node
+    }
 }
 
 impl<S> ToHtml<S> for DomNode<S>

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -14,6 +14,7 @@
 
 use crate::tests::testutils_composer_model::{cm, tx};
 use crate::tests::testutils_conversion::utf16;
+use crate::Location;
 
 #[test]
 fn set_link_to_empty_selection_at_end_of_alink() {

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -14,7 +14,6 @@
 
 use crate::tests::testutils_composer_model::{cm, tx};
 use crate::tests::testutils_conversion::utf16;
-use crate::Location;
 
 #[test]
 fn set_link_to_empty_selection_at_end_of_alink() {


### PR DESCRIPTION
## What?
Adds a DOM method to insert a parent node around a range.

## Why?
Currently, when adding a hyperlink to a range, it is done by applying the link to every leaf in the range. In order to wrap the leaves at a higher level in the tree, it'd be useful to have a method at the Dom level to insert a parent node around a rnage.

## What does this look like?
Take for example the following HTML with selection indicated by `{`, `}` and cursor by `|`.

```
<i><b>Hel{lo</b><u>formatted</u>wor}|ld</i>
```

It's now possible to insert a link around the range like so:


```mermaid
graph TD
classDef default stroke:#000
classDef hello fill:#ffa
classDef formatted fill:#faf
classDef world fill:#aff
classDef link fill:#cfa,stroke-width:4px

Dom[Dom before] --> Italic
Italic --> Bold
Italic --> Underline
Italic --> World:::world
Bold:::hello --> Hello
Underline:::formatted --> Formatted
Hello["&quot;Hello&quot;"]:::hello
Formatted["&quot;formatted&quot;"]:::formatted
World["&quot;world&quot;"]:::split

Dom2[Dom after] --> Italic2[Italic]
Italic2 --> Bold2a[Bold]
Bold2a:::hello --> Hello2a
Italic2 --> Link
Link:::link --> Bold2b[Bold]
Link --> Underline2
Link --> World2a
Italic2 --> World2b
Bold2b:::hello --> Hello2b
Underline2[Underline]:::formatted --> Formatted2
Hello2a["&quot;Hel&quot;"]:::hello
Hello2b["&quot;lo&quot;"]:::hello
Formatted2["&quot;formatted&quot;"]:::formatted
World2a["&quot;wor&quot;"]:::world
World2b["&quot;ld&quot;"]:::world
```