### PR TITLE
Enable live document tree and display it by default

### DIFF
--- a/platforms/ios/example/Wysiwyg/Views/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/Views/ContentView.swift
@@ -22,7 +22,7 @@ import WysiwygComposer
 struct ContentView: View {
     /// A composer content "saved" and displayed upon hitting the send button.
     @State private var sentMessage: WysiwygComposerContent?
-    @State private var tree: String?
+    @State private var showTree = true
     /// View model for the composer.
     @StateObject private var viewModel = WysiwygComposerViewModel(
         minHeight: WysiwygSharedConstants.composerMinHeight,
@@ -48,13 +48,13 @@ struct ContentView: View {
         }
         .disabled(viewModel.isContentEmpty)
         .accessibilityIdentifier(.sendButton)
-        Button("Show tree") {
-            tree = viewModel.treeRepresentation()
+        Button(showTree ? "Hide tree" : "Show tree") {
+            showTree.toggle()
         }
         .accessibilityIdentifier(.showTreeButton)
         ScrollView {
-            if let tree = tree {
-                Text(tree)
+            if showTree {
+                Text(viewModel.treeRepresentation())
                     .accessibilityIdentifier(.treeText)
                     .font(.system(size: 11.0, weight: .regular, design: .monospaced))
                     .multilineTextAlignment(.leading)

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+CodeBlocks.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+CodeBlocks.swift
@@ -24,7 +24,6 @@ extension WysiwygUITests {
         // FIXME: iOS automatically adds an extra line break even if not in the model
         assertTextViewContent("​Some text\n")
 
-        button(.showTreeButton).tap()
         assertTreeEquals(
             """
             └>pre

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Format.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Format.swift
@@ -32,7 +32,6 @@ extension WysiwygUITests {
         // Bolding doesn't change text and we can't test text attributes from this context.
         assertTextViewContent("Some bold text")
 
-        button(.showTreeButton).tap()
         assertTreeEquals(
             """
             ├>"Some bold "

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Quotes.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Quotes.swift
@@ -24,7 +24,6 @@ extension WysiwygUITests {
         // FIXME: iOS automatically adds an extra line break even if not in the model
         assertTextViewContent("Some text\n")
 
-        button(.showTreeButton).tap()
         assertTreeEquals(
             """
             └>blockquote

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -96,7 +96,6 @@ internal extension WysiwygUITests {
     ///
     /// - Parameter content: the tree content to assert, must be provided without newlines at the start and at the end.
     func assertTreeEquals(_ content: String) {
-        button(.showTreeButton).tap()
         XCTAssertEqual(staticText(.treeText).label, "\n\(content)\n")
     }
 }

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -96,6 +96,7 @@ internal extension WysiwygUITests {
     ///
     /// - Parameter content: the tree content to assert, must be provided without newlines at the start and at the end.
     func assertTreeEquals(_ content: String) {
+        sleep(1)
         XCTAssertEqual(staticText(.treeText).label, "\n\(content)\n")
     }
 }


### PR DESCRIPTION
Display document tree by default and update it live

![Simulator Screen Recording - iPhone 13 - 2023-01-12 at 17 37 47](https://user-images.githubusercontent.com/80891108/212126691-62d5aa84-685b-459f-8aad-7b996481da17.gif)
