### PR TITLE
Use defaults where appropriate

### DIFF
--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -47,7 +47,7 @@ where
 {
     pub fn new() -> Self {
         let mut instance = Self {
-            state: ComposerState::new(),
+            state: ComposerState::default(),
             previous_states: Vec::new(),
             next_states: Vec::new(),
             action_states: HashMap::new(), // TODO: Calculate state based on ComposerState

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -671,7 +671,7 @@ mod test {
     fn tx_formats_empty_model() {
         let model: ComposerModel<Utf16String> =
             ComposerModel::from_state(ComposerState {
-                dom: Dom::new(Vec::new()),
+                dom: Dom::default(),
                 start: Location::from(1),
                 end: Location::from(1),
                 toggled_format_types: Vec::new(),

--- a/crates/wysiwyg/src/composer_state.rs
+++ b/crates/wysiwyg/src/composer_state.rs
@@ -32,9 +32,9 @@ where
 {
     pub fn new() -> Self {
         Self {
-            dom: Dom::new(Vec::new()),
-            start: Location::from(0),
-            end: Location::from(0),
+            dom: Dom::default(),
+            start: Location::default(),
+            end: Location::default(),
             toggled_format_types: Vec::new(),
         }
     }

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -38,12 +38,8 @@ where
     S: UnicodeString,
 {
     pub fn new(top_level_items: Vec<DomNode<S>>) -> Self {
-        let mut document = ContainerNode::new(
-            S::default(),
-            ContainerNodeKind::Generic,
-            None,
-            top_level_items,
-        );
+        let mut document = ContainerNode::default();
+        document.append_children(top_level_items);
         document.set_handle(DomHandle::from_raw(Vec::new()));
 
         Self {

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -15,7 +15,7 @@
 use std::fmt::Display;
 
 use crate::composer_model::example_format::SelectionWriter;
-use crate::dom::nodes::{ContainerNode, ContainerNodeKind, DomNode};
+use crate::dom::nodes::{ContainerNode, DomNode};
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -168,6 +168,12 @@ where
         child_handle
     }
 
+    pub fn append_children(&mut self, children: Vec<DomNode<S>>) {
+        for child in children {
+            self.append_child(child);
+        }
+    }
+
     pub fn remove_child(&mut self, index: usize) -> DomNode<S> {
         assert!(self.handle.is_set());
         assert!(index < self.children().len());


### PR DESCRIPTION
Recent work to fix clippy warnings and errors introduced manual defaults in the DomNode and ContainerNode files, as well as deriving defaults where possible.

This work uses the newly derived/specified defaults in the places I thought appropriate. To reduce repetition, it also adds an `add_children` method to tidy up creating a new container node (as it was effectively just creating a default but with a few children appended).