### PR TITLE
Call inputEventProcessor on keyDown

### DIFF
--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -20,17 +20,18 @@ import {
     InputEventProcessor,
     Wysiwyg,
     FormattingFunctions,
+    WysiwygEvent,
 } from './types';
 import { isClipboardEvent, isLinkEvent } from './useListeners/assert';
 import { TestUtilities } from './useTestCases/types';
 
-function processEvent(
-    e: WysiwygInputEvent,
+export function processEvent<T extends WysiwygEvent>(
+    e: T,
     wysiwyg: Wysiwyg,
     inputEventProcessor?: InputEventProcessor,
-): WysiwygInputEvent | null {
+): T | null {
     if (inputEventProcessor) {
-        return inputEventProcessor(e, wysiwyg);
+        return inputEventProcessor(e, wysiwyg) as T | null;
     } else {
         return e;
     }

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -27,6 +27,8 @@ export type WysiwygInputEvent =
           data?: string | null;
       });
 
+export type WysiwygEvent = WysiwygInputEvent | KeyboardEvent;
+
 export type ActionTypes = typeof ACTION_TYPES[number];
 
 export type ActionState = 'enabled' | 'reversed' | 'disabled';
@@ -49,6 +51,6 @@ export type Wysiwyg = {
 };
 
 export type InputEventProcessor = (
-    event: WysiwygInputEvent,
+    event: WysiwygEvent,
     wysiwyg: Wysiwyg,
-) => WysiwygInputEvent | null;
+) => WysiwygEvent | null;

--- a/platforms/web/lib/useListeners/event.test.ts
+++ b/platforms/web/lib/useListeners/event.test.ts
@@ -18,6 +18,7 @@ limitations under the License.
 import init, { new_composer_model } from '../../generated/wysiwyg';
 import { extractActionStates, handleKeyDown } from './event';
 import { FormatBlockEvent } from './types';
+import { FormattingFunctions } from '../types';
 
 beforeAll(async () => {
     await init();
@@ -71,7 +72,9 @@ describe('handleKeyDown', () => {
             }) as EventListener);
         });
 
-        handleKeyDown(event, elem);
+        const model = new_composer_model();
+
+        handleKeyDown(event, elem, model, {} as FormattingFunctions);
         expect(await result).toBe(expected);
     });
 });

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { MouseEvent as ReactMouseEvent } from 'react';
 
 import { ComposerModel, MenuStateUpdate } from '../../generated/wysiwyg';
-import { processInput } from '../composer';
+import { processEvent, processInput } from '../composer';
 import {
     getCurrentSelection,
     refreshComposerView,
@@ -60,7 +60,12 @@ export function sendWysiwygInputEvent(
  * @param {KeyboardEvent} e
  * @returns {BlockType | null}
  */
-function getInputFromKeyDown(e: KeyboardEvent): BlockType | null {
+function getInputFromKeyDown(
+    e: KeyboardEvent,
+    composerModel: ComposerModel,
+    formattingFunctions: FormattingFunctions,
+    inputEventProcessor?: InputEventProcessor,
+): BlockType | null {
     if (e.shiftKey && e.altKey) {
         switch (e.key) {
             case '5':
@@ -87,6 +92,14 @@ function getInputFromKeyDown(e: KeyboardEvent): BlockType | null {
         }
     }
 
+    processEvent(
+        e,
+        {
+            actions: formattingFunctions,
+            content: () => composerModel.get_content_as_html(),
+        },
+        inputEventProcessor,
+    );
     return null;
 }
 
@@ -95,8 +108,19 @@ function getInputFromKeyDown(e: KeyboardEvent): BlockType | null {
  * @param {KeyboardEvent} e
  * @param {HTMLElement} editor
  */
-export function handleKeyDown(e: KeyboardEvent, editor: HTMLElement) {
-    const inputType = getInputFromKeyDown(e);
+export function handleKeyDown(
+    e: KeyboardEvent,
+    editor: HTMLElement,
+    composerModel: ComposerModel,
+    formattingFunctions: FormattingFunctions,
+    inputEventProcessor?: InputEventProcessor,
+) {
+    const inputType = getInputFromKeyDown(
+        e,
+        composerModel,
+        formattingFunctions,
+        inputEventProcessor,
+    );
     if (inputType) {
         sendWysiwygInputEvent(editor, inputType, e);
     }

--- a/platforms/web/lib/useListeners/useListeners.ts
+++ b/platforms/web/lib/useListeners/useListeners.ts
@@ -117,7 +117,13 @@ export function useListeners(
         editorNode.addEventListener('wysiwygInput', onWysiwygInput);
 
         const onKeyDown = (e: KeyboardEvent) => {
-            handleKeyDown(e, editorNode);
+            handleKeyDown(
+                e,
+                editorNode,
+                composerModel,
+                formattingFunctions,
+                inputEventProcessor,
+            );
         };
         editorNode.addEventListener('keydown', onKeyDown);
 

--- a/platforms/web/lib/useWysiwyg.inputEventProcessor.test.tsx
+++ b/platforms/web/lib/useWysiwyg.inputEventProcessor.test.tsx
@@ -28,6 +28,23 @@ describe('inputEventProcessor', () => {
         await waitFor(() =>
             expect(textbox).toHaveAttribute('contentEditable', 'true'),
         );
+        inputEventProcessor.mockReset();
+    });
+
+    it('Should call inputEventProcess on keydown', async () => {
+        // When
+        fireEvent.keyDown(textbox, { key: 'A', code: 'KeyA' });
+
+        await waitFor(() => {
+            expect(inputEventProcessor).toBeCalledTimes(1);
+            expect(inputEventProcessor).toBeCalledWith(
+                new KeyboardEvent('keyDown', {
+                    key: 'A',
+                    code: 'KeyA',
+                }),
+                expect.anything(),
+            );
+        });
     });
 
     /**

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -25,7 +25,7 @@ import underlineImage from './images/underline.svg';
 import strikeTroughImage from './images/strike_through.svg';
 import listUnorderedImage from './images/list-unordered.svg';
 import listOrderedImage from './images/list-ordered.svg';
-import { Wysiwyg, WysiwygInputEvent } from '../lib/types';
+import { Wysiwyg, WysiwygEvent } from '../lib/types';
 
 type ButtonProps = {
     onClick: MouseEventHandler<HTMLButtonElement>;
@@ -55,16 +55,17 @@ function App() {
     const [enterToSend, setEnterToSend] = useState(true);
 
     const inputEventProcessor = (
-        e: WysiwygInputEvent,
+        e: WysiwygEvent,
         wysiwyg: Wysiwyg,
-    ): WysiwygInputEvent | null => {
+    ): WysiwygEvent | null => {
         if (e instanceof ClipboardEvent) {
             return e;
         }
 
         if (
-            (enterToSend && e.inputType === 'insertParagraph') ||
-            e.inputType === 'sendMessage'
+            !(e instanceof KeyboardEvent) &&
+            ((enterToSend && e.inputType === 'insertParagraph') ||
+                e.inputType === 'sendMessage')
         ) {
             if (debug.testRef.current) {
                 debug.traceAction(null, 'send', `${wysiwyg.content()}`);


### PR DESCRIPTION
The purpose is to call the inputEventProcessor on keyDown. I need in element-web to stop the propagation of the `Enter` event in order to avoid the editor to grow (new line).

Enter should send the message and not add a new line. 