### PR TITLE
Add conversion types to vite config

### DIFF
--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
         dts({
             include: [
                 'lib/useWysiwyg.ts',
+                'lib/conversion.ts',
                 'lib/types.ts',
                 'lib/constants.ts',
                 'lib/useListeners/types.ts',


### PR DESCRIPTION
Did not export the types for the conversion utils, so this adds the file path to the vite config to include them.