### PR TITLE
Fix creating a list from an empty text node

### DIFF
--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -263,13 +263,16 @@ where
         let first_node = self.state.dom.lookup_node(first_handle);
         // It's expected to add a ZWSP for each line break + an additional leading ZWSP.
         // end_correction is always 1, start_correction is 1 only if the start is located
-        // strictly after the first char of the range. If a leading ZWSP is already present,
-        // e.g. the node following another list both corrections are 0.
+        // strictly after the first char of the range (or if we are creating a list from an
+        // empty text node, in that case the first node text_len is 0). If a leading ZWSP
+        // is already present, e.g. the node following another list both corrections are 0.
         if first_node.has_leading_zwsp() {
             start_correction = 0;
             end_correction = 0;
         } else {
-            start_correction = usize::from(s - range.start() > 0);
+            start_correction = usize::from(
+                s - range.start() > 0 || first_node.text_len() == 0,
+            );
             end_correction = 1;
         }
 

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -53,7 +53,9 @@ where
             list_items.insert(0, DomNode::Container(sliced));
         }
 
-        if list_item.text_len() > 0 {
+        // Create a list item if we have a non-empty part remaining, or
+        // if it's the only part we have (empty list case).
+        if list_item.text_len() > 0 || list_items.is_empty() {
             list_item.add_leading_zwsp();
             list_items.insert(0, DomNode::Container(list_item));
         }

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -107,7 +107,11 @@ impl DomLocation {
 
     /// Returns the relative position of this DomLocation towards the range.
     pub fn relative_position(&self) -> DomLocationPosition {
-        if self.start_offset == self.length {
+        if self.length == 0 {
+            // Note: this should only trigger on an initial/single empty text node.
+            // Other nodes are not allowed to have a length of 0.
+            DomLocationPosition::Inside
+        } else if self.start_offset == self.length {
             DomLocationPosition::Before
         } else if self.end_offset == 0 {
             DomLocationPosition::After

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -400,6 +400,15 @@ fn creating_list_from_multiline_selection_with_cross_leading_formatting() {
     )
 }
 
+#[test]
+fn backspacing_in_empty_list_then_creating_a_new_list() {
+    let mut model = cm("<ol><li>~|</li></ol>");
+    model.backspace();
+    assert_eq!(tx(&model), "|");
+    model.unordered_list();
+    assert_eq!(tx(&model), "<ul><li>~|</li></ul>");
+}
+
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {
     model.replace_text(utf16(new_text));
 }


### PR DESCRIPTION
Depending on previous operations (e.g. backspace), an empty model could either be no nodes at all, or an initial empty text node (text is `""`). 
This fix ensures that in both cases we are able to recreate a list properly.

Fixes #432 