### PR TITLE
Include Espresso only in Android test configurations

### DIFF
--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -77,12 +77,13 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel:2.5.1'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.test.espresso:espresso-accessibility:3.4.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.8'
     testImplementation 'io.mockk:mockk:1.12.5'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-accessibility:3.4.0'
     androidTestImplementation 'io.mockk:mockk-android:1.12.5'
 }
 


### PR DESCRIPTION
## What?
Include Espresso only in test configuration.

## Why?

Espresso shouldn't be needed outside of test builds since it is a test framework.

It creates dependency resolution issues in consumers of the library e.g.
- https://github.com/vector-im/element-android/pull/7883
- https://github.com/vector-im/element-android/actions/runs/3833639242/jobs/6525294449#step:9:1915