### PR TITLE
Fix broken Android tests

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/fakes/FakeStyleConfig.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/fakes/FakeStyleConfig.kt
@@ -1,0 +1,8 @@
+package io.element.android.wysiwyg.fakes
+
+import io.element.android.wysiwyg.utils.StyleConfig
+
+internal val fakeStyleConfig = StyleConfig(
+    bulletGapWidth = 1f,
+    bulletRadius = 1f,
+)

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.test.core.app.ApplicationProvider
+import io.element.android.wysiwyg.fakes.fakeStyleConfig
 import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import io.element.android.wysiwyg.test.utils.dumpSpans
@@ -26,7 +27,8 @@ class InterceptInputConnectionIntegrationTest {
             provideHtmlToSpansParser = { html ->
                 HtmlToSpansParser(
                     AndroidResourcesProvider(app),
-                    html
+                    html,
+                    fakeStyleConfig,
                 )
             },
         )
@@ -176,7 +178,7 @@ class InterceptInputConnectionIntegrationTest {
                     "${ZWSP}hello: android.widget.Editor.SpanController (0-6) fl=#18",
                     ": android.text.Selection.START (6-6) fl=#546",
                     ": android.text.Selection.END (6-6) fl=#34",
-                    "${ZWSP}hello: android.text.style.BulletSpan (0-6) fl=#33",
+                    "${ZWSP}hello: io.element.android.wysiwyg.spans.UnorderedListSpan (0-6) fl=#33",
                     "hello: android.text.style.UnderlineSpan (1-6) fl=#289",
                     "hello: android.view.inputmethod.ComposingText (1-6) fl=#289",
                 )
@@ -198,7 +200,7 @@ class InterceptInputConnectionIntegrationTest {
                     "${ZWSP}hello: android.widget.Editor.SpanController (0-6) fl=#18",
                     ": android.text.Selection.START (6-6) fl=#546",
                     ": android.text.Selection.END (6-6) fl=#34",
-                    "${ZWSP}hello: android.text.style.BulletSpan (0-6) fl=#33",
+                    "${ZWSP}hello: io.element.android.wysiwyg.spans.UnorderedListSpan (0-6) fl=#33",
                     "hello: android.text.style.UnderlineSpan (1-6) fl=#289",
                     "hello: android.view.inputmethod.ComposingText (1-6) fl=#289",
                 )

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/HtmlToSpansParserTest.kt
@@ -2,6 +2,7 @@ package io.element.android.wysiwyg.test.utils
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.element.android.wysiwyg.fakes.fakeStyleConfig
 import io.element.android.wysiwyg.utils.AndroidResourcesProvider
 import io.element.android.wysiwyg.utils.HtmlToSpansParser
 import io.element.android.wysiwyg.utils.ZWSP
@@ -59,9 +60,9 @@ class HtmlToSpansParserTest {
                     "${ZWSP}ordered1: io.element.android.wysiwyg.spans.OrderedListSpan (0-9) fl=#33",
                     "\n: io.element.android.wysiwyg.spans.ExtraCharacterSpan (9-10) fl=#33",
                     "${ZWSP}ordered2: io.element.android.wysiwyg.spans.OrderedListSpan (10-19) fl=#33",
-                    "${ZWSP}bullet1: android.text.style.BulletSpan (20-28) fl=#33",
+                    "${ZWSP}bullet1: io.element.android.wysiwyg.spans.UnorderedListSpan (20-28) fl=#33",
                     "\n: io.element.android.wysiwyg.spans.ExtraCharacterSpan (28-29) fl=#33",
-                    "${ZWSP}bullet2: android.text.style.BulletSpan (29-37) fl=#33"
+                    "${ZWSP}bullet2: io.element.android.wysiwyg.spans.UnorderedListSpan (29-37) fl=#33"
                 )
             )
         )
@@ -98,6 +99,7 @@ class HtmlToSpansParserTest {
     private fun convertHtml(html: String) =
         HtmlToSpansParser(
             resourcesProvider = AndroidResourcesProvider(application = ApplicationProvider.getApplicationContext()),
-            html = html
+            html = html,
+            styleConfig = fakeStyleConfig,
         ).convert()
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
@@ -122,4 +122,5 @@ class MockComposer {
     fun givenGetContentAsMarkdown(
         markdown: String = ""
     ) = every { instance.getContentAsMarkdown() } returns markdown
+
 }


### PR DESCRIPTION
Fixes tests failing because:
* `BulletSpan` was replaced by a custom `UnorderedListSpan`.
* Missing `StyleConfig` for `HtmlToSpansParser`.
* No response in `MockComposer` for `toExampleFormat()`.

This PR should hopefully fix all those issues.