### PR TITLE
Make Android bullet size configurable

### DIFF
--- a/platforms/android/example/src/main/res/layout/view_rich_text_editor.xml
+++ b/platforms/android/example/src/main/res/layout/view_rich_text_editor.xml
@@ -20,7 +20,10 @@
             android:inputType="textMultiLine"
             android:minHeight="48dp"
             android:background="?colorSurface"
-            android:singleLine="false" />
+            android:singleLine="false"
+            app:bulletRadius="4dp"
+            app:bulletGap="8dp"
+            />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/UnorderedListSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/UnorderedListSpan.kt
@@ -1,0 +1,46 @@
+package io.element.android.wysiwyg.spans
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import android.text.style.LeadingMarginSpan
+import androidx.annotation.Px
+import android.text.Layout
+import android.text.Spanned
+import androidx.annotation.IntRange
+
+class UnorderedListSpan(
+    @Px
+    private val gapWidth: Int,
+    @Px
+    @IntRange(from = 0)
+    private val bulletRadius: Int,
+) : LeadingMarginSpan {
+    override fun getLeadingMargin(first: Boolean): Int {
+        return 2 * bulletRadius + gapWidth
+    }
+
+    override fun drawLeadingMargin(
+        canvas: Canvas, paint: Paint, x: Int, dir: Int,
+        top: Int, baseline: Int, bottom: Int,
+        text: CharSequence, start: Int, end: Int,
+        first: Boolean, layout: Layout?
+    ) {
+        if ((text as Spanned).getSpanStart(this) != start) {
+            return
+        }
+
+        val style = paint.style
+        paint.style = Paint.Style.FILL
+
+        val bounds = Rect().also {
+            paint.getTextBounds("1", 0, 1, it)
+        }
+
+        val yPosition = (baseline - bounds.height() / 2f)
+        val xPosition = (x + dir * bulletRadius).toFloat()
+
+        canvas.drawCircle(xPosition, yPosition, bulletRadius.toFloat(), paint)
+        paint.style = style
+    }
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/StyleConfig.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/StyleConfig.kt
@@ -1,0 +1,10 @@
+package io.element.android.wysiwyg.utils
+
+import androidx.annotation.Px
+
+internal data class StyleConfig(
+    @Px
+    val bulletGapWidth: Float,
+    @Px
+    val bulletRadius: Float,
+)

--- a/platforms/android/library/src/main/res/values/attrs.xml
+++ b/platforms/android/library/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="EditorEditText">
+        <attr name="bulletGap" format="dimension" />
+        <attr name="bulletRadius" format="dimension" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
## What?

Make the bullet size configurable via XML layout attributes.

Note that I've replaced the default `BulletSpan` with a custom `UnorderedListSpan` because the `BulletSpan` did not allow customising the bullet radius without setting a color (which might be different to the text color).

## Why?

This will allow the Element app to match the style of bullet points as they appear in the timeline.

Following design feedback on
- https://github.com/vector-im/element-android/pull/7887

## Screenshot
<img src="https://user-images.githubusercontent.com/4940864/210767517-fba8fad9-3222-4aa3-a1de-9c8b853af43b.png" width="50%">
