### PR TITLE
Replace some legacy methods with dom methods

### DIFF
--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -52,7 +52,7 @@ where
             // TODO: should probably also get inside here if our selection
             // only contains a zero-wdith space.
             let range = self.state.dom.find_range(s, e);
-            self.backspace_single_cursor(range, e)
+            self.backspace_single_cursor(range)
         } else {
             self.do_backspace()
         }
@@ -298,11 +298,7 @@ where
         }
     }
 
-    fn backspace_single_cursor(
-        &mut self,
-        range: Range,
-        end_position: usize,
-    ) -> ComposerUpdate<S> {
+    fn backspace_single_cursor(&mut self, range: Range) -> ComposerUpdate<S> {
         // Find the first leaf node in this selection - note there
         // should only be one because s == e, so we don't have a
         // selection that spans multiple leaves.
@@ -316,7 +312,7 @@ where
                 .dom
                 .find_parent_list_item_or_self(&leaf.node_handle);
             if let Some(parent_handle) = parent_list_item_handle {
-                self.do_backspace_in_list(&parent_handle, end_position)
+                self.do_backspace_in_list(&parent_handle)
             } else {
                 self.do_backspace()
             }

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -137,11 +137,8 @@ where
                             && l.kind == ListItem
                     })
                     .unwrap();
-                let current_cursor_global_location =
-                    leaf.position + leaf.start_offset;
                 self.do_enter_in_list(
                     &list_item.node_handle,
-                    current_cursor_global_location,
                     list_item.end_offset,
                 )
             }

--- a/crates/wysiwyg/src/composer_model/selection.rs
+++ b/crates/wysiwyg/src/composer_model/selection.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::AddAssign;
+
 use crate::composer_model::menu_state::MenuStateComputeType;
 use crate::{ComposerModel, ComposerUpdate, Location, UnicodeString};
 
@@ -73,6 +75,12 @@ where
     pub fn has_cursor(&self) -> bool {
         let (s, e) = self.safe_selection();
         s == e
+    }
+
+    /// Increment both the start and the end of the selection by given isize.
+    pub(crate) fn increment_selection(&mut self, rhs: isize) {
+        self.state.start.add_assign(rhs);
+        self.state.end.add_assign(rhs);
     }
 }
 

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -152,6 +152,31 @@ where
         }
         self.join_nodes_in_container(&handle.parent_handle());
     }
+
+    /// Slice list item at given handle and offset. A ZWSP node
+    /// is added at the beginning of the created list item.
+    ///
+    /// * `handle` - the list item handle.
+    /// * `offset` - offset at which the list item should be sliced
+    pub(crate) fn slice_list_item(
+        &mut self,
+        handle: &DomHandle,
+        offset: usize,
+    ) {
+        let list_item = self.lookup_node_mut(handle);
+        let mut slice = list_item.slice_after(offset);
+        slice.as_container_mut().unwrap().add_leading_zwsp();
+        let list = self.lookup_node_mut(&handle.parent_handle());
+        let DomNode::Container(list) = list else { panic!("List node is not a container") };
+        if slice.text_len() == 0 {
+            list.insert_child(
+                handle.index_in_parent() + 1,
+                DomNode::new_list_item(vec![DomNode::new_zwsp()]),
+            );
+        } else {
+            list.insert_child(handle.index_in_parent() + 1, slice);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -352,6 +377,22 @@ mod test {
 
         dom.extract_list_items(&DomHandle::from_raw(vec![0]), 0, 3);
         assert_eq!(ds(&dom), "abc<br />def<br />ghi");
+    }
+
+    #[test]
+    fn slice_list_item() {
+        let mut dom = cm("<em>abcd</em>ef|").state.dom;
+        dom.wrap_nodes_in_list(
+            ListType::Ordered,
+            vec![&DomHandle::from_raw(vec![0]), &DomHandle::from_raw(vec![1])],
+        );
+        assert_eq!(ds(&dom), "<ol><li><em>~abcd</em>ef</li></ol>");
+
+        dom.slice_list_item(&DomHandle::from_raw(vec![0, 0]), 4);
+        assert_eq!(
+            ds(&dom),
+            "<ol><li><em>~abc</em></li><li><em>~d</em>ef</li></ol>"
+        );
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -168,14 +168,8 @@ where
         slice.as_container_mut().unwrap().add_leading_zwsp();
         let list = self.lookup_node_mut(&handle.parent_handle());
         let DomNode::Container(list) = list else { panic!("List node is not a container") };
-        if slice.text_len() == 0 {
-            list.insert_child(
-                handle.index_in_parent() + 1,
-                DomNode::new_list_item(vec![DomNode::new_zwsp()]),
-            );
-        } else {
-            list.insert_child(handle.index_in_parent() + 1, slice);
-        }
+        list.insert_child(handle.index_in_parent() + 1, slice);
+        self.join_nodes_in_container(&handle.parent_handle());
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -452,7 +452,15 @@ where
             return false;
         };
         match first_child {
-            DomNode::Container(c) => c.remove_leading_zwsp(),
+            DomNode::Container(c) => {
+                // Remove the entire container if all it contains is the ZWSP.
+                if c.text_len() == 1 && c.has_leading_zwsp() {
+                    self.remove_child(0);
+                    true
+                } else {
+                    c.remove_leading_zwsp()
+                }
+            }
             DomNode::Zwsp(_) => {
                 // Note: handle might not be set in cases where we are transforming a node
                 // that is detached from the DOM. In that case it's fine to transform it


### PR DESCRIPTION
* Removed another legacy function
* Add the capability for removing container that only contains a ZWSP node, instead of leaving them empty.
* Move slicing list item to dom methods