### PR TITLE
Fix selection after toggling off list

### DIFF
--- a/crates/wysiwyg/src/composer_model/selection.rs
+++ b/crates/wysiwyg/src/composer_model/selection.rs
@@ -77,8 +77,8 @@ where
         s == e
     }
 
-    /// Increment both the start and the end of the selection by given isize.
-    pub(crate) fn increment_selection(&mut self, rhs: isize) {
+    /// Offset both the start and the end of the selection by given isize.
+    pub(crate) fn offset_selection(&mut self, rhs: isize) {
         self.state.start.add_assign(rhs);
         self.state.end.add_assign(rhs);
     }

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -14,7 +14,7 @@
 
 use widestring::Utf16String;
 
-use crate::tests::testutils_composer_model::{cm, tx};
+use crate::tests::testutils_composer_model::{cm, sel, tx};
 use crate::tests::testutils_conversion::utf16;
 
 use crate::ComposerModel;
@@ -439,6 +439,16 @@ fn new_list_after_linebreak() {
 
     model.unordered_list();
     assert_eq!(tx(&model), "start<ul><li>~|</li></ul>");
+}
+
+#[test]
+fn toggling_list_updates_selection() {
+    let mut model = cm("Test|");
+    assert_eq!(model.get_selection(), sel(4, 4));
+    model.ordered_list();
+    assert_eq!(model.get_selection(), sel(5, 5));
+    model.ordered_list();
+    assert_eq!(model.get_selection(), sel(4, 4));
 }
 
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {

--- a/crates/wysiwyg/src/tests/testutils_composer_model.rs
+++ b/crates/wysiwyg/src/tests/testutils_composer_model.rs
@@ -14,7 +14,7 @@
 
 use widestring::Utf16String;
 
-use crate::ComposerModel;
+use crate::{ComposerModel, Location};
 
 /// Short wrapper around [ComposerModel::from_example_format].
 pub fn cm(text: &str) -> ComposerModel<Utf16String> {
@@ -24,6 +24,10 @@ pub fn cm(text: &str) -> ComposerModel<Utf16String> {
 /// Short wrapper around [ComposerModel::to_example_format].
 pub fn tx(model: &ComposerModel<Utf16String>) -> String {
     model.to_example_format()
+}
+
+pub(crate) fn sel(start: usize, end: usize) -> (Location, Location) {
+    (Location::from(start), Location::from(end))
 }
 
 pub(crate) fn restore_whitespace(text: &str) -> String {


### PR DESCRIPTION
Fixes an issue where selection doesn't update properly when toggling off list and completely removing the list object.

Fixes #457 