### PR TITLE
Codeblock button state change

### DIFF
--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -208,7 +208,12 @@ where
                 ComposerAction::Link,
             ])
         } else if contains_code_block(locations) {
-            disabled_actions.extend(vec![ComposerAction::InlineCode])
+            disabled_actions.extend(vec![
+                ComposerAction::InlineCode,
+                ComposerAction::OrderedList,
+                ComposerAction::UnorderedList,
+                ComposerAction::Quote,
+            ])
         }
         disabled_actions
     }

--- a/crates/wysiwyg/src/composer_model/quotes.rs
+++ b/crates/wysiwyg/src/composer_model/quotes.rs
@@ -312,13 +312,6 @@ mod test {
     }
 
     #[test]
-    fn remove_quote_containing_code_block() {
-        let mut model = cm("<blockquote>~<pre>~Some| code</pre></blockquote>");
-        model.quote();
-        assert_eq!(tx(&model), "<pre>~Some| code</pre>");
-    }
-
-    #[test]
     fn create_and_remove_quote() {
         let mut model = cm("|");
         model.quote();

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -195,6 +195,16 @@ fn inline_code_is_disabled_when_selection_intersects_with_code_block() {
     assert!(model.action_is_disabled(ComposerAction::InlineCode));
 }
 
+#[test]
+fn code_block_disables_expected_formatting_functions() {
+    let mut model = cm("|");
+    model.code_block();
+    assert!(model.action_is_disabled(ComposerAction::InlineCode));
+    assert!(model.action_is_disabled(ComposerAction::OrderedList));
+    assert!(model.action_is_disabled(ComposerAction::UnorderedList));
+    assert!(model.action_is_disabled(ComposerAction::Quote));
+}
+
 fn assert_formatting_actions_and_links_are_disabled(
     model: &ComposerModel<Utf16String>,
 ) {


### PR DESCRIPTION
Small change to make firing `code_block` disable a few more options.

I've removed a test as I thought that we shouldn't be able to put code blocks inside quotes from my reading of the comments, but this might have been a mistake.

Adds a test to verify the new behaviour