### PR TITLE
Update link behaviour to wrap existing elements

### DIFF
--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -66,7 +66,7 @@ where
         let mut range = self.state.dom.find_range(s, e);
 
         // Find container link that completely covers the range
-        if let Some(link) = self.find_parent_links(&range) {
+        if let Some(link) = self.find_closest_ancestor_link(&range) {
             // If found, update the range to the container link bounds
             range = self.state.dom.find_range_by_node(&link);
             (s, e) = (range.start(), range.end());
@@ -103,7 +103,10 @@ where
         }
     }
 
-    fn find_parent_links(&mut self, range: &Range) -> Option<DomHandle> {
+    fn find_closest_ancestor_link(
+        &mut self,
+        range: &Range,
+    ) -> Option<DomHandle> {
         let mut parent_handle = range.shared_parent_outside();
         while !parent_handle.is_root() {
             let node = self.state.dom.lookup_node(&parent_handle);

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -104,7 +104,7 @@ where
     }
 
     fn find_parent_links(&mut self, range: &Range) -> Option<DomHandle> {
-        let mut parent_handle = range.shared_parent();
+        let mut parent_handle = range.shared_parent_outside();
         while !parent_handle.is_root() {
             let node = self.state.dom.lookup_node(&parent_handle);
             let container = match node {

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -189,7 +189,7 @@ where
         let leaves = locations.iter().filter(|l| l.is_leaf());
 
         let s = leaves.clone().map(|l| l.position).min().unwrap();
-        let e = leaves.clone().map(|l| l.position + l.length).max().unwrap();
+        let e = leaves.map(|l| l.position + l.length).max().unwrap();
 
         self.find_range(s, e)
     }

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -117,10 +117,10 @@ where
         &mut self,
         node_handle: &DomHandle,
         node: DomNode<S>,
-    ) -> &DomNode<S> {
+    ) -> DomHandle {
         let parent = self.parent_mut(node_handle);
         let index = node_handle.index_in_parent();
-        parent.insert_child(index, node)
+        parent.insert_child(index, node).handle()
     }
 
     /// Insert given [nodes] in order at the [node_handle] position,

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -179,7 +179,7 @@ where
     }
 
     pub fn find_range_by_node(&self, node_handle: &DomHandle) -> Range {
-        let result = find_range::find_pos(self, &node_handle, 0, usize::MAX);
+        let result = find_range::find_pos(self, node_handle, 0, usize::MAX);
 
         let locations = match result {
             FindResult::Found(locations) => locations,
@@ -820,6 +820,25 @@ mod test {
         // Last level doesn't exist, [0, 0, 1] does not have 6 children
         let handle = DomHandle::from_raw(vec![0, 0, 1, 5]);
         assert!(!d.contains(&handle));
+    }
+
+    #[test]
+    fn find_range_by_node() {
+        let d = cm("<b><u>Hello, <i>world|</i></u></b>").state.dom;
+        let range_by_node =
+            d.find_range_by_node(&DomHandle::from_raw(vec![0, 0, 0]));
+        let actual_range = d.find_range(0, 7);
+
+        assert_eq!(range_by_node, actual_range);
+    }
+
+    #[test]
+    fn find_range_by_node_root() {
+        let d = cm("<b><u>Hello, <i>world|</i></u></b>").state.dom;
+        let range_by_node = d.find_range_by_node(&DomHandle::root());
+        let actual_range = d.find_range(0, 12);
+
+        assert_eq!(range_by_node, actual_range);
     }
 
     const NO_CHILDREN: &Vec<DomNode<Utf16String>> = &Vec::new();

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -23,6 +23,8 @@ use crate::dom::{
 };
 use crate::ToHtml;
 
+use super::FindResult;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Dom<S>
 where
@@ -174,6 +176,22 @@ where
     /// selected. The returned range lists all the Dom nodes involved.
     pub fn find_range(&self, start: usize, end: usize) -> Range {
         find_range::find_range(self, start, end)
+    }
+
+    pub fn find_range_by_node(&self, node_handle: &DomHandle) -> Range {
+        let result = find_range::find_pos(self, &node_handle, 0, usize::MAX);
+
+        let locations = match result {
+            FindResult::Found(locations) => locations,
+            _ => panic!("Node does not exist"),
+        };
+
+        let leaves = locations.iter().filter(|l| l.is_leaf());
+
+        let s = leaves.clone().map(|l| l.position).min().unwrap();
+        let e = leaves.clone().map(|l| l.position + l.length).max().unwrap();
+
+        self.find_range(s, e)
     }
 
     pub(crate) fn document_handle(&self) -> DomHandle {

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -291,6 +291,23 @@ mod test {
     }
 
     #[test]
+    fn insert_parent_includes_covered_shared_parent_nodes() {
+        let mut model = cm("<i><em>{A<b>B</b><u>C</u>}|</em>D</i>");
+        let (start, end) = model.safe_selection();
+        let range = model.state.dom.find_range(start, end);
+
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+
+        assert_eq!(
+            model.state.dom.to_html(),
+            r#"<i><a href="link"><em>A<b>B</b><u>C</u></em></a>D</i>"#
+        )
+    }
+
+    #[test]
     #[should_panic]
     fn insert_parent_panics_if_new_is_not_container() {
         let mut model = cm("{X}|");

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -25,7 +25,7 @@ where
         }
         // Check if the range has shared ancestry. The new parent node should not contain
         // these nodes, so filter them from the range.
-        let shared_depth = range.shared_parent().depth();
+        let shared_depth = range.shared_parent_outside().depth();
         let range = Range::new(range.locations_from_depth(shared_depth));
 
         // Prepare the new parent node to have the selected range moved into it:

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -8,7 +8,11 @@ where
 {
     #[allow(dead_code)]
     /// Insert a node and make this node the parent of a given range.
-    pub fn insert_parent(&mut self, range: &Range, mut new_node: DomNode<S>) {
+    pub fn insert_parent(
+        &mut self,
+        range: &Range,
+        mut new_node: DomNode<S>,
+    ) -> DomHandle {
         #[cfg(any(test, feature = "assert-invariants"))]
         self.assert_invariants();
 
@@ -94,10 +98,12 @@ where
         }
 
         // Insert the new container into the DOM
-        self.insert_at(&new_handle, new_node);
+        let inserted = self.insert_at(&new_handle, new_node);
 
         #[cfg(any(test, feature = "assert-invariants"))]
         self.assert_invariants();
+
+        inserted
     }
 }
 

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -310,9 +310,24 @@ impl Range {
             }
 
             shared_path.push(min_leaf_path[i]);
+
+            let location =
+                self.find_location(&DomHandle::from_raw(shared_path.clone()));
+
+            if location.is_covered() {
+                shared_path.pop();
+                break;
+            }
         }
 
         DomHandle::from_raw(shared_path)
+    }
+
+    fn find_location(&self, node_handle: &DomHandle) -> &DomLocation {
+        self.locations
+            .iter()
+            .find(|l| *l.node_handle.raw() == *node_handle.raw())
+            .unwrap()
     }
 }
 
@@ -514,8 +529,8 @@ mod test {
 
     #[test]
     fn range_shared_parent() {
-        let range = range_of("<em><strong><b>{a</b>b}|</strong></em>");
-        assert_eq!(range.shared_parent(), DomHandle::from_raw(vec![0, 0]));
+        let range = range_of("<em><strong><b>{a</b>b}|</strong>c</em>");
+        assert_eq!(range.shared_parent(), DomHandle::from_raw(vec![0]));
     }
 
     #[test]
@@ -527,7 +542,7 @@ mod test {
     #[test]
     fn range_shared_parent_deep_flat() {
         let range = range_of("<em><strong>{ab}|</strong></em>");
-        assert_eq!(range.shared_parent(), DomHandle::from_raw(vec![0, 0]));
+        assert_eq!(range.shared_parent(), DomHandle::from_raw(vec![]));
     }
 
     fn range_of(model: &str) -> Range {

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -60,7 +60,7 @@ fn set_link_in_multiple_leaves_of_formatted_text() {
     model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
-        "<i><a href=\"https://element.io\">test_italic</a><b><a href=\"https://element.io\">test_italic_bold</a></b></i>"
+        "<a href=\"https://element.io\"><i>test_italic<b>test_italic_bold</b></i></a>"
     )
 }
 
@@ -70,7 +70,7 @@ fn set_link_in_multiple_leaves_of_formatted_text_partially_covered() {
     model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
-        "<i>test_it<a href=\"https://element.io\">alic</a><b><a href=\"https://element.io\">test_ital</a>ic_bold</b></i>"
+        "<i>test_it<a href=\"https://element.io\">alic<b>test_ital</b></a><b>ic_bold</b></i>"
     )
 }
 
@@ -80,7 +80,7 @@ fn set_link_in_multiple_leaves_of_formatted_text_partially_covered_2() {
     model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
-        "<i><u>test_it<a href=\"https://element.io\">alic_underline</a></u><a href=\"https://element.io\">test_italic</a><b><a href=\"https://element.io\">test_ital</a>ic_bold</b></i>"
+        "<i><u>test_it</u><a href=\"https://element.io\"><u>alic_underline</u>test_italic<b>test_ital</b></a><b>ic_bold</b></i>"
     )
 }
 
@@ -111,7 +111,7 @@ fn set_link_in_text_and_already_linked_text() {
     model.set_link(utf16("https://matrix.org"));
     assert_eq!(
         model.state.dom.to_string(),
-        "<a href=\"https://matrix.org\">non_link_text</a><a href=\"https://matrix.org\">link_text</a>"
+        "<a href=\"https://matrix.org\">non_link_textlink_text</a>"
     )
 }
 
@@ -121,8 +121,45 @@ fn set_link_in_multiple_leaves_of_formatted_text_with_link() {
     model.set_link(utf16("https://matrix.org"));
     assert_eq!(
         model.state.dom.to_string(),
-        "<i><a href=\"https://matrix.org\">test_italic</a><b><a href=\"https://matrix.org\">test_italic_bold</a></b></i>"
+        "<a href=\"https://matrix.org\"><i>test_italic<b>test_italic_bold</b></i></a>"
     )
+}
+
+#[test]
+fn set_link_partially_highlighted_inside_a_link_and_starting_inside() {
+    let mut model = cm("<a href=\"https://element.io\">test_{link</a> test}|");
+    model.set_link(utf16("https://matrix.org"));
+    assert_eq!(
+        tx(&model),
+        r#"<a href="https://element.io">test_</a><a href="https://matrix.org">{link test}|</a>"#
+    );
+}
+
+#[test]
+fn set_link_partially_highlighted_inside_a_link_and_starting_before() {
+    let mut model = cm("{test <a href=\"https://element.io\">test}|_link</a>");
+    model.set_link(utf16("https://matrix.org"));
+    assert_eq!(
+        tx(&model),
+        r#"<a href="https://matrix.org">{test test}|</a><a href="https://element.io">_link</a>"#
+    );
+}
+
+#[test]
+fn set_link_highlighted_inside_a_link() {
+    let mut model = cm("<a href=\"https://element.io\">test {test}| test</a>");
+    model.set_link(utf16("https://matrix.org"));
+    assert_eq!(
+        tx(&model),
+        r#"<a href="https://matrix.org">test {test}| test</a>"#
+    );
+}
+
+#[test]
+fn set_link_around_links() {
+    let mut model = cm(r#"{X <a href="linkA">A</a> <a href="linkB">B</a> Y}|"#);
+    model.set_link(utf16("https://matrix.org"));
+    assert_eq!(tx(&model), r#"<a href="https://matrix.org">{X A B Y}|</a>"#);
 }
 
 #[test]


### PR DESCRIPTION
## What?

Allow links to wrap other elements.

### Example
Given the following editor content:
```
<b><u>Hello</u> <i>world</i></b>
```
When applying a link to the whole range, previously you'd end up with:
```
<b><u><a href="">Hello</a></u> <i><a href="">world</a></i></b>
```
Now, only one link tag is created:
```
<a href=""><b><u>Hello</u> <i>world</i></b></a>
```
### Notes
- This change does not pay much attention to the case where the selection touches existing links (see [`PSU-997`](https://element-io.atlassian.net/browse/PSU-997)). But note that the behaviour is slightly different
  - links can now be split just like any other element (previously, the whole link was edited).
  - links that completely contain the selection, are edited.
- This change does not affect insertion (i.e. creating new text with a link)

## Why?
This simplifies the document model and reduces the number of duplicate tags, making the ability to edit links simpler.


## See
- [`PSU-997`](https://element-io.atlassian.net/browse/PSU-997)
- https://github.com/matrix-org/matrix-rich-text-editor/pull/415