### PR TITLE
Removed vitest coverage in ci

### DIFF
--- a/.github/workflows/react-build.yml
+++ b/.github/workflows/react-build.yml
@@ -40,7 +40,7 @@ jobs:
       run: yarn lint
     - name: Test with coverage
       working-directory: platforms/web
-      run: yarn coverage --watch false
+      run: yarn test
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/react-build.yml
+++ b/.github/workflows/react-build.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Rust & Cargo cache
       uses: Swatinem/rust-cache@v2
-    - name: Build WASM bindings
+    - name: Build
       run: make web
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3

--- a/.github/workflows/react-build.yml
+++ b/.github/workflows/react-build.yml
@@ -31,9 +31,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
         cache-dependency-path: platforms/web/yarn.lock
-    - name: Build
-      working-directory: platforms/web
-      run: yarn install
     - name: Typescript check
       working-directory: platforms/web
       run: yarn tsc

--- a/.github/workflows/react-build.yml
+++ b/.github/workflows/react-build.yml
@@ -40,7 +40,7 @@ jobs:
       run: yarn lint
     - name: Test with coverage
       working-directory: platforms/web
-      run: yarn coverage
+      run: yarn coverage --watch false
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/react-build.yml
+++ b/.github/workflows/react-build.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Rust & Cargo cache
+      uses: Swatinem/rust-cache@v2
     - name: Build WASM bindings
       run: make web
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
I removed the coverage ci which were slowing done make sometimes the ci fails. I tried the `watch` argument at `false` without success.

The coverage is still exported to sonar, so available.

Add rust & cargo cache
Remove Build step which is already done in make web (Building WASM bindings)