### PR TITLE
Bindings & fix corner cases in block nodes (code block, quotes) with new lines

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -154,6 +154,12 @@ impl ComposerModel {
         ))
     }
 
+    pub fn code_block(self: &Arc<Self>) -> Arc<ComposerUpdate> {
+        Arc::new(ComposerUpdate::from(
+            self.inner.lock().unwrap().code_block(),
+        ))
+    }
+
     pub fn ordered_list(self: &Arc<Self>) -> Arc<ComposerUpdate> {
         Arc::new(ComposerUpdate::from(
             self.inner.lock().unwrap().ordered_list(),

--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -160,6 +160,10 @@ impl ComposerModel {
         ))
     }
 
+    pub fn quote(self: &Arc<Self>) -> Arc<ComposerUpdate> {
+        Arc::new(ComposerUpdate::from(self.inner.lock().unwrap().quote()))
+    }
+
     pub fn ordered_list(self: &Arc<Self>) -> Arc<ComposerUpdate> {
         Arc::new(ComposerUpdate::from(
             self.inner.lock().unwrap().ordered_list(),

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -44,6 +44,7 @@ interface ComposerModel {
     ComposerUpdate set_link_with_text(string link, string text);
     ComposerUpdate remove_links();
     ComposerUpdate code_block();
+    ComposerUpdate quote();
     string to_tree();
     ComposerState get_current_dom_state();
     record<ComposerAction, ActionState> action_states();

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -43,6 +43,7 @@ interface ComposerModel {
     ComposerUpdate set_link(string link);
     ComposerUpdate set_link_with_text(string link, string text);
     ComposerUpdate remove_links();
+    ComposerUpdate code_block();
     string to_tree();
     ComposerState get_current_dom_state();
     record<ComposerAction, ActionState> action_states();

--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -35,8 +35,20 @@ where
     fn add_code_block(&mut self) -> ComposerUpdate<S> {
         let (s, e) = self.safe_selection();
         let Some(wrap_result) = self.state.dom.find_nodes_to_wrap_in_block(s, e) else {
-            // No suitable nodes found to be wrapped inside the code block. The Dom should be empty
-            self.state.dom.append_at_end_of_document(DomNode::new_code_block(vec![DomNode::new_zwsp()]));
+            // No suitable nodes found to be wrapped inside the code block. Add an empty block.
+            let range = self.state.dom.find_range(s, e);
+            let leaves: Vec<&DomLocation> = range.leaves().collect();
+            if leaves.is_empty() {
+                self.state.dom.append_at_end_of_document(DomNode::new_code_block(vec![DomNode::new_zwsp()]));
+            } else {
+                let first_leaf_loc = leaves.first().unwrap();
+                let insert_at = if first_leaf_loc.is_start() {
+                    first_leaf_loc.node_handle.next_sibling()
+                } else {
+                   first_leaf_loc.node_handle.clone()
+                };
+                self.state.dom.insert_at(&insert_at, DomNode::new_code_block(vec![DomNode::new_zwsp()]));
+            }
             self.state.start += 1;
             self.state.end += 1;
             return self.create_update_replace_all();
@@ -168,11 +180,23 @@ where
         let end_in_block = code_block_location.end_offset;
         let mut selection_offset_start = 0;
         let mut selection_offset_end = 0;
-        self.state.start += 1;
-        self.state.end += 1;
 
-        // If we remove the whole code block, we should start by adding a line break
-        let mut nodes_to_add = vec![DomNode::new_line_break()];
+        // If we remove the whole code block and it's not the first child, we should start by adding a line break
+        let has_previous_line_break = self
+            .state
+            .dom
+            .prev_leaf(&code_block_location.node_handle)
+            .map_or(false, |n| n.is_line_break());
+        let mut nodes_to_add =
+            if code_block_location.node_handle.index_in_parent() > 0
+                && !has_previous_line_break
+            {
+                self.state.start += 1;
+                self.state.end += 1;
+                vec![DomNode::new_line_break()]
+            } else {
+                Vec::new()
+            };
         // Just remove everything
         let DomNode::Container(block) =
             self.state.dom.lookup_node(&code_block_location.node_handle) else
@@ -219,9 +243,14 @@ where
             }
         }
 
+        let has_next_line_break = self
+            .state
+            .dom
+            .next_leaf(&code_block_location.node_handle)
+            .map_or(false, |n| n.is_line_break());
         // Add a final line break if needed
         if let Some(last_node) = nodes_to_add.last() {
-            if last_node.kind() != LineBreak {
+            if last_node.kind() != LineBreak && !has_next_line_break {
                 nodes_to_add.push(DomNode::new_line_break());
             }
         }
@@ -394,7 +423,6 @@ where
 #[cfg(test)]
 mod test {
     use crate::tests::testutils_composer_model::{cm, tx};
-    use crate::tests::testutils_conversion::utf16;
 
     #[test]
     fn add_code_block_to_empty_dom() {
@@ -581,16 +609,29 @@ mod test {
     }
 
     #[test]
-    fn text_insertion() {
-        let mut model = cm("A<br />|<br />B");
-        model.replace_text(utf16("C"));
-        assert_eq!(tx(&model), "A<br />C|<br />B");
+    fn creating_and_removing_code_block_works() {
+        let mut model = cm("|");
+        model.code_block();
+        assert_eq!(tx(&model), "<pre>~|</pre>");
+        model.code_block();
+        assert_eq!(tx(&model), "|");
     }
 
     #[test]
-    fn text_insertion_nested() {
-        let mut model = cm("A<br /><b>|<br />B</b>");
-        model.replace_text(utf16("C"));
-        assert_eq!(tx(&model), "A<br /><b>C|<br />B</b>");
+    fn removing_code_block_doesnt_add_extra_line_break_at_start() {
+        let mut model = cm("<br />|");
+        model.code_block();
+        assert_eq!(tx(&model), "<br /><pre>~|</pre>");
+        model.code_block();
+        assert_eq!(tx(&model), "<br />|");
+    }
+
+    #[test]
+    fn removing_code_block_doesnt_add_extra_line_break_at_end() {
+        let mut model = cm("|<br />");
+        model.code_block();
+        assert_eq!(tx(&model), "<pre>~|</pre><br />");
+        model.code_block();
+        assert_eq!(tx(&model), "|<br />");
     }
 }

--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -394,6 +394,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::tests::testutils_composer_model::{cm, tx};
+    use crate::tests::testutils_conversion::utf16;
 
     #[test]
     fn add_code_block_to_empty_dom() {
@@ -577,5 +578,19 @@ mod test {
         let mut model = cm("Test<br/>|");
         model.code_block();
         assert_eq!(tx(&model), "Test<br /><pre>~|</pre>");
+    }
+
+    #[test]
+    fn text_insertion() {
+        let mut model = cm("A<br />|<br />B");
+        model.replace_text(utf16("C"));
+        assert_eq!(tx(&model), "A<br />C|<br />B");
+    }
+
+    #[test]
+    fn text_insertion_nested() {
+        let mut model = cm("A<br /><b>|<br />B</b>");
+        model.replace_text(utf16("C"));
+        assert_eq!(tx(&model), "A<br /><b>C|<br />B</b>");
     }
 }

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -300,44 +300,19 @@ where
             if block.children().is_empty() {
                 // If it's the first character, we need to add 2 line breaks instead, since the
                 // first one will be automatically removed by any HTML parser
-                self.state.dom.insert_at(
-                    &leaf.node_handle,
-                    DomNode::new_text("\n\n".into()),
-                );
-                self.state.start += 2;
-                self.state.end = self.state.start;
-                self.state
-                    .dom
-                    .join_nodes_in_container(&block_location.node_handle);
-                self.create_update_replace_all()
-            } else if let DomNode::Text(text_node) =
-                self.state.dom.lookup_node_mut(&leaf.node_handle)
-            {
-                // Just add the line break and move the selection
-                let mut new_data = text_node.data().to_owned();
-                new_data.insert(leaf.start_offset, &S::from("\n"));
-                text_node.set_data(new_data);
-                self.state.start += 1;
-                self.state.end = self.state.start;
-                self.state
-                    .dom
-                    .join_nodes_in_container(&block_location.node_handle);
-                self.create_update_replace_all()
-            } else if let DomNode::Zwsp(_) =
-                self.state.dom.lookup_node(&leaf.node_handle)
-            {
-                let text_node = DomNode::new_text("\n".into());
-                self.state
-                    .dom
-                    .insert_at(&leaf.node_handle.next_sibling(), text_node);
-                self.state.start += 1;
-                self.state.end = self.state.start;
-                self.state
-                    .dom
-                    .join_nodes_in_container(&block_location.node_handle);
-                self.create_update_replace_all()
+                self.replace_text("\n\n".into())
             } else {
-                ComposerUpdate::keep()
+                let cursor_pos = leaf.position + leaf.start_offset;
+                // I'd call `self.state.replace_text` here too, but we'd end up calling
+                // this same code recursively
+                self.state.dom.replace_text_in(
+                    "\n".into(),
+                    cursor_pos,
+                    cursor_pos,
+                );
+                self.state.start += 1;
+                self.state.end = self.state.start;
+                self.create_update_replace_all()
             }
         }
     }

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -213,7 +213,10 @@ where
             };
 
             let new_line_at_end = leaf.is_start();
-            if !sub_tree_container.has_leading_zwsp() {
+
+            if !sub_tree_container.is_empty()
+                && !sub_tree_container.has_leading_zwsp()
+            {
                 sub_tree_container.insert_child(0, DomNode::new_zwsp());
             }
 
@@ -235,7 +238,9 @@ where
                     } else {
                         let next_handle =
                             block_location.node_handle.next_sibling();
-                        if !sub_tree_container.children().is_empty() {
+                        if !sub_tree_container.is_empty()
+                            && !sub_tree_container.only_contains_zwsp()
+                        {
                             self.state.dom.insert_at(
                                 &next_handle,
                                 DomNode::new_code_block(

--- a/crates/wysiwyg/src/dom/action_list.rs
+++ b/crates/wysiwyg/src/dom/action_list.rs
@@ -142,6 +142,9 @@ impl<S: UnicodeString> DomActionList<S> {
     pub fn push(&mut self, action: DomAction<S>) {
         self.actions.push(action);
     }
+    pub fn remove(&mut self, idx: usize) -> DomAction<S> {
+        self.actions.remove(idx)
+    }
 
     #[allow(dead_code)]
     pub fn replace_actions(&mut self, new_actions: Vec<DomAction<S>>) {

--- a/crates/wysiwyg/src/dom/action_list.rs
+++ b/crates/wysiwyg/src/dom/action_list.rs
@@ -142,9 +142,6 @@ impl<S: UnicodeString> DomActionList<S> {
     pub fn push(&mut self, action: DomAction<S>) {
         self.actions.push(action);
     }
-    pub fn remove(&mut self, idx: usize) -> DomAction<S> {
-        self.actions.remove(idx)
-    }
 
     #[allow(dead_code)]
     pub fn replace_actions(&mut self, new_actions: Vec<DomAction<S>>) {

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -702,7 +702,7 @@ where
         if (cur_handle == *from_handle
             || (from_handle.is_ancestor_of(&cur_handle)
                 && cur_handle.index_in_parent() == 0))
-            && (1..text_node.data().chars().count() + 1).contains(&start_offset)
+            && (1..=text_node.data().chars().count()).contains(&start_offset)
         {
             let left_data = text_node.data()[..start_offset].to_owned();
             let right_data = text_node.data()[start_offset..].to_owned();
@@ -712,7 +712,7 @@ where
             }
         } else if to_handle.is_some()
             && cur_handle == to_handle.unwrap()
-            && (1..text_node.data().chars().count() + 1).contains(&end_offset)
+            && (1..=text_node.data().chars().count()).contains(&end_offset)
         {
             let left_data = text_node.data()[..end_offset].to_owned();
             let right_data = text_node.data()[end_offset..].to_owned();

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -319,7 +319,7 @@ where
                             // Cursor is after line break, no need to delete
                         }
                         (0, 0) => {
-                            if !new_text.is_empty() {
+                            if first_text_node && !new_text.is_empty() {
                                 action_list.push(DomAction::add_node(
                                     loc.node_handle.parent_handle(),
                                     loc.node_handle.index_in_parent(),
@@ -384,7 +384,7 @@ where
                             // Cursor is after zwsp, no need to delete
                         }
                         (0, 0) => {
-                            if !new_text.is_empty() {
+                            if first_text_node && !new_text.is_empty() {
                                 action_list.push(DomAction::add_node(
                                     insert_at.parent_handle(),
                                     insert_at.index_in_parent(),

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -311,6 +311,8 @@ where
                     panic!("Leaves shouldn't have containers")
                 }
                 DomNode::LineBreak(_) => {
+                    // Workaround to avoid adding the same text twice when on a boundary between
+                    // 2 line breaks
                     Self::remove_prev_added_action(&mut action_list, &new_text);
                     match (loc.start_offset, loc.end_offset) {
                         (0, 1) => {
@@ -392,6 +394,8 @@ where
                     first_text_node = false;
                 }
                 DomNode::Zwsp(_) => {
+                    // Workaround to avoid adding the same text twice when on a boundary between
+                    // 2 ZWSP nodes
                     Self::remove_prev_added_action(&mut action_list, &new_text);
                     // FIXME: zwsp might not be handled in the same way as linebreak in some cases.
                     match (loc.start_offset, loc.end_offset) {
@@ -444,6 +448,9 @@ where
         action_list
     }
 
+    // FIXME: this is a workaround to avoid inserting the same text twice when selection is between 2 line breaks/ZWSP nodes.
+    // Example: `<br />|<br />` would become `<br />A|A<br />` when adding "A".
+    // If we tried to check if it's already added to not add it twice, we'd end up with `<br />|A<br />`, which is not what we want either.
     fn remove_prev_added_action(
         action_list: &mut DomActionList<S>,
         new_text: &S::Str,

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -48,7 +48,9 @@ where
         }
 
         // Clean up any adjacent text nodes
-        merge_if_adjacent_text_nodes(parent, last_index - 1);
+        if last_index > 0 {
+            merge_if_adjacent_text_nodes(parent, last_index - 1);
+        }
         if index > 0 {
             merge_if_adjacent_text_nodes(parent, index - 1);
         }

--- a/crates/wysiwyg/src/dom/iter.rs
+++ b/crates/wysiwyg/src/dom/iter.rs
@@ -85,6 +85,18 @@ where
         iter.next_back()
     }
 
+    /// Return the previous leaf node in the DOM, if exists, in depth-first order.
+    pub fn prev_leaf(&mut self, handle: &DomHandle) -> Option<&DomNode<S>> {
+        let mut iter = self.iter_from_handle(handle);
+        iter.next_back(); // Current node
+        while let Some(prev) = iter.next_back() {
+            if prev.is_leaf() {
+                return Some(prev);
+            }
+        }
+        None
+    }
+
     /// Return the handle of the previous node in the DOM, if exists, in depth-first order.
     pub fn prev_handle(&mut self, handle: &DomHandle) -> Option<DomHandle> {
         let mut iter = self.iter_from_handle(handle);
@@ -100,6 +112,18 @@ where
         let mut iter = self.iter_from_handle(handle);
         iter.next(); // Current node
         iter.next()
+    }
+
+    /// Return the next leaf node in the DOM, if exists, in depth-first order.
+    pub fn next_leaf(&mut self, handle: &DomHandle) -> Option<&DomNode<S>> {
+        let mut iter = self.iter_from_handle(handle);
+        iter.next(); // Current node
+        while let Some(prev) = iter.next() {
+            if prev.is_leaf() {
+                return Some(prev);
+            }
+        }
+        None
     }
 
     /// Return the handle of the next node in the DOM, if exists, in depth-first order.

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -308,6 +308,20 @@ fn inserting_a_new_line_and_text_before_a_new_line_works() {
     assert_eq!(tx(&model), "Test|<br /><br />");
 }
 
+#[test]
+fn insert_text_between_line_breaks() {
+    let mut model = cm("A<br />|<br />B");
+    model.replace_text(utf16("C"));
+    assert_eq!(tx(&model), "A<br />C|<br />B");
+}
+
+#[test]
+fn insert_text_between_line_breaks_in_format_node() {
+    let mut model = cm("A<br /><b>|<br />B</b>");
+    model.replace_text(utf16("C"));
+    assert_eq!(tx(&model), "A<br /><b>C|<br />B</b>");
+}
+
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {
     model.replace_text(utf16(new_text));
 }

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -330,7 +330,7 @@ fn backspace_emptying_code_block_removes_it() {
 }
 
 #[test]
-fn double_enter_in_code_block_middle() {
+fn double_enter_in_code_block_middle_and_insert_text() {
     let mut model = cm("<pre>~asd|asd</pre>");
     model.enter();
     assert_eq!(tx(&model), "<pre>~asd\n|asd</pre>");
@@ -338,4 +338,6 @@ fn double_enter_in_code_block_middle() {
     assert_eq!(tx(&model), "<pre>~asd</pre><br />|<pre>~asd</pre>");
     model.replace_text("A".into());
     assert_eq!(tx(&model), "<pre>~asd</pre><br />A|<pre>~asd</pre>");
+    model.replace_text("S".into());
+    assert_eq!(tx(&model), "<pre>~asd</pre><br />AS|<pre>~asd</pre>");
 }

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -328,3 +328,14 @@ fn backspace_emptying_code_block_removes_it() {
     model.backspace();
     assert_eq!(tx(&model), "Test&nbsp;|");
 }
+
+#[test]
+fn double_enter_in_code_block_middle() {
+    let mut model = cm("<pre>~asd|asd</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre>~asd\n|asd</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre>~asd</pre><br />|<pre>~asd</pre>");
+    model.replace_text("A".into());
+    assert_eq!(tx(&model), "<pre>~asd</pre><br />A|<pre>~asd</pre>");
+}

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -286,6 +286,18 @@ fn double_enter_in_quote_at_end_when_not_empty() {
 }
 
 #[test]
+fn double_enter_in_code_block_when_empty_removes_it_and_adds_new_line() {
+    let mut model = cm("|");
+    model.code_block();
+    model.enter();
+    assert_eq!(tx(&model), "<pre>~\n|</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<br />|");
+    model.replace_text("asd".into());
+    assert_eq!(tx(&model), "<br />asd|");
+}
+
+#[test]
 fn double_enter_in_quote_in_nested_nodes() {
     let mut model =
         cm("<blockquote>~<b><i>Left<br />|Right</i></b></blockquote>");

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -241,6 +241,13 @@ fn enter_in_code_block_after_nested_line_break_in_middle_splits_code_block() {
 }
 
 #[test]
+fn enter_in_code_block_after_line_break_at_end() {
+    let mut model = cm("<pre>~<b>Bold</b> plain\n|</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre>~<b>Bold</b> plain</pre><br />|")
+}
+
+#[test]
 fn simple_enter_in_quote() {
     let mut model = cm("<blockquote>~Left|Right</blockquote>");
     model.enter();

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -197,9 +197,15 @@ fn enter_in_code_block_at_start_adds_the_line_break() {
 fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_code_block(
 ) {
     // The initial line break will be removed, so it's the same as having a single line break at the start
-    let mut model = cm("<pre>\n~\n|Test</pre>");
+    let mut model = cm("|");
+    model.code_block();
+    model.replace_text("Test".into());
+    model.select(1.into(), 1.into());
+    assert_eq!(tx(&model), "<pre>~|Test</pre>");
     model.enter();
-    assert_eq!(tx(&model), "<br />|<pre>~Test</pre>")
+    assert_eq!(tx(&model), "<pre>~\n|Test</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<br />|<pre>~Test</pre>");
 }
 
 #[test]
@@ -289,6 +295,7 @@ fn double_enter_in_quote_at_end_when_not_empty() {
 fn double_enter_in_code_block_when_empty_removes_it_and_adds_new_line() {
     let mut model = cm("|");
     model.code_block();
+    assert_eq!(tx(&model), "<pre>~|</pre>");
     model.enter();
     assert_eq!(tx(&model), "<pre>~\n|</pre>");
     model.enter();


### PR DESCRIPTION
This PR:

* Adds FFI bindings for quotes and code blocks so they can be integrated into mobile clients.
* Fixes an issue with adding text between line breaks/zwsp nodes that appeared while testing block nodes.
* Fixes several corner cases with block nodes and line breaks.