### PR TITLE
Add inline code style helpers for Android

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/fakes/FakeStyleConfig.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/fakes/FakeStyleConfig.kt
@@ -1,20 +1,29 @@
 package io.element.android.wysiwyg.fakes
 
 import android.graphics.drawable.ColorDrawable
+import io.element.android.wysiwyg.utils.BulletListStyleConfig
+import io.element.android.wysiwyg.utils.CodeBlockStyleConfig
+import io.element.android.wysiwyg.utils.InlineCodeStyleConfig
 import io.element.android.wysiwyg.utils.StyleConfig
 
 private val fakeDrawable = ColorDrawable()
 
 internal fun createFakeStyleConfig() = StyleConfig(
-    bulletGapWidth = 1f,
-    bulletRadius = 1f,
-    inlineCodeHorizontalPadding = 2,
-    inlineCodeVerticalPadding = 2,
-    inlineCodeSingleLineBg = fakeDrawable,
-    inlineCodeMultiLineBgLeft = fakeDrawable,
-    inlineCodeMultiLineBgMid = fakeDrawable,
-    inlineCodeMultiLineBgRight = fakeDrawable,
-    codeBlockLeadingMargin = 0,
-    codeBlockVerticalPadding = 0,
-    codeBlockBackgroundDrawable = fakeDrawable,
+    bulletList = BulletListStyleConfig(
+        bulletGapWidth = 1f,
+        bulletRadius = 1f,
+    ),
+    inlineCode = InlineCodeStyleConfig(
+        horizontalPadding = 2,
+        verticalPadding = 2,
+        singleLineBg = fakeDrawable,
+        multiLineBgLeft = fakeDrawable,
+        multiLineBgMid = fakeDrawable,
+        multiLineBgRight = fakeDrawable,
+    ),
+    codeBlock = CodeBlockStyleConfig(
+        leadingMargin = 0,
+        verticalPadding = 0,
+        backgroundDrawable = fakeDrawable,
+    )
 )

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -21,6 +21,7 @@ import androidx.core.graphics.withTranslation
 import androidx.lifecycle.*
 import com.google.android.material.textfield.TextInputEditText
 import io.element.android.wysiwyg.inlinebg.SpanBackgroundHelper
+import io.element.android.wysiwyg.inlinebg.SpanBackgroundHelperFactory
 import io.element.android.wysiwyg.inputhandlers.InterceptInputConnection
 import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
@@ -40,8 +41,12 @@ class EditorEditText : TextInputEditText {
     private var inputConnection: InterceptInputConnection? = null
 
     private lateinit var styleConfig: StyleConfig
-    private lateinit var inlineCodeBgHelper: SpanBackgroundHelper<InlineCodeSpan>
-    private lateinit var codeBlockBgHelper: SpanBackgroundHelper<CodeBlockSpan>
+    private val inlineCodeBgHelper: SpanBackgroundHelper<InlineCodeSpan> by lazy {
+        SpanBackgroundHelperFactory.createInlineCodeBackgroundHelper(styleConfig.inlineCode)
+    }
+    private val codeBlockBgHelper: SpanBackgroundHelper<CodeBlockSpan> by lazy {
+        SpanBackgroundHelperFactory.createCodeBlockBackgroundHelper(styleConfig.codeBlock)
+    }
 
     private val viewModel: EditorViewModel by viewModel(
         viewModelInitializer = {
@@ -72,23 +77,7 @@ class EditorEditText : TextInputEditText {
     constructor(context: Context) : super(context)
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
-
         styleConfig = EditorEditTextAttributeReader(context, attrs).styleConfig
-        inlineCodeBgHelper = SpanBackgroundHelper(
-            spanType = InlineCodeSpan::class.java,
-            horizontalPadding = styleConfig.inlineCodeHorizontalPadding,
-            verticalPadding = styleConfig.inlineCodeVerticalPadding,
-            drawable = styleConfig.inlineCodeSingleLineBg,
-            drawableLeft = styleConfig.inlineCodeMultiLineBgLeft,
-            drawableMid = styleConfig.inlineCodeMultiLineBgMid,
-            drawableRight = styleConfig.inlineCodeMultiLineBgRight,
-        )
-        codeBlockBgHelper = SpanBackgroundHelper(
-            spanType = CodeBlockSpan::class.java,
-            horizontalPadding = 0,
-            verticalPadding = 0,
-            drawable = styleConfig.codeBlockBackgroundDrawable,
-        )
     }
 
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditTextAttributeReader.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditTextAttributeReader.kt
@@ -2,10 +2,12 @@ package io.element.android.wysiwyg
 
 import android.content.Context
 import android.util.AttributeSet
-import androidx.core.content.res.getColorOrThrow
 import androidx.core.content.res.getDimensionOrThrow
 import androidx.core.content.res.getDimensionPixelSizeOrThrow
 import androidx.core.content.res.getDrawableOrThrow
+import io.element.android.wysiwyg.utils.BulletListStyleConfig
+import io.element.android.wysiwyg.utils.CodeBlockStyleConfig
+import io.element.android.wysiwyg.utils.InlineCodeStyleConfig
 import io.element.android.wysiwyg.utils.StyleConfig
 
 internal class EditorEditTextAttributeReader(context: Context, attrs: AttributeSet?) {
@@ -19,17 +21,23 @@ internal class EditorEditTextAttributeReader(context: Context, attrs: AttributeS
             R.style.EditorEditText
         )
         styleConfig = StyleConfig(
-            bulletGapWidth = typedArray.getDimensionOrThrow(R.styleable.EditorEditText_bulletGap),
-            bulletRadius = typedArray.getDimensionOrThrow(R.styleable.EditorEditText_bulletRadius),
-            inlineCodeHorizontalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_inlineCodeHorizontalPadding),
-            inlineCodeVerticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_inlineCodeVerticalPadding),
-            inlineCodeSingleLineBg = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeSingleLineBg),
-            inlineCodeMultiLineBgLeft = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgLeft),
-            inlineCodeMultiLineBgMid = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgMid),
-            inlineCodeMultiLineBgRight = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgRight),
-            codeBlockLeadingMargin = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockLeadingMargin),
-            codeBlockVerticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockVerticalPadding),
-            codeBlockBackgroundDrawable = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_codeBlockBackgroundDrawable),
+            bulletList = BulletListStyleConfig(
+                bulletGapWidth = typedArray.getDimensionOrThrow(R.styleable.EditorEditText_bulletGap),
+                bulletRadius = typedArray.getDimensionOrThrow(R.styleable.EditorEditText_bulletRadius),
+            ),
+            inlineCode = InlineCodeStyleConfig(
+                horizontalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_inlineCodeHorizontalPadding),
+                verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_inlineCodeVerticalPadding),
+                singleLineBg = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeSingleLineBg),
+                multiLineBgLeft = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgLeft),
+                multiLineBgMid = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgMid),
+                multiLineBgRight = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgRight),
+            ),
+            codeBlock = CodeBlockStyleConfig(
+                leadingMargin = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockLeadingMargin),
+                verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockVerticalPadding),
+                backgroundDrawable = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_codeBlockBackgroundDrawable),
+            )
         )
         typedArray.recycle()
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -1,0 +1,42 @@
+package io.element.android.wysiwyg
+
+import android.content.Context
+import android.graphics.Canvas
+import android.text.Spanned
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.graphics.withTranslation
+import io.element.android.wysiwyg.inlinebg.SpanBackgroundHelper
+import io.element.android.wysiwyg.inlinebg.SpanBackgroundHelperFactory
+import io.element.android.wysiwyg.spans.InlineCodeSpan
+import io.element.android.wysiwyg.utils.*
+
+/**
+ * This TextView can display all spans used by the editor.
+ */
+class EditorStyledTextView : AppCompatTextView {
+    private lateinit var inlineCodeStyleConfig: InlineCodeStyleConfig
+    private val inlineCodeBgHelper: SpanBackgroundHelper<InlineCodeSpan> by lazy {
+        SpanBackgroundHelperFactory.createInlineCodeBackgroundHelper(inlineCodeStyleConfig)
+    }
+
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
+        inlineCodeStyleConfig =
+            EditorStyledTextViewAttributeReader(context, attrs).inlineCodeStyleConfig
+    }
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
+            super(context, attrs, defStyleAttr)
+
+    override fun onDraw(canvas: Canvas) {
+        // need to draw bg first so that text can be on top during super.onDraw()
+        if (text is Spanned && layout != null) {
+            canvas.withTranslation(totalPaddingLeft.toFloat(), totalPaddingTop.toFloat()) {
+                inlineCodeBgHelper.draw(canvas, text as Spanned, layout)
+            }
+        }
+        super.onDraw(canvas)
+    }
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextViewAttributeReader.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextViewAttributeReader.kt
@@ -1,0 +1,29 @@
+package io.element.android.wysiwyg
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.core.content.res.getDimensionPixelSizeOrThrow
+import androidx.core.content.res.getDrawableOrThrow
+import io.element.android.wysiwyg.utils.InlineCodeStyleConfig
+
+internal class EditorStyledTextViewAttributeReader(context: Context, attrs: AttributeSet?) {
+    internal val inlineCodeStyleConfig: InlineCodeStyleConfig
+
+    init {
+        val typedArray = context.theme.obtainStyledAttributes(
+            attrs,
+            R.styleable.EditorStyledTextView,
+            0,
+            R.style.EditorStyledTextView
+        )
+        inlineCodeStyleConfig = InlineCodeStyleConfig(
+            horizontalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorStyledTextView_inlineCodeHorizontalPadding),
+            verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorStyledTextView_inlineCodeVerticalPadding),
+            singleLineBg = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeSingleLineBg),
+            multiLineBgLeft = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgLeft),
+            multiLineBgMid = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgMid),
+            multiLineBgRight = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgRight),
+        )
+        typedArray.recycle()
+    }
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/SpanBackgroundHelper.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/SpanBackgroundHelper.kt
@@ -43,7 +43,7 @@ import io.element.android.wysiwyg.spans.BlockSpan
  * @param drawableMid the drawable used to draw for whole line
  * @param drawableRight the drawable used to draw right edge of the background
  */
-internal class SpanBackgroundHelper<T>(
+class SpanBackgroundHelper<T>(
     private val spanType: Class<T>,
     val horizontalPadding: Int,
     val verticalPadding: Int,

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/SpanBackgroundHelperFactory.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/SpanBackgroundHelperFactory.kt
@@ -1,0 +1,29 @@
+package io.element.android.wysiwyg.inlinebg
+
+import io.element.android.wysiwyg.spans.CodeBlockSpan
+import io.element.android.wysiwyg.spans.InlineCodeSpan
+import io.element.android.wysiwyg.utils.CodeBlockStyleConfig
+import io.element.android.wysiwyg.utils.InlineCodeStyleConfig
+
+object SpanBackgroundHelperFactory {
+    fun createInlineCodeBackgroundHelper(styleConfig: InlineCodeStyleConfig): SpanBackgroundHelper<InlineCodeSpan> {
+        return SpanBackgroundHelper(
+            spanType = InlineCodeSpan::class.java,
+            horizontalPadding = styleConfig.horizontalPadding,
+            verticalPadding = styleConfig.verticalPadding,
+            drawable = styleConfig.singleLineBg,
+            drawableLeft = styleConfig.multiLineBgLeft,
+            drawableMid = styleConfig.multiLineBgMid,
+            drawableRight = styleConfig.multiLineBgRight,
+        )
+    }
+
+    fun createCodeBlockBackgroundHelper(styleConfig: CodeBlockStyleConfig): SpanBackgroundHelper<CodeBlockSpan> {
+        return SpanBackgroundHelper(
+            spanType = CodeBlockSpan::class.java,
+            horizontalPadding = 0,
+            verticalPadding = 0,
+            drawable = styleConfig.backgroundDrawable,
+        )
+    }
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/SpanBackgroundRenderer.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inlinebg/SpanBackgroundRenderer.kt
@@ -104,7 +104,8 @@ internal class SingleLineRenderer(
         // the language direction
         val left = min(startOffset, endOffset)
         val right = max(startOffset, endOffset)
-        drawable.setBounds(left, lineTop, right, lineBottom)
+        val width = canvas.width
+        drawable.setBounds(max(left, 0), lineTop, min(right, width), lineBottom)
         drawable.draw(canvas)
     }
 }
@@ -182,11 +183,12 @@ internal class MultiLineRenderer(
      * @param bottom bottom coordinate for the background
      */
     private fun drawStart(canvas: Canvas, start: Int, top: Int, end: Int, bottom: Int) {
+        val width = canvas.width
         if (start > end) {
-            drawableRight.setBounds(end, top, start, bottom)
+            drawableRight.setBounds(max(end, 0), top, min(start, width), bottom)
             drawableRight.draw(canvas)
         } else {
-            drawableLeft.setBounds(start, top, end, bottom)
+            drawableLeft.setBounds(max(start, 0), top, min(end, width), bottom)
             drawableLeft.draw(canvas)
         }
     }
@@ -201,11 +203,12 @@ internal class MultiLineRenderer(
      * @param bottom bottom coordinate for the background
      */
     private fun drawEnd(canvas: Canvas, start: Int, top: Int, end: Int, bottom: Int) {
+        val width = canvas.width
         if (start > end) {
-            drawableLeft.setBounds(end, top, start, bottom)
+            drawableLeft.setBounds(max(end, 0), top, min(start, width), bottom)
             drawableLeft.draw(canvas)
         } else {
-            drawableRight.setBounds(start, top, end, bottom)
+            drawableRight.setBounds(max(start, 0), top, min(end, width), bottom)
             drawableRight.draw(canvas)
         }
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/InlineCodeSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/InlineCodeSpan.kt
@@ -8,8 +8,13 @@ import android.text.style.TypefaceSpan
  * Note that this span does not apply a background style; it simply tells the TextView where to
  * apply an inline background.
  *
+ * To display this span, either:
+ * - use [io.element.android.wysiwyg.EditorStyledTextView], or
+ * - add [io.element.android.wysiwyg.inlinebg.SpanBackgroundRenderer] to your TextView, using
+ *   [io.element.android.wysiwyg.inlinebg.InlineBgHelper] as a reference
+ *
  * See [io.element.android.wysiwyg.inlinebg.SpanBackgroundRenderer], based on the official Google sample:
  * - https://medium.com/androiddevelopers/drawing-a-rounded-corner-background-on-text-5a610a95af5
  * - https://github.com/googlearchive/android-text/tree/996fdb65bbfbb786c3ca4e4e40b30509067201fc/RoundedBackground-Kotlin
  */
-internal class InlineCodeSpan: TypefaceSpan("monospace")
+class InlineCodeSpan: TypefaceSpan("monospace")

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -164,7 +164,7 @@ internal class HtmlToSpansParser(
                 val start = addLeadingLineBreakIfNeeded(text.getSpanStart(last))
                 text.removeSpan(last)
 
-                val codeSpan = CodeBlockSpan(styleConfig.codeBlockLeadingMargin, styleConfig.codeBlockVerticalPadding)
+                val codeSpan = CodeBlockSpan(styleConfig.codeBlock.leadingMargin, styleConfig.codeBlock.verticalPadding)
 
                 addZWSP(text.length)
 
@@ -241,8 +241,8 @@ internal class HtmlToSpansParser(
     }
 
     private fun createListSpan(last: ListItem): ParagraphStyle {
-        val gapWidth = styleConfig.bulletGapWidth.roundToInt()
-        val bulletRadius = styleConfig.bulletRadius.roundToInt()
+        val gapWidth = styleConfig.bulletList.bulletGapWidth.roundToInt()
+        val bulletRadius = styleConfig.bulletList.bulletRadius.roundToInt()
 
         return if (last.ordered) {
             // TODO: provide typeface and textSize somehow

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/StyleConfig.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/StyleConfig.kt
@@ -1,24 +1,32 @@
 package io.element.android.wysiwyg.utils
 
 import android.graphics.drawable.Drawable
-import androidx.annotation.ColorInt
 import androidx.annotation.Px
 
 internal data class StyleConfig(
-    // Unordered list
+    val bulletList: BulletListStyleConfig,
+
+    val inlineCode: InlineCodeStyleConfig,
+
+    val codeBlock: CodeBlockStyleConfig
+)
+
+data class BulletListStyleConfig(
     @Px val bulletGapWidth: Float,
     @Px val bulletRadius: Float,
+)
 
-    // Inline code
-    @Px val inlineCodeHorizontalPadding: Int,
-    @Px val inlineCodeVerticalPadding: Int,
-    val inlineCodeSingleLineBg: Drawable,
-    val inlineCodeMultiLineBgLeft: Drawable,
-    val inlineCodeMultiLineBgMid: Drawable,
-    val inlineCodeMultiLineBgRight: Drawable,
+data class InlineCodeStyleConfig(
+    @Px val horizontalPadding: Int,
+    @Px val verticalPadding: Int,
+    val singleLineBg: Drawable,
+    val multiLineBgLeft: Drawable,
+    val multiLineBgMid: Drawable,
+    val multiLineBgRight: Drawable,
+)
 
-    // Code blocks
-    @Px val codeBlockLeadingMargin: Int,
-    @Px val codeBlockVerticalPadding: Int,
-    val codeBlockBackgroundDrawable: Drawable,
+data class CodeBlockStyleConfig(
+    @Px val leadingMargin: Int,
+    @Px val verticalPadding: Int,
+    val backgroundDrawable: Drawable,
 )

--- a/platforms/android/library/src/main/res/values/attrs.xml
+++ b/platforms/android/library/src/main/res/values/attrs.xml
@@ -1,16 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <attr name="bulletGap" format="dimension" />
+    <attr name="bulletRadius" format="dimension" />
+    <attr name="codeBlockLeadingMargin" format="dimension" />
+    <attr name="codeBlockVerticalPadding" format="dimension" />
+    <attr name="codeBlockBackgroundDrawable" format="reference" />
+    <attr name="inlineCodeHorizontalPadding" format="dimension" />
+    <attr name="inlineCodeVerticalPadding" format="dimension" />
+    <attr name="inlineCodeSingleLineBg" format="reference" />
+    <attr name="inlineCodeMultiLineBgLeft" format="reference" />
+    <attr name="inlineCodeMultiLineBgMid" format="reference" />
+    <attr name="inlineCodeMultiLineBgRight" format="reference" />
+
     <declare-styleable name="EditorEditText">
-        <attr name="bulletGap" format="dimension" />
-        <attr name="bulletRadius" format="dimension" />
-        <attr name="inlineCodeHorizontalPadding" format="dimension"/>
-        <attr name="inlineCodeVerticalPadding" format="dimension"/>
-        <attr name="inlineCodeSingleLineBg" format="reference"/>
-        <attr name="inlineCodeMultiLineBgLeft" format="reference"/>
-        <attr name="inlineCodeMultiLineBgMid" format="reference"/>
-        <attr name="inlineCodeMultiLineBgRight" format="reference"/>
-        <attr name="codeBlockLeadingMargin" format="dimension" />
-        <attr name="codeBlockVerticalPadding" format="dimension" />
-        <attr name="codeBlockBackgroundDrawable" format="reference" />
+        <attr name="bulletGap" />
+        <attr name="bulletRadius" />
+        <attr name="codeBlockLeadingMargin" />
+        <attr name="codeBlockVerticalPadding" />
+        <attr name="codeBlockBackgroundDrawable" />
+        <attr name="inlineCodeHorizontalPadding" />
+        <attr name="inlineCodeVerticalPadding" />
+        <attr name="inlineCodeSingleLineBg" />
+        <attr name="inlineCodeMultiLineBgLeft" />
+        <attr name="inlineCodeMultiLineBgMid" />
+        <attr name="inlineCodeMultiLineBgRight" />
+    </declare-styleable>
+
+    <declare-styleable name="EditorStyledTextView">
+        <attr name="inlineCodeHorizontalPadding" />
+        <attr name="inlineCodeVerticalPadding" />
+        <attr name="inlineCodeSingleLineBg" />
+        <attr name="inlineCodeMultiLineBgLeft" />
+        <attr name="inlineCodeMultiLineBgMid" />
+        <attr name="inlineCodeMultiLineBgRight" />
     </declare-styleable>
 </resources>

--- a/platforms/android/library/src/main/res/values/styles.xml
+++ b/platforms/android/library/src/main/res/values/styles.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="EditorEditText">
-        <item name="bulletGap">2dp</item>
-        <item name="bulletRadius">2dp</item>
+    <style name="EditorStyledTextView">
         <item name="inlineCodeHorizontalPadding">2dp</item>
         <item name="inlineCodeVerticalPadding">0dp</item>
         <item name="inlineCodeSingleLineBg">@drawable/inline_code_single_line_bg</item>
         <item name="inlineCodeMultiLineBgLeft">@drawable/inline_code_multi_line_bg_left</item>
         <item name="inlineCodeMultiLineBgMid">@drawable/inline_code_multi_line_bg_mid</item>
         <item name="inlineCodeMultiLineBgRight">@drawable/inline_code_multi_line_bg_right</item>
+    </style>
+
+    <style name="EditorEditText" parent="EditorStyledTextView">
+        <item name="bulletGap">2dp</item>
+        <item name="bulletRadius">2dp</item>
         <item name="codeBlockLeadingMargin">10dp</item>
         <item name="codeBlockVerticalPadding">4dp</item>
         <item name="codeBlockBackgroundDrawable">@drawable/code_block_bg</item>


### PR DESCRIPTION
## What?

### Allow apps to display the inline code style
Allow users of the library to display inline code in their apps using `InlineCodeSpan`. There are now two ways to do this:

- **`EditorStyledTextView`**
This convenience view allows apps to use and display inline code using `InlineCodeSpan` without overriding `View.onDraw`.
- **`SpanBackgroundHelperFactory`**
This can be used by apps to create the background renderer needed to display inline code. Apps can then implement their own custom text view (rather than being restricted to using or subclassing `EditorStyledTextView`).

### Fix inline code style at edges
Fix inline code background that was being clipped by the start or end of the text view. Note that the padding at the start or end of inline code is now limited by the bounds of the text view.

![image](https://user-images.githubusercontent.com/4940864/212713053-4f3160df-4ba0-418f-9680-2362123fc039.png)

## Why?
[`PSU-1069`](https://element-io.atlassian.net/browse/PSU-1069)

After a message is sent or received, the Element app needs to display the new inline code style in the timeline.