### PR TITLE
Add dom method to extract list items

### DIFF
--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -222,7 +222,12 @@ where
         if let Some(list_item_handle) = parent_list_item_handle {
             let list = self.state.dom.parent(&list_item_handle);
             if list.is_list_of_type(&list_type) {
-                self.move_list_item_content_to_list_parent(&list_item_handle)
+                self.state.dom.extract_list_items(
+                    &list_item_handle.parent_handle(),
+                    list_item_handle.index_in_parent(),
+                    1,
+                );
+                self.create_update_replace_all()
             } else {
                 let list_node_handle = list.handle();
                 self.update_list_type(&list_node_handle, list_type)
@@ -281,35 +286,6 @@ where
             Location::from(s + start_correction),
             Location::from(e + end_correction),
         );
-        self.create_update_replace_all()
-    }
-
-    fn move_list_item_content_to_list_parent(
-        &mut self,
-        list_item_handle: &DomHandle,
-    ) -> ComposerUpdate<S> {
-        let list_item_node = self.state.dom.lookup_node(list_item_handle);
-        if let DomNode::Container(list_item) = list_item_node {
-            let list_item_children = list_item.children().clone();
-            let list_handle = list_item_handle.parent_handle();
-            let list_index_in_parent = list_handle.index_in_parent();
-            let list_parent = self.state.dom.parent_mut(&list_handle);
-            for child in list_item_children.iter().rev() {
-                list_parent
-                    .insert_child(list_index_in_parent + 1, child.clone());
-            }
-
-            let list_item_index_in_parent = list_item_handle.index_in_parent();
-            let list_node = self.state.dom.lookup_node_mut(&list_handle);
-            if let DomNode::Container(list) = list_node {
-                list.remove_child(list_item_index_in_parent);
-            } else {
-                panic!("List node is not a container")
-            }
-        } else {
-            panic!("List item is not a container")
-        }
-
         self.create_update_replace_all()
     }
 

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -106,7 +106,11 @@ where
 
         if index_in_parent == 0 {
             list_item.remove_leading_zwsp();
-            self.insert(&list_handle, list_item.take_children());
+            if list.children().is_empty() {
+                self.replace(&list_handle, list_item.take_children());
+            } else {
+                self.insert(&list_handle, list_item.take_children());
+            }
         } else {
             let mut to_insert = list_item.take_children();
             let new_list_children = list.take_children_after(index_in_parent);
@@ -216,6 +220,19 @@ mod test {
             ds(&dom),
             "<ol><li>~abc</li></ol>~def<ol><li>~ghi</li><li>~jkl</li></ol>"
         );
+    }
+
+    #[test]
+    fn extract_single_list_item() {
+        let mut dom = cm("abc|").state.dom;
+        dom.wrap_nodes_in_list(
+            ListType::Ordered,
+            vec![&DomHandle::from_raw(vec![0])],
+        );
+        assert_eq!(ds(&dom), "<ol><li>~abc</li></ol>");
+
+        dom.extract_list_item(&DomHandle::from_raw(vec![0, 0]));
+        assert_eq!(ds(&dom), "abc");
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -26,6 +26,11 @@ impl<S> Dom<S>
 where
     S: UnicodeString,
 {
+    /// Wrap nodes at given handles into a new list. Line breaks
+    /// are converted into a new list item starting with a ZWSP node.
+    ///
+    /// * `list_type` - the type of list to create (ordered/unordered).
+    /// * `handles` - vec containing all the node handles.
     pub fn wrap_nodes_in_list(
         &mut self,
         list_type: ListType,
@@ -68,7 +73,12 @@ where
         }
     }
 
-    pub fn remove_list(&mut self, handle: &DomHandle) {
+    /// Extract all items from the list at given handle and move
+    /// them appropriately into the DOM. Extracted list items are
+    /// separated by line breaks.
+    ///
+    /// * `handle` - the list handle.
+    pub fn extract_from_list(&mut self, handle: &DomHandle) {
         let list = self.remove(handle);
         let mut nodes_to_insert = Vec::new();
         let DomNode::Container(mut list) = list else {
@@ -94,6 +104,13 @@ where
         self.join_nodes_in_container(&handle.parent_handle());
     }
 
+    /// Extract items from the list at given handle and positions
+    /// and move them appropriately into the DOM. Extracted list
+    /// items are separated by line breaks.
+    ///
+    /// * `handle` - the list handle.
+    /// * `start` - child index at which the extraction should start.
+    /// * `count` - number of children that should be extracted.
     pub fn extract_list_items(
         &mut self,
         handle: &DomHandle,
@@ -182,7 +199,7 @@ mod test {
             "<ol><li>~abc<strong>de<em>f</em></strong></li><li><strong><em>~gh</em>i</strong>jkl</li></ol>",
         );
 
-        dom.remove_list(&DomHandle::from_raw(vec![0]));
+        dom.extract_from_list(&DomHandle::from_raw(vec![0]));
 
         assert_eq!(ds(&dom), "abc<strong>de<em>f<br />gh</em>i</strong>jkl",);
     }
@@ -377,7 +394,7 @@ mod test {
             .state
             .dom
             .wrap_nodes_in_list(ListType::Ordered, handles);
-        model.state.dom.remove_list(&first_handle);
+        model.state.dom.extract_from_list(&first_handle);
         assert_eq!(tx(&model), text);
     }
 

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -91,12 +91,12 @@ where
     /// items are separated by line breaks.
     ///
     /// * `handle` - the list handle.
-    /// * `start` - child index at which the extraction should start.
+    /// * `child_index` - child index at which the extraction should start.
     /// * `count` - number of children that should be extracted.
     pub fn extract_list_items(
         &mut self,
         handle: &DomHandle,
-        start: usize,
+        child_index: usize,
         count: usize,
     ) {
         let list = self.lookup_node_mut(handle);
@@ -104,10 +104,10 @@ where
             panic!("List is not a container")
         };
 
-        if start == 0 {
+        if child_index == 0 {
             let mut nodes_to_insert = Vec::new();
-            for _index in start..start + count {
-                let list_item = list.remove_child(start);
+            for _index in child_index..child_index + count {
+                let list_item = list.remove_child(child_index);
                 let DomNode::Container(mut list_item) = list_item else {
                     panic!("List item is not a container")
                 };
@@ -127,8 +127,8 @@ where
             }
         } else {
             let mut nodes_to_insert = Vec::new();
-            for _index in start..start + count {
-                let list_item = list.remove_child(start);
+            for _index in child_index..child_index + count {
+                let list_item = list.remove_child(child_index);
                 let DomNode::Container(mut list_item) = list_item else {
                     panic!("List item is not a container")
                 };
@@ -139,8 +139,8 @@ where
             }
 
             // Extract further list items to a new list, if any.
-            if list.children().len() > start {
-                let new_list_children = list.take_children_after(start);
+            if list.children().len() > child_index {
+                let new_list_children = list.take_children_after(child_index);
                 let new_list = DomNode::new_list(
                     list.get_list_type().expect("Node is not a list").clone(),
                     new_list_children,

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -79,29 +79,11 @@ where
     ///
     /// * `handle` - the list handle.
     pub fn extract_from_list(&mut self, handle: &DomHandle) {
-        let list = self.remove(handle);
-        let mut nodes_to_insert = Vec::new();
-        let DomNode::Container(mut list) = list else {
-            panic!("List node is not a container")
+        let list = self.lookup_node(handle);
+        let DomNode::Container(list) = list else {
+            panic!("List is not a container")
         };
-        while !list.children().is_empty() {
-            let list_item = list.remove_child(0);
-            let DomNode::Container(mut list_item) = list_item else {
-                panic!("List item is not a container")
-            };
-            if nodes_to_insert.is_empty() {
-                list_item.remove_leading_zwsp();
-            } else {
-                list_item.replace_leading_zwsp_with_linebreak();
-            }
-
-            while !list_item.children().is_empty() {
-                nodes_to_insert.push(list_item.remove_child(0));
-            }
-        }
-
-        self.insert(handle, nodes_to_insert);
-        self.join_nodes_in_container(&handle.parent_handle());
+        self.extract_list_items(handle, 0, list.children().len());
     }
 
     /// Extract items from the list at given handle and positions
@@ -168,6 +150,7 @@ where
 
             self.insert(&handle.next_sibling(), nodes_to_insert);
         }
+        self.join_nodes_in_container(&handle.parent_handle());
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -280,9 +280,15 @@ where
         &self.children
     }
 
-    #[cfg(all(feature = "js", target_arch = "wasm32"))]
     pub(crate) fn take_children(self) -> Vec<DomNode<S>> {
         self.children
+    }
+
+    pub(crate) fn take_children_after(
+        &mut self,
+        position: usize,
+    ) -> Vec<DomNode<S>> {
+        return self.children.drain(position..self.children.len()).collect();
     }
 
     pub fn kind(&self) -> &ContainerNodeKind<S> {
@@ -343,6 +349,13 @@ where
                 raw_text.is_empty() || raw_text == char::zwsp().to_string()
             }
             _ => false,
+        }
+    }
+
+    pub(crate) fn get_list_type(&mut self) -> Option<&ListType> {
+        match &self.kind {
+            ContainerNodeKind::List(t) => Some(t),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
Add a dom method to allow extracting list items out of lists.

Update: 
* Added multiple list items extractions variant + tests
* Replace the dedicated `remove_list` and the single list item variant
* Added a bit of documentation.
* Replaced one of the legacy list extraction code in `composer_model`