### PR TITLE
`get_link_action()` returns `CreateWithText` for blank selections

### DIFF
--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -38,14 +38,14 @@ where
                 return LinkAction::Edit(link);
             }
         }
-        if s == e || self.is_empty_selection(range) {
+        if s == e || self.is_blank_selection(range) {
             LinkAction::CreateWithText
         } else {
             LinkAction::Create
         }
     }
 
-    fn is_empty_selection(&self, range: Range) -> bool {
+    fn is_blank_selection(&self, range: Range) -> bool {
         for leaf in range.leaves() {
             if leaf.kind == Zwsp || leaf.kind == LineBreak {
                 continue;

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -72,10 +72,10 @@ where
         link: S,
         text: S,
     ) -> ComposerUpdate<S> {
-        let (s, mut e) = self.safe_selection();
+        let (s, _) = self.safe_selection();
         self.push_state_to_history();
         self.do_replace_text(text.clone());
-        e += text.len();
+        let e = s + text.len();
         let range = self.state.dom.find_range(s, e);
         self.set_link_range(range, link)
     }

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use crate::dom::nodes::dom_node::DomNodeKind;
+use crate::dom::nodes::dom_node::{
+    DomNodeKind::LineBreak, DomNodeKind::Text, DomNodeKind::Zwsp,
+};
 use crate::dom::nodes::ContainerNodeKind;
 use crate::dom::nodes::{ContainerNodeKind::Link, DomNode};
 use crate::dom::unicode_string::UnicodeStrExt;
@@ -28,18 +31,40 @@ where
     pub fn get_link_action(&self) -> LinkAction<S> {
         let (s, e) = self.safe_selection();
         let range = self.state.dom.find_range(s, e);
-        for loc in range.locations {
+        for loc in range.locations.iter() {
             if loc.kind == DomNodeKind::Link {
                 let node = self.state.dom.lookup_node(&loc.node_handle);
                 let link = node.as_container().unwrap().get_link().unwrap();
                 return LinkAction::Edit(link);
             }
         }
-        if s == e {
+        if s == e || self.is_empty_selection(range) {
             LinkAction::CreateWithText
         } else {
             LinkAction::Create
         }
+    }
+
+    fn is_empty_selection(&self, range: Range) -> bool {
+        for leaf in range.leaves() {
+            if leaf.kind == Zwsp || leaf.kind == LineBreak {
+                continue;
+            } else if leaf.kind == Text {
+                let text_node = self
+                    .state
+                    .dom
+                    .lookup_node(&leaf.node_handle)
+                    .as_text()
+                    .unwrap();
+                let selection_range = leaf.start_offset..leaf.end_offset;
+                if !text_node.is_blank_in_range(selection_range) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        true
     }
 
     pub fn set_link_with_text(
@@ -48,10 +73,6 @@ where
         text: S,
     ) -> ComposerUpdate<S> {
         let (s, mut e) = self.safe_selection();
-        if s != e {
-            // This function is made to be used only when s == e
-            return ComposerUpdate::keep();
-        }
         self.push_state_to_history();
         self.do_replace_text(text.clone());
         e += text.len();

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -78,6 +78,12 @@ where
             .all(|c| matches!(c, ' ' | '\x09'..='\x0d'))
     }
 
+    pub fn is_blank_in_range(&self, range: Range<usize>) -> bool {
+        self.data[range]
+            .chars()
+            .all(|c| matches!(c, ' ' | '\x09'..='\x0d'))
+    }
+
     pub fn remove_trailing_line_break(&mut self) -> bool {
         if self.data.chars().last() == Some('\n') {
             self.data.pop_last();
@@ -132,6 +138,8 @@ where
     pub fn is_empty(&self) -> bool {
         self.data().len() != 0
     }
+
+    /// Check if the textNode contains only whitespaces
 
     /// Push content of the given text node into self. If given
     /// node is empty or a single ZWSP, nothing is pushed.

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -72,12 +72,15 @@ where
         self.handle = handle;
     }
 
+    /// Returns true if the text_node contains only blank characters
     pub fn is_blank(&self) -> bool {
         self.data
             .chars()
             .all(|c| matches!(c, ' ' | '\x09'..='\x0d'))
     }
 
+    /// Returns true if the text_node contains only blank characters
+    /// in the specified range
     pub fn is_blank_in_range(&self, range: Range<usize>) -> bool {
         self.data[range]
             .chars()
@@ -138,8 +141,6 @@ where
     pub fn is_empty(&self) -> bool {
         self.data().len() != 0
     }
-
-    /// Check if the textNode contains only whitespaces
 
     /// Push content of the given text node into self. If given
     /// node is empty or a single ZWSP, nothing is pushed.

--- a/crates/wysiwyg/src/tests/test_get_link_action.rs
+++ b/crates/wysiwyg/src/tests/test_get_link_action.rs
@@ -119,3 +119,15 @@ fn get_link_action_from_selection_that_contains_multiple_links_partially_in_diff
         LinkAction::Edit(utf16("https://element.io"))
     )
 }
+
+#[test]
+fn get_link_action_on_empty_selection() {
+    let model = cm("{   }|");
+    assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
+}
+
+#[test]
+fn get_link_action_on_empty_selection_between_texts() {
+    let model = cm("test{   }|test");
+    assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
+}

--- a/crates/wysiwyg/src/tests/test_get_link_action.rs
+++ b/crates/wysiwyg/src/tests/test_get_link_action.rs
@@ -121,61 +121,61 @@ fn get_link_action_from_selection_that_contains_multiple_links_partially_in_diff
 }
 
 #[test]
-fn get_link_action_on_empty_selection() {
+fn get_link_action_on_blank_selection() {
     let model = cm("{   }|");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
 
 #[test]
-fn set_link_with_text_on_empty_selection_after_text() {
+fn set_link_with_text_on_blank_selection_after_text() {
     let model = cm("test{   }|");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
 
 #[test]
-fn set_link_with_text_on_empty_selection_before_text() {
+fn set_link_with_text_on_blank_selection_before_text() {
     let model = cm("{   }|test");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
 
 #[test]
-fn get_link_action_on_empty_selection_between_texts() {
+fn get_link_action_on_blank_selection_between_texts() {
     let model = cm("test{   }|test");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
 
 #[test]
-fn get_link_action_on_empty_selection_in_container() {
+fn get_link_action_on_blank_selection_in_container() {
     let model = cm("<b>test{   }| test</b>");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
 
 #[test]
-fn get_link_action_on_empty_selection_with_line_break() {
+fn get_link_action_on_blank_selection_with_line_break() {
     let model = cm("test{  <br> }|test");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
 
 #[test]
-fn get_link_action_on_empty_selection_with_zwsp() {
+fn get_link_action_on_blank_selection_with_zwsp() {
     let model = cm("test{  ~ }|test");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
 
 #[test]
-fn get_link_action_on_empty_selection_with_different_containers() {
+fn get_link_action_on_blank_selection_with_different_containers() {
     let model = cm("<b>test_bold{ </b><br>  ~  <i> }|test_italic</i>");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
 
 #[test]
-fn get_link_action_on_empty_selection_with_different_types_of_whitespaces() {
+fn get_link_action_on_blank_selection_with_different_types_of_whitespaces() {
     let model = cm("test { \t \n \r }| test");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
 
 #[test]
-fn get_link_action_on_empty_selection_after_a_link() {
+fn get_link_action_on_blank_selection_after_a_link() {
     let model = cm("<a href=\"https://element.io\">test</a>{  }|");
     // This is the correct behaviour because the end of a link should be considered part of the link itself
     assert_eq!(

--- a/crates/wysiwyg/src/tests/test_get_link_action.rs
+++ b/crates/wysiwyg/src/tests/test_get_link_action.rs
@@ -127,6 +127,18 @@ fn get_link_action_on_empty_selection() {
 }
 
 #[test]
+fn set_link_with_text_on_empty_selection_after_text() {
+    let model = cm("test{   }|");
+    assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
+}
+
+#[test]
+fn set_link_with_text_on_empty_selection_before_text() {
+    let model = cm("{   }|test");
+    assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
+}
+
+#[test]
 fn get_link_action_on_empty_selection_between_texts() {
     let model = cm("test{   }|test");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)

--- a/crates/wysiwyg/src/tests/test_get_link_action.rs
+++ b/crates/wysiwyg/src/tests/test_get_link_action.rs
@@ -143,3 +143,43 @@ fn get_link_action_on_empty_selection_between_texts() {
     let model = cm("test{   }|test");
     assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
 }
+
+#[test]
+fn get_link_action_on_empty_selection_in_container() {
+    let model = cm("<b>test{   }| test</b>");
+    assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
+}
+
+#[test]
+fn get_link_action_on_empty_selection_with_line_break() {
+    let model = cm("test{  <br> }|test");
+    assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
+}
+
+#[test]
+fn get_link_action_on_empty_selection_with_zwsp() {
+    let model = cm("test{  ~ }|test");
+    assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
+}
+
+#[test]
+fn get_link_action_on_empty_selection_with_different_containers() {
+    let model = cm("<b>test_bold{ </b><br>  ~  <i> }|test_italic</i>");
+    assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
+}
+
+#[test]
+fn get_link_action_on_empty_selection_with_different_types_of_whitespaces() {
+    let model = cm("test { \t \n \r }| test");
+    assert_eq!(model.get_link_action(), LinkAction::CreateWithText)
+}
+
+#[test]
+fn get_link_action_on_empty_selection_after_a_link() {
+    let model = cm("<a href=\"https://element.io\">test</a>{  }|");
+    // This is the correct behaviour because the end of a link should be considered part of the link itself
+    assert_eq!(
+        model.get_link_action(),
+        LinkAction::Edit(utf16("https://element.io"))
+    )
+}

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -414,11 +414,65 @@ fn set_link_with_text_in_container() {
 }
 
 #[test]
-fn set_link_with_text_on_selection() {
-    // This use case should never happen, but just in case it would, nothing will happen.
-    let mut model = cm("{test}|");
+fn set_link_with_text_on_empty_selection() {
+    let mut model = cm("{   }|");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
-    assert_eq!(tx(&model), "{test}|");
+    assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
+}
+
+#[test]
+fn set_link_with_text_on_empty_selection_after_text() {
+    let mut model = cm("test{   }|");
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    assert_eq!(
+        tx(&model),
+        "test<a href=\"https://element.io\">added_link|</a>"
+    );
+}
+
+#[test]
+fn set_link_with_text_on_empty_selection_between_texts() {
+    let mut model = cm("test{   }|test");
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    // this one does not work returns:
+    // "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i><a href=\"https://element.io\">test_i</a>talic</i>"
+    // probably this shift is caused by the removal of the intermediate text_node with whitespaces
+    // and requires to update the set_link_range
+    assert_eq!(
+        tx(&model),
+        "test<a href=\"https://element.io\">added_link|</a>test"
+    );
+}
+
+#[test]
+fn set_link_with_text_on_empty_selection_in_container() {
+    let mut model = cm("<b>test{   }|</b>");
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    assert_eq!(
+        tx(&model),
+        "<b>test<a href=\"https://element.io\">added_link|</a></b>"
+    );
+}
+
+#[test]
+fn set_link_with_text_on_empty_selection_with_line_break() {
+    let mut model = cm("test{  <br> }|");
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    assert_eq!(
+        tx(&model),
+        "<b>test<a href=\"https://element.io\">added_link|</a></b>"
+    );
+}
+
+#[test]
+fn set_link_with_text_on_empty_selection_with_different_containers() {
+    let mut model = cm("<b>test_bold{ </b><br>   <i> }|test_italic</i>");
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    // this one does not work returns:
+    // "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i><a href=\"https://element.io\">test_i</a>talic</i>"
+    // probably this shift is caused by the removal of the intermediate text_node with whitespaces
+    // and requires to update the set_link_range
+    assert_eq!(tx(&model), "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i>test_italic</i>");
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -452,11 +452,11 @@ fn set_link_with_text_on_empty_selection_between_texts() {
 
 #[test]
 fn set_link_with_text_on_empty_selection_in_container() {
-    let mut model = cm("<b>test{   }|</b>");
+    let mut model = cm("<b>test{   }| test</b>");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "<b>test<a href=\"https://element.io\">added_link|</a></b>"
+        "<b>test<a href=\"https://element.io\">added_link|</a> test</b>"
     );
 }
 
@@ -472,7 +472,7 @@ fn set_link_with_text_on_empty_selection_with_line_break() {
 
 #[test]
 fn set_link_with_text_on_empty_selection_with_different_containers() {
-    let mut model = cm("<b>test_bold{ </b><br>   <i> }|test_italic</i>");
+    let mut model = cm("<b>test_bold{ </b><br>  ~ <i> }|test_italic</i>");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(tx(&model), "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i>test_italic</i>");
 }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -431,13 +431,19 @@ fn set_link_with_text_on_empty_selection_after_text() {
 }
 
 #[test]
+fn set_link_with_text_on_empty_selection_before_text() {
+    let mut model = cm("{   }|test");
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    assert_eq!(
+        tx(&model),
+        "<a href=\"https://element.io\">added_link|</a>test"
+    );
+}
+
+#[test]
 fn set_link_with_text_on_empty_selection_between_texts() {
     let mut model = cm("test{   }|test");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
-    // this one does not work returns:
-    // "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i><a href=\"https://element.io\">test_i</a>talic</i>"
-    // probably this shift is caused by the removal of the intermediate text_node with whitespaces
-    // and requires to update the set_link_range
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>test"
@@ -456,11 +462,11 @@ fn set_link_with_text_on_empty_selection_in_container() {
 
 #[test]
 fn set_link_with_text_on_empty_selection_with_line_break() {
-    let mut model = cm("test{  <br> }|");
+    let mut model = cm("test{  <br> }|test");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "<b>test<a href=\"https://element.io\">added_link|</a></b>"
+        "test<a href=\"https://element.io\">added_link|</a>test"
     );
 }
 
@@ -468,10 +474,6 @@ fn set_link_with_text_on_empty_selection_with_line_break() {
 fn set_link_with_text_on_empty_selection_with_different_containers() {
     let mut model = cm("<b>test_bold{ </b><br>   <i> }|test_italic</i>");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
-    // this one does not work returns:
-    // "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i><a href=\"https://element.io\">test_i</a>talic</i>"
-    // probably this shift is caused by the removal of the intermediate text_node with whitespaces
-    // and requires to update the set_link_range
     assert_eq!(tx(&model), "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i>test_italic</i>");
 }
 

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -414,14 +414,14 @@ fn set_link_with_text_in_container() {
 }
 
 #[test]
-fn set_link_with_text_on_empty_selection() {
+fn set_link_with_text_on_blank_selection() {
     let mut model = cm("{   }|");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
 }
 
 #[test]
-fn set_link_with_text_on_empty_selection_after_text() {
+fn set_link_with_text_on_blank_selection_after_text() {
     let mut model = cm("test{   }|");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
@@ -431,7 +431,7 @@ fn set_link_with_text_on_empty_selection_after_text() {
 }
 
 #[test]
-fn set_link_with_text_on_empty_selection_before_text() {
+fn set_link_with_text_on_blank_selection_before_text() {
     let mut model = cm("{   }|test");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
@@ -441,7 +441,7 @@ fn set_link_with_text_on_empty_selection_before_text() {
 }
 
 #[test]
-fn set_link_with_text_on_empty_selection_between_texts() {
+fn set_link_with_text_on_blank_selection_between_texts() {
     let mut model = cm("test{   }|test");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
@@ -451,7 +451,7 @@ fn set_link_with_text_on_empty_selection_between_texts() {
 }
 
 #[test]
-fn set_link_with_text_on_empty_selection_in_container() {
+fn set_link_with_text_on_blank_selection_in_container() {
     let mut model = cm("<b>test{   }| test</b>");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
@@ -461,7 +461,7 @@ fn set_link_with_text_on_empty_selection_in_container() {
 }
 
 #[test]
-fn set_link_with_text_on_empty_selection_with_line_break() {
+fn set_link_with_text_on_blank_selection_with_line_break() {
     let mut model = cm("test{  <br> }|test");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
@@ -471,7 +471,7 @@ fn set_link_with_text_on_empty_selection_with_line_break() {
 }
 
 #[test]
-fn set_link_with_text_on_empty_selection_with_different_containers() {
+fn set_link_with_text_on_blank_selection_with_different_containers() {
     let mut model = cm("<b>test_bold{ </b><br>  ~ <i> }|test_italic</i>");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(tx(&model), "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i>test_italic</i>");


### PR DESCRIPTION
When the user selects a portion of text that only contains whitespace characters, line breaks or zwsp nodes, since a link would actually not be visible (and on some platforms not even tappable), we want to actually replace that selection with some new text, and replicate the exact same behaviour that happens when there is not selection.