### PR TITLE
Add custom background renderer for CodeBlock

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/fakes/FakeStyleConfig.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/fakes/FakeStyleConfig.kt
@@ -3,13 +3,18 @@ package io.element.android.wysiwyg.fakes
 import android.graphics.drawable.ColorDrawable
 import io.element.android.wysiwyg.utils.StyleConfig
 
+private val fakeDrawable = ColorDrawable()
+
 internal fun createFakeStyleConfig() = StyleConfig(
     bulletGapWidth = 1f,
     bulletRadius = 1f,
     inlineCodeHorizontalPadding = 2,
     inlineCodeVerticalPadding = 2,
-    inlineCodeSingleLineBg = ColorDrawable(),
-    inlineCodeMultiLineBgLeft = ColorDrawable(),
-    inlineCodeMultiLineBgMid = ColorDrawable(),
-    inlineCodeMultiLineBgRight = ColorDrawable(),
+    inlineCodeSingleLineBg = fakeDrawable,
+    inlineCodeMultiLineBgLeft = fakeDrawable,
+    inlineCodeMultiLineBgMid = fakeDrawable,
+    inlineCodeMultiLineBgRight = fakeDrawable,
+    codeBlockLeadingMargin = 0,
+    codeBlockVerticalPadding = 0,
+    codeBlockBackgroundDrawable = fakeDrawable,
 )

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -20,12 +20,13 @@ import android.view.inputmethod.InputConnection
 import androidx.core.graphics.withTranslation
 import androidx.lifecycle.*
 import com.google.android.material.textfield.TextInputEditText
-import io.element.android.wysiwyg.inlinebg.InlineBgHelper
+import io.element.android.wysiwyg.inlinebg.SpanBackgroundHelper
 import io.element.android.wysiwyg.inputhandlers.InterceptInputConnection
 import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import io.element.android.wysiwyg.inputhandlers.models.LinkAction
 import io.element.android.wysiwyg.inputhandlers.models.ReplaceTextResult
+import io.element.android.wysiwyg.spans.CodeBlockSpan
 import io.element.android.wysiwyg.spans.InlineCodeSpan
 import io.element.android.wysiwyg.utils.*
 import io.element.android.wysiwyg.utils.HtmlToSpansParser.FormattingSpans.removeFormattingSpans
@@ -39,7 +40,8 @@ class EditorEditText : TextInputEditText {
     private var inputConnection: InterceptInputConnection? = null
 
     private lateinit var styleConfig: StyleConfig
-    private lateinit var inlineCodeBgHelper: InlineBgHelper<InlineCodeSpan>
+    private lateinit var inlineCodeBgHelper: SpanBackgroundHelper<InlineCodeSpan>
+    private lateinit var codeBlockBgHelper: SpanBackgroundHelper<CodeBlockSpan>
 
     private val viewModel: EditorViewModel by viewModel(
         viewModelInitializer = {
@@ -72,14 +74,20 @@ class EditorEditText : TextInputEditText {
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
 
         styleConfig = EditorEditTextAttributeReader(context, attrs).styleConfig
-        inlineCodeBgHelper = InlineBgHelper(
+        inlineCodeBgHelper = SpanBackgroundHelper(
             spanType = InlineCodeSpan::class.java,
             horizontalPadding = styleConfig.inlineCodeHorizontalPadding,
             verticalPadding = styleConfig.inlineCodeVerticalPadding,
             drawable = styleConfig.inlineCodeSingleLineBg,
             drawableLeft = styleConfig.inlineCodeMultiLineBgLeft,
             drawableMid = styleConfig.inlineCodeMultiLineBgMid,
-            drawableRight = styleConfig.inlineCodeMultiLineBgRight
+            drawableRight = styleConfig.inlineCodeMultiLineBgRight,
+        )
+        codeBlockBgHelper = SpanBackgroundHelper(
+            spanType = CodeBlockSpan::class.java,
+            horizontalPadding = 0,
+            verticalPadding = 0,
+            drawable = styleConfig.codeBlockBackgroundDrawable,
         )
     }
 
@@ -378,6 +386,7 @@ class EditorEditText : TextInputEditText {
         if (text is Spanned && layout != null) {
             canvas.withTranslation(totalPaddingLeft.toFloat(), totalPaddingTop.toFloat()) {
                 inlineCodeBgHelper.draw(canvas, text as Spanned, layout)
+                codeBlockBgHelper.draw(canvas, text as Spanned, layout)
             }
         }
         super.onDraw(canvas)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditTextAttributeReader.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditTextAttributeReader.kt
@@ -2,6 +2,7 @@ package io.element.android.wysiwyg
 
 import android.content.Context
 import android.util.AttributeSet
+import androidx.core.content.res.getColorOrThrow
 import androidx.core.content.res.getDimensionOrThrow
 import androidx.core.content.res.getDimensionPixelSizeOrThrow
 import androidx.core.content.res.getDrawableOrThrow
@@ -26,6 +27,9 @@ internal class EditorEditTextAttributeReader(context: Context, attrs: AttributeS
             inlineCodeMultiLineBgLeft = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgLeft),
             inlineCodeMultiLineBgMid = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgMid),
             inlineCodeMultiLineBgRight = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgRight),
+            codeBlockLeadingMargin = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockLeadingMargin),
+            codeBlockVerticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockVerticalPadding),
+            codeBlockBackgroundDrawable = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_codeBlockBackgroundDrawable),
         )
         typedArray.recycle()
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/BlockRenderer.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/BlockRenderer.kt
@@ -1,0 +1,35 @@
+package io.element.android.wysiwyg.inlinebg
+
+import android.graphics.Canvas
+import android.graphics.drawable.Drawable
+import android.text.Layout
+
+/**
+ * Helper class to render a single 'block' with a bordered round rectangle as its background.
+ */
+internal class BlockRenderer(
+    private val drawable: Drawable,
+    horizontalPadding: Int,
+    verticalPadding: Int
+): SpanBackgroundRenderer(horizontalPadding, verticalPadding) {
+
+    override fun draw(
+        canvas: Canvas,
+        layout: Layout,
+        startLine: Int,
+        endLine: Int,
+        startOffset: Int,
+        endOffset: Int
+    ) {
+        val top = layout.getLineTop(startLine)
+        val bottom = layout.getLineBottom(endLine)
+        drawable.setBounds(
+            horizontalPadding,
+            top + verticalPadding,
+            layout.width - horizontalPadding * 2,
+            bottom - verticalPadding * 2
+        )
+        drawable.draw(canvas)
+    }
+
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/SpanBackgroundRenderer.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/SpanBackgroundRenderer.kt
@@ -30,7 +30,7 @@ import kotlin.math.min
  * @param horizontalPadding the padding to be applied to left & right of the background
  * @param verticalPadding the padding to be applied to top & bottom of the background
  */
-internal abstract class InlineBgRenderer(
+internal abstract class SpanBackgroundRenderer(
         val horizontalPadding: Int,
         val verticalPadding: Int
 ) {
@@ -88,7 +88,7 @@ internal class SingleLineRenderer(
     horizontalPadding: Int,
     verticalPadding: Int,
     val drawable: Drawable
-) : InlineBgRenderer(horizontalPadding, verticalPadding) {
+) : SpanBackgroundRenderer(horizontalPadding, verticalPadding) {
 
     override fun draw(
         canvas: Canvas,
@@ -124,7 +124,7 @@ internal class MultiLineRenderer(
     val drawableLeft: Drawable,
     val drawableMid: Drawable,
     val drawableRight: Drawable
-) : InlineBgRenderer(horizontalPadding, verticalPadding) {
+) : SpanBackgroundRenderer(horizontalPadding, verticalPadding) {
 
     override fun draw(
         canvas: Canvas,

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/BlockSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/BlockSpan.kt
@@ -1,0 +1,3 @@
+package io.element.android.wysiwyg.spans
+
+interface BlockSpan

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/InlineCodeSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/InlineCodeSpan.kt
@@ -8,7 +8,7 @@ import android.text.style.TypefaceSpan
  * Note that this span does not apply a background style; it simply tells the TextView where to
  * apply an inline background.
  *
- * See [io.element.android.wysiwyg.inlinebg.InlineBgRenderer], based on the official Google sample:
+ * See [io.element.android.wysiwyg.inlinebg.SpanBackgroundRenderer], based on the official Google sample:
  * - https://medium.com/androiddevelopers/drawing-a-rounded-corner-background-on-text-5a610a95af5
  * - https://github.com/googlearchive/android-text/tree/996fdb65bbfbb786c3ca4e4e40b30509067201fc/RoundedBackground-Kotlin
  */

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -164,10 +164,7 @@ internal class HtmlToSpansParser(
                 val start = addLeadingLineBreakIfNeeded(text.getSpanStart(last))
                 text.removeSpan(last)
 
-                val codeSpan = CodeBlockSpan(
-                    0xC0A0A0A0.toInt(),
-                    10.dpToPx().toInt(),
-                )
+                val codeSpan = CodeBlockSpan(styleConfig.codeBlockLeadingMargin, styleConfig.codeBlockVerticalPadding)
 
                 addZWSP(text.length)
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/StyleConfig.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/StyleConfig.kt
@@ -1,15 +1,24 @@
 package io.element.android.wysiwyg.utils
 
 import android.graphics.drawable.Drawable
+import androidx.annotation.ColorInt
 import androidx.annotation.Px
 
 internal data class StyleConfig(
+    // Unordered list
     @Px val bulletGapWidth: Float,
     @Px val bulletRadius: Float,
+
+    // Inline code
     @Px val inlineCodeHorizontalPadding: Int,
     @Px val inlineCodeVerticalPadding: Int,
     val inlineCodeSingleLineBg: Drawable,
     val inlineCodeMultiLineBgLeft: Drawable,
     val inlineCodeMultiLineBgMid: Drawable,
     val inlineCodeMultiLineBgRight: Drawable,
+
+    // Code blocks
+    @Px val codeBlockLeadingMargin: Int,
+    @Px val codeBlockVerticalPadding: Int,
+    val codeBlockBackgroundDrawable: Drawable,
 )

--- a/platforms/android/library/src/main/res/drawable/code_block_bg.xml
+++ b/platforms/android/library/src/main/res/drawable/code_block_bg.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/inline_code_bg"/>
+    <stroke android:width="@dimen/code_block_border_width" android:color="@color/inline_code_border"/>
+    <corners android:radius="@dimen/code_block_border_radius"/>
+</shape>

--- a/platforms/android/library/src/main/res/values/attrs.xml
+++ b/platforms/android/library/src/main/res/values/attrs.xml
@@ -9,5 +9,8 @@
         <attr name="inlineCodeMultiLineBgLeft" format="reference"/>
         <attr name="inlineCodeMultiLineBgMid" format="reference"/>
         <attr name="inlineCodeMultiLineBgRight" format="reference"/>
+        <attr name="codeBlockLeadingMargin" format="dimension" />
+        <attr name="codeBlockVerticalPadding" format="dimension" />
+        <attr name="codeBlockBackgroundDrawable" format="reference" />
     </declare-styleable>
 </resources>

--- a/platforms/android/library/src/main/res/values/dimens.xml
+++ b/platforms/android/library/src/main/res/values/dimens.xml
@@ -2,4 +2,6 @@
 <resources>
     <dimen name="inline_code_border_radius">4dp</dimen>
     <dimen name="inline_code_border_width">1dp</dimen>
+    <dimen name="code_block_border_radius">2dp</dimen>
+    <dimen name="code_block_border_width">1dp</dimen>
 </resources>

--- a/platforms/android/library/src/main/res/values/styles.xml
+++ b/platforms/android/library/src/main/res/values/styles.xml
@@ -9,5 +9,8 @@
         <item name="inlineCodeMultiLineBgLeft">@drawable/inline_code_multi_line_bg_left</item>
         <item name="inlineCodeMultiLineBgMid">@drawable/inline_code_multi_line_bg_mid</item>
         <item name="inlineCodeMultiLineBgRight">@drawable/inline_code_multi_line_bg_right</item>
+        <item name="codeBlockLeadingMargin">10dp</item>
+        <item name="codeBlockVerticalPadding">4dp</item>
+        <item name="codeBlockBackgroundDrawable">@drawable/code_block_bg</item>
     </style>
 </resources>


### PR DESCRIPTION
## What?

Implement the new designs for code blocks on Android.

Changes:
* Added a new type of background renderer for the `EditorEditText`: `BlockRenderer`.
* Renamed `InlineBgHelper` and `InlineBgRenderer` to `SpanBackgroundHelper` and `SpanBackgroundRenderer`, as they're not limited to inline spans now.
* Created `BlockSpan` to differentiate spans that need a `BlockRenderer`, made `CodeBlockSpan` implement it.

## Why?

[`PSU-1028`](https://element-io.atlassian.net/browse/PSU-1028)

## Screenshots

<img width="602" alt="image" src="https://user-images.githubusercontent.com/480955/212309476-6c1f89a2-a084-403c-a095-c555ef58a954.png">
