### PR TITLE
Amend conversion functions

### DIFF
--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -61,18 +61,39 @@ describe('Rich text <=> plain text', () => {
 });
 
 describe('Plain text <=> markdown', () => {
-    it('converts linebreaks for plain => markdown', () => {
+    it('converts single linebreak for plain => markdown', () => {
         const plain = 'multi\nline';
         const convertedMarkdown = plainToMarkdown(plain);
-        const expectedMarkdown = `multi<br />\nline`;
+        const expectedMarkdown = `multi<br />line`;
 
         expect(convertedMarkdown).toBe(expectedMarkdown);
     });
 
-    it('converts linebreaks for markdown => plain', () => {
+    it('converts multiple linebreak for plain => markdown', () => {
+        // nb for correct display, there will be one br tag less
+        // than \n at the end
+        const plain = 'multiple\nline\n\nbreaks\n\n\n';
+        const convertedMarkdown = plainToMarkdown(plain);
+        const expectedMarkdown =
+            'multiple<br />line<br /><br />breaks<br /><br />';
+
+        expect(convertedMarkdown).toBe(expectedMarkdown);
+    });
+
+    it('converts single linebreak for markdown => plain', () => {
         const markdown = 'multi\\\nline';
         const convertedPlainText = markdownToPlain(markdown);
         const expectedPlainText = 'multi\nline';
+
+        expect(convertedPlainText).toBe(expectedPlainText);
+    });
+
+    it('converts multiple linebreak for markdown => plain', () => {
+        // nb for correct display, there will be one \n more
+        // than \\\n at the end
+        const markdown = 'multiple\\\nline\\\n\\\nbreaks\\\n\\\n\\\n';
+        const convertedPlainText = markdownToPlain(markdown);
+        const expectedPlainText = 'multiple\nline\n\nbreaks\n\n\n\n';
 
         expect(convertedPlainText).toBe(expectedPlainText);
     });

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -21,17 +21,31 @@ import {
 } from '../generated/wysiwyg.js';
 import { initOnce } from './useComposerModel.js';
 
-// in plain text, newlines will be represented as \n if input
-// by the user pressing enter, so we want to convert these to
-// valid markdown before parsing by MarkdownHTMLParser::to_html
-export const plainToMarkdown = (plainText: string) =>
-    plainText.replaceAll(/\n/g, '<br />\n');
+// In plain text there, due to cursor positioning, ending at a linebreak will
+// include an extra \n, so trim that off if required.
+// We replace the remaining \n with valid markdown before
+// parsing by MarkdownHTMLParser::to_html.
+export const plainToMarkdown = (plainText: string) => {
+    let markdown = plainText;
+    if (markdown.endsWith('\n')) {
+        // manually remove the final linebreak
+        markdown = markdown.slice(0, -1);
+    }
+    return markdown.replaceAll(/\n/g, '<br />');
+};
 
-// in plain text, markdown newlines (displays '\' character followed by
+// In plain text, markdown newlines (displays '\' character followed by
 // a newline character) will be represented as \n for display as the
-// display box can not interpret markdown
-export const markdownToPlain = (markdown: string) =>
-    markdown.replaceAll(/\\/g, '');
+// display box can not interpret markdown.
+// We also may need to manually add a \n to account for trailing newlines.
+export const markdownToPlain = (markdown: string) => {
+    let plainText = markdown;
+    if (plainText.endsWith('\n')) {
+        // for cursor positioning we need to manually add another linebreak
+        plainText = `${plainText}\n`;
+    }
+    return plainText.replaceAll(/\\/g, '');
+};
 
 export async function richToPlain(richText: string) {
     if (richText.length === 0) {


### PR DESCRIPTION
Amends the functions used for converting between rich and plain text in web. 

Corrects issue with trailing newlines when switching between rich and plain with the setting enabled that makes enter insert newlines, as opposed to sending the message.