### PR TITLE
Disable link in code block and add test

### DIFF
--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -213,6 +213,7 @@ where
                 ComposerAction::OrderedList,
                 ComposerAction::UnorderedList,
                 ComposerAction::Quote,
+                ComposerAction::Link,
             ])
         }
         disabled_actions

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -203,6 +203,7 @@ fn code_block_disables_expected_formatting_functions() {
     assert!(model.action_is_disabled(ComposerAction::OrderedList));
     assert!(model.action_is_disabled(ComposerAction::UnorderedList));
     assert!(model.action_is_disabled(ComposerAction::Quote));
+    assert!(model.action_is_disabled(ComposerAction::Link));
 }
 
 fn assert_formatting_actions_and_links_are_disabled(

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -190,15 +190,29 @@ fn formatting_is_disabled_when_selection_covers_inline_code_node_and_others() {
 }
 
 #[test]
-fn inline_code_is_disabled_when_selection_intersects_with_code_block() {
-    let model = cm("<pre>Some {code</pre> and}| text");
+fn clicking_code_block_disables_expected_formatting_functions() {
+    let mut model = cm("|");
+    model.code_block();
     assert!(model.action_is_disabled(ComposerAction::InlineCode));
+    assert!(model.action_is_disabled(ComposerAction::OrderedList));
+    assert!(model.action_is_disabled(ComposerAction::UnorderedList));
+    assert!(model.action_is_disabled(ComposerAction::Quote));
+    assert!(model.action_is_disabled(ComposerAction::Link));
 }
 
 #[test]
-fn code_block_disables_expected_formatting_functions() {
-    let mut model = cm("|");
-    model.code_block();
+fn code_block_disables_expected_formatting_functions_with_cursor() {
+    let model = cm("<pre>Some code| as text</pre> and text");
+    assert!(model.action_is_disabled(ComposerAction::InlineCode));
+    assert!(model.action_is_disabled(ComposerAction::OrderedList));
+    assert!(model.action_is_disabled(ComposerAction::UnorderedList));
+    assert!(model.action_is_disabled(ComposerAction::Quote));
+    assert!(model.action_is_disabled(ComposerAction::Link));
+}
+
+#[test]
+fn code_block_disables_expected_formatting_functions_with_selection() {
+    let model = cm("<pre>Some {code as text</pre> and}| text");
     assert!(model.action_is_disabled(ComposerAction::InlineCode));
     assert!(model.action_is_disabled(ComposerAction::OrderedList));
     assert!(model.action_is_disabled(ComposerAction::UnorderedList));


### PR DESCRIPTION
As per the title. Disables links inside codeblocks and adds a test for this.