### PR TITLE
Links will use the innermost approach when the selection contains block or structure nodes

### DIFF
--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -101,13 +101,18 @@ where
             return ComposerUpdate::keep();
         }
 
-        let inserted = self
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(link, vec![]));
-
-        // Ensure no duplication by deleting any links contained within the new link
-        self.delete_child_links(&inserted);
+        if range.locations.iter().any(|location| {
+            location.kind.is_structure_kind() || location.kind.is_block_kind()
+        }) {
+            return self.set_link_range(range, link);
+        } else {
+            let inserted = self
+                .state
+                .dom
+                .insert_parent(&range, DomNode::new_link(link, vec![]));
+            // Ensure no duplication by deleting any links contained within the new link
+            self.delete_child_links(&inserted);
+        }
 
         self.create_update_replace_all()
     }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -572,3 +572,71 @@ fn set_link_with_selection_add_http_scheme() {
     model.set_link(utf16("element.io"));
     assert_eq!(tx(&model), "<a href=\"https://element.io\">test_link|</a>");
 }
+
+#[test]
+fn set_link_accross_list_items() {
+    let mut model = cm("<ul><li>Te{st</li><li>Bo}|ld</li></ul>");
+    model.set_link("https://element.io".into());
+    assert_eq!(
+        tx(&model),
+        "<ul>\
+            <li>Te<a href=\"https://element.io\">{st</a></li>\
+            <li><a href=\"https://element.io\">Bo}|</a>ld</li>\
+        </ul>"
+    );
+}
+
+#[test]
+fn set_link_accross_list_items_with_container() {
+    let mut model = cm("<ul><li><b>Te{st</b></li><li><b>Bo}|ld</b></li></ul>");
+    model.set_link("https://element.io".into());
+    assert_eq!(
+        tx(&model),
+        "<ul>\
+            <li>\
+            <b>Te<a href=\"https://element.io\">{st</a></b>\
+            </li>\
+            <li>\
+            <b><a href=\"https://element.io\">Bo}|</a>ld</b>\
+            </li>\
+        </ul>"
+    );
+}
+
+//<ul><li>tes<a href=\"https://element.io\">{t</a><b><a href=\"https://element.io\">test_bold</a></b></li><li><i><a href=\"https://element.io\">test_}|</a>italic</i></li></ul>
+#[test]
+fn set_link_across_list_items_with_multiple_inline_formattings_selected() {
+    let mut model = cm("<ul>\
+        <li>\
+            tes{t<b>test_bold</b>\
+        </li>\
+        <li>\
+            <i>test_}|italic</i>\
+        </li>\
+    </ul>");
+    model.set_link("https://element.io".into());
+    assert_eq!(
+        tx(&model),
+        "<ul>\
+            <li>\
+                tes<a href=\"https://element.io\">{t<b>test_bold</b></a>\
+            </li>\
+            <li>\
+                <i><a href=\"https://element.io\">test_}</a>|italic</i>\
+            </li>\
+        </ul>"
+    );
+}
+
+#[test]
+fn set_link_accross_quote() {
+    let mut model = cm("<blockquote>test_{block_quote</blockquote> test}|");
+    model.set_link("https://element.io".into());
+    assert_eq!(
+        tx(&model),
+        "<blockquote>\
+            test_<a href=\"https://element.io\">{block_quote</a>\
+        </blockquote>\
+        <a href=\"https://element.io\"> test}|</a>"
+    );
+}

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -603,8 +603,12 @@ fn set_link_accross_list_items_with_container() {
     );
 }
 
-//<ul><li>tes<a href=\"https://element.io\">{t</a><b><a href=\"https://element.io\">test_bold</a></b></li><li><i><a href=\"https://element.io\">test_}|</a>italic</i></li></ul>
 #[test]
+#[ignore]
+// This will not work because we have disabled insert_parent when the selection
+// contains struct or block nodes, so e a link for each text node will be created
+//<ul><li>tes<a href=\"https://element.io\">{t</a><b><a href=\"https://element.io\">test_bold</a></b></li><li><i><a href=\"https://element.io\">test_}|</a>italic</i></li></ul>
+// will add this improvement in a later PR
 fn set_link_across_list_items_with_multiple_inline_formattings_selected() {
     let mut model = cm("<ul>\
         <li>\


### PR DESCRIPTION
This is a fix that uses a non optimal solution to deal with links breaking block nodes.
Essentially if the selection contains a non block node, we will use the old approach, the innermost one, where we add the link node directly to each single text node leaf.

This is not optimal, and I am already working with @jonnyandrew on a more optimal solution, but will at least fix the bug, make links usable alongside block nodes.