### PR TITLE
iOS automation improvement

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 env:
-  GH_TOKEN: ${{ secrets.SWIFTPM_GH_TOKEN }}
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.jvm.options="-Xmx2560m" -Dkotlin.incremental=false
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 4 --no-daemon
   ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/release_ios.sh
+++ b/release_ios.sh
@@ -50,12 +50,8 @@ git commit -m "release $last_commit"
 if [ "$TAG" != "" ]; then
   echo "found a tag $TAG"]
   REMOTE_BRANCH_NAME="release_v_$TAG"
-  BODY="Remember when merging to substitute the default commit message with the branch/PR name to perform auto-tag on main"
 else
   echo "tag not found"
   REMOTE_BRANCH_NAME=${RELEASE_BRANCH}
-  BODY=""
 fi
 git push origin $RELEASE_BRANCH:$REMOTE_BRANCH_NAME
-# if you have github cli installed this will create the PR automatically
-gh pr create -B main -H $REMOTE_BRANCH_NAME -r matrix.org/professional-services-uk -t $REMOTE_BRANCH_NAME -b "$BODY"


### PR DESCRIPTION
In this final improvement we don't need to open the PR through gh from this repo anymore, because I set up a workflow on the swiftpm repo that does that for us every time a "release_*" branch is pushed on it.
This means that the PRs will be opened by using the github workflow bot.
This also means that we can now remove the GH_TOKEN usage