### PR TITLE
Fix special/extra character handling on Android

### DIFF
--- a/platforms/android/.idea/.name
+++ b/platforms/android/.idea/.name
@@ -1,1 +1,1 @@
-WYSIWYG
+Rich Text Editor

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/HtmlToSpansParserTest.kt
@@ -1,10 +1,10 @@
 package io.element.android.wysiwyg.test.utils
 
-import android.text.TextUtils
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.wysiwyg.utils.AndroidResourcesProvider
 import io.element.android.wysiwyg.utils.HtmlToSpansParser
+import io.element.android.wysiwyg.utils.ZWSP
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
@@ -42,12 +42,12 @@ class HtmlToSpansParserTest {
     fun testLists() {
         val html = """
             <ol>
-                <li>ordered1</li>
-                <li>ordered2</li>
+                <li>${ZWSP}ordered1</li>
+                <li>${ZWSP}ordered2</li>
             </ol>
-            <ul>
-                <li>bullet1</li>
-                <li>bullet2</li>
+            <ul> 
+                <li>${ZWSP}bullet1</li>
+                <li>${ZWSP}bullet2</li>
             </ul>
         """.trimIndent()
         val spanned = convertHtml(html)
@@ -56,13 +56,12 @@ class HtmlToSpansParserTest {
         assertThat(
             spanned.dumpSpans(), equalTo(
                 listOf(
-                    "\u200B: io.element.android.wysiwyg.spans.ExtraCharacterSpan (0-1) fl=#33",
-                    "\u200Bordered1: io.element.android.wysiwyg.spans.OrderedListSpan (0-9) fl=#33",
+                    "${ZWSP}ordered1: io.element.android.wysiwyg.spans.OrderedListSpan (0-9) fl=#33",
                     "\n: io.element.android.wysiwyg.spans.ExtraCharacterSpan (9-10) fl=#33",
-                    "ordered2: io.element.android.wysiwyg.spans.OrderedListSpan (10-18) fl=#33",
-                    "bullet1: android.text.style.BulletSpan (19-26) fl=#33",
-                    "\n: io.element.android.wysiwyg.spans.ExtraCharacterSpan (26-27) fl=#33",
-                    "bullet2: android.text.style.BulletSpan (27-34) fl=#33"
+                    "${ZWSP}ordered2: io.element.android.wysiwyg.spans.OrderedListSpan (10-19) fl=#33",
+                    "${ZWSP}bullet1: android.text.style.BulletSpan (20-28) fl=#33",
+                    "\n: io.element.android.wysiwyg.spans.ExtraCharacterSpan (28-29) fl=#33",
+                    "${ZWSP}bullet2: android.text.style.BulletSpan (29-37) fl=#33"
                 )
             )
         )

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/ZeroWidthSpace.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/ZeroWidthSpace.kt
@@ -1,0 +1,6 @@
+package io.element.android.wysiwyg.utils
+
+/**
+ * Zero width space character used internally to delimit list items and block containers.
+ */
+const val ZWSP: Char = '\u200B'

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/EditorIndexMapperTests.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/EditorIndexMapperTests.kt
@@ -64,6 +64,24 @@ class EditorIndexMapperTests {
     }
     //endregion
 
+    // region Index at/before an extra character
+    @Test
+    fun `given an index before an extra character, when using fromEditorToComposer, then the indexes have an offset`() {
+        val index = 22
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(index, index, editableText)!!
+        Assert.assertEquals(index, newStart.toInt())
+        Assert.assertEquals(index, newEnd.toInt())
+    }
+
+    @Test
+    fun `given an index at an extra character, when using fromEditorToComposer, then the indexes have an offset`() {
+        val index = 23
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(index, index, editableText)!!
+        Assert.assertEquals(index, newStart.toInt())
+        Assert.assertEquals(index, newEnd.toInt())
+    }
+    // endregion
+
     // region Index after an extra character
     @Test
     fun `given an index with an extra character before it, when using fromComposerToEditor, then the indexes have an offset`() {
@@ -79,6 +97,14 @@ class EditorIndexMapperTests {
         val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(index, index, editableText)!!
         Assert.assertEquals(index-1, newStart.toInt())
         Assert.assertEquals(index-1, newEnd.toInt())
+    }
+
+    @Test
+    fun `given an index with an extra character immediately before it, when using fromEditorToComposer, then the indexes have an offset`() {
+        val index = 24
+        val (newStart, newEnd) = EditorIndexMapper.fromEditorToComposer(index, index, editableText)!!
+        Assert.assertEquals(index - 1, newStart.toInt())
+        Assert.assertEquals(index - 1, newEnd.toInt())
     }
     // endregion
 


### PR DESCRIPTION
## What?
- **Fix editor/model index mapping**
   Fixes the edge case where the cursor is at an extra new line character. In this case, the new calculation reflects that the extra character is neither preceding nor included in the selection.
- **Remove custom zero width space insertion**
   Fixes the handling of zero width space characters. Previously the Android code inserted these characters at the start of lists but this is now done by the internal Rust model.
   
## Why?
Zero width spaces are used by the editor to help display lists and new line characters are used by the internal model to distinguish whether the cursor selection is at the end of a list item or the start of the next.

This change updates the Android editor implementation to match the internal representation.

[`PSU-1012`](https://element-io.atlassian.net/browse/PSU-1012)