### PR TITLE
Fix link structure

### DIFF
--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -472,21 +472,16 @@ where
         let right = clone.split_sub_tree_from(from_handle, offset, depth);
 
         // Remove unmodified children of the right split
-        // TODO: create a utility for this
-        let right = right.as_container().unwrap();
-        let mut right =
-            Dom::new(vec![right.children().first().unwrap().clone()]);
+        let mut right = right.into_container().unwrap().take_children();
+        right.truncate(1);
 
-        // Remove unmodified children of the left split and apply a generic container
-        // TODO: create a utility for this
-        let mut left = Dom::new(vec![clone
-            .lookup_node(&from_handle.sub_handle_up_to(depth))
-            .as_container()
+        // Remove unmodified children of the left split
+        let mut left = clone
+            .into_node(&from_handle.sub_handle_up_to(depth))
+            .into_container()
             .unwrap()
-            .children()
-            .last()
-            .unwrap()
-            .clone()]);
+            .take_children();
+        let left = left.split_off(left.len() - 1);
 
         // Reset the handle roots after unmodified siblings were removed
         let mut right_handle =
@@ -499,7 +494,7 @@ where
         left_handle[0] = 0;
         let left_handle = DomHandle::from_raw(left_handle);
 
-        (left, left_handle, right, right_handle)
+        (Dom::new(left), left_handle, Dom::new(right), right_handle)
     }
 
     /// Splits the current tree at the given handle, returning the 'right' side of the split tree, after the given handle to the end of the Dom.

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -57,6 +57,14 @@ where
         }
     }
 
+    pub fn into_container(self) -> ContainerNode<S> {
+        if let DomNode::Container(ret) = self.document {
+            ret
+        } else {
+            panic!("Document should always be a Container!")
+        }
+    }
+
     pub fn document_mut(&mut self) -> &mut ContainerNode<S> {
         // Would be nice if we could avoid this, but it is really convenient
         // in several places to be able to treat document as a DomNode.
@@ -69,6 +77,10 @@ where
 
     pub fn document_node(&self) -> &DomNode<S> {
         &self.document
+    }
+
+    pub fn take_document_node(self) -> DomNode<S> {
+        self.document
     }
 
     pub fn children(&self) -> &Vec<DomNode<S>> {

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -79,8 +79,16 @@ where
         &self.document
     }
 
-    pub fn take_document_node(self) -> DomNode<S> {
+    pub fn into_document_node(self) -> DomNode<S> {
         self.document
+    }
+
+    pub fn into_node(mut self, handle: &DomHandle) -> DomNode<S> {
+        if handle.is_root() {
+            self.into_document_node()
+        } else {
+            self.remove(handle)
+        }
     }
 
     pub fn children(&self) -> &Vec<DomNode<S>> {
@@ -601,7 +609,7 @@ mod test {
     use crate::dom::nodes::TextNode;
     use crate::tests::testutils_composer_model::cm;
     use crate::tests::testutils_conversion::utf16;
-    use crate::tests::testutils_dom::{a, b, dom, i, i_c, tn};
+    use crate::tests::testutils_dom::{a, b, dom, handle, i, i_c, tn};
 
     use super::*;
 
@@ -735,6 +743,18 @@ mod test {
     #[test]
     fn empty_tag_serialises() {
         assert_eq!(dom(&[b(&[]),]).to_string(), "<b></b>");
+    }
+
+    #[test]
+    fn into_node() {
+        assert!(dom(&[tn("foo")]).into_node(&handle(vec![0])).is_text_node())
+    }
+
+    #[test]
+    fn into_node_from_root() {
+        assert!(dom(&[tn("foo")])
+            .into_node(&handle(vec![]))
+            .is_container_node())
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -77,15 +77,20 @@ where
                 let (left, left_handle, right, right_handle) =
                     self.split_new_sub_trees(handle, offset, shared_depth);
 
+                // `outers` are the new subtrees outside the given range
                 let mut outers = if location.ends_inside() {
                     vec![right.lookup_node(&right_handle).clone()]
                 } else {
                     vec![left.lookup_node(&left_handle).clone()]
                 };
 
+                // `inner` is the new subtree within the given range
                 let mut inner =
                     if location.ends_inside() { left } else { right };
 
+                // If the range both starts and ends inside this leaf then
+                // split the leaf again. We've already split the end off so
+                // now we need to split the start.
                 if location.ends_inside() && location.starts_inside() {
                     let offset = location.start_offset;
                     let before = inner

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -88,11 +88,15 @@ where
 
                 if location.ends_inside() && location.starts_inside() {
                     let offset = location.start_offset;
-                    let before = inner.slice_before(offset);
-                    outers.insert(0, before)
+                    let before = inner
+                        .document_mut()
+                        .slice_before(offset)
+                        .take_children();
+                    outers.splice(0..0, before);
                 }
+                let inner_children = inner.into_container().take_children();
 
-                container.insert_child(0, inner);
+                container.insert_children(0, inner_children);
                 self.replace(handle, outers);
             }
         }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -218,6 +218,14 @@ where
         }
     }
 
+    pub(crate) fn into_container(self) -> Option<ContainerNode<S>> {
+        if let Self::Container(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     pub(crate) fn as_container_mut(&mut self) -> Option<&mut ContainerNode<S>> {
         if let Self::Container(v) = self {
             Some(v)

--- a/crates/wysiwyg/src/tests/testutils_dom.rs
+++ b/crates/wysiwyg/src/tests/testutils_dom.rs
@@ -16,6 +16,7 @@ use widestring::Utf16String;
 
 use crate::dom::nodes::DomNode;
 use crate::dom::Dom;
+use crate::DomHandle;
 
 use crate::tests::testutils_conversion::utf16;
 
@@ -57,4 +58,8 @@ fn clone_children<'a>(
 
 pub fn tn(data: &str) -> DomNode<Utf16String> {
     DomNode::new_text(utf16(data))
+}
+
+pub fn handle(raw_path: Vec<usize>) -> DomHandle {
+    DomHandle::from_raw(raw_path)
 }


### PR DESCRIPTION
## What?

Previously, when creating a link, the resulting structure might look like so:
```
├>a "https://element.io"
│ └>"test_"
└>a "https://matrix.org"
  ├>                               // <<< Note the redundant container here
  │ └>"link"
  └>" test"
```

After this change, the structure should no longer contain the redundant container:

```
├>a "https://element.io"
│ └>"test_"
└>a "https://matrix.org"
  └> "link test"
```

So to fix this,
- Stop inserting redundant container nodes during the creation of links
- Add a check for the invariant that generic container nodes can only exist at the root
- Refactor `split_new_sub_trees` to return a `Dom` (rather than a `DomNode`), so that the existence of a root node is implicit

[`PSU-1067`](https://element-io.atlassian.net/browse/PSU-1067)

## Why?

To keep the document representation minimal.