### PR TITLE
Change how we calculate where to insert the new code block/quotes

### DIFF
--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -103,7 +103,6 @@ where
             self.state.dom.find_insert_handle_for_extracted_block_node(
                 &start_handle,
                 &parent_handle,
-                subtree.document_node(),
             );
 
         let code_block = DomNode::new_code_block(children);
@@ -461,6 +460,54 @@ mod test {
                       └>p
                 "#
             }
+        );
+    }
+
+    #[test]
+    fn applying_code_block_to_the_first_paragraph_does_not_move_it() {
+        let mut model = cm("\
+        <p>|A</p>\
+        <p>B</p>\
+        <p>C</p>");
+        model.code_block();
+        assert_eq!(
+            tx(&model),
+            "\
+        <pre>|A</pre>\
+        <p>B</p>\
+        <p>C</p>"
+        );
+    }
+
+    #[test]
+    fn applying_code_block_to_some_middle_paragraph_does_not_move_it() {
+        let mut model = cm("\
+        <p>A</p>\
+        <p>B|</p>\
+        <p>C</p>");
+        model.code_block();
+        assert_eq!(
+            tx(&model),
+            "\
+        <p>A</p>\
+        <pre>B|</pre>\
+        <p>C</p>"
+        );
+    }
+
+    #[test]
+    fn applying_code_block_to_the_last_paragraph_does_not_move_it() {
+        let mut model = cm("\
+        <p>A</p>\
+        <p>B</p>\
+        <p>|C</p>");
+        model.code_block();
+        assert_eq!(
+            tx(&model),
+            "\
+        <p>A</p>\
+        <p>B</p>\
+        <pre>|C</pre>"
         );
     }
 }

--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -404,7 +404,7 @@ mod test {
     }
 
     #[test]
-    fn line_break_in_quote_splits_quote() {
+    fn line_break_in_empty_paragraph_inside_quote_splits_quote() {
         let mut model =
             cm("<blockquote><p>First</p><p>|</p><p>Second</p></blockquote>");
         model.enter();

--- a/crates/wysiwyg/src/composer_model/quotes.rs
+++ b/crates/wysiwyg/src/composer_model/quotes.rs
@@ -82,7 +82,6 @@ where
             self.state.dom.find_insert_handle_for_extracted_block_node(
                 &start_handle,
                 &parent_handle,
-                subtree.document_node(),
             );
         let subtree_root_kind = subtree.document_node().kind();
         let quote_node = if subtree_root_kind.is_block_kind()

--- a/crates/wysiwyg/src/dom/dom_block_nodes.rs
+++ b/crates/wysiwyg/src/dom/dom_block_nodes.rs
@@ -157,22 +157,24 @@ where
         &self,
         start_handle: &DomHandle,
         parent_handle: &DomHandle,
-        subtree: &DomNode<S>,
     ) -> DomHandle {
-        let start_handle_is_start_at_depth =
-            start_handle.raw().iter().all(|i| *i == 0);
-        let mut insert_at_handle =
-            if subtree.is_block_node() && subtree.kind() != Generic {
-                start_handle.sub_handle_up_to(parent_handle.depth())
-            } else {
+        if self.document().is_empty() {
+            self.document_handle().child_handle(0)
+        } else {
+            let mut insert_at_handle = if parent_handle.is_root() {
                 start_handle.sub_handle_up_to(parent_handle.depth() + 1)
+            } else {
+                start_handle.sub_handle_up_to(parent_handle.depth())
             };
-        if !start_handle_is_start_at_depth && self.contains(&insert_at_handle) {
-            insert_at_handle = insert_at_handle.next_sibling();
-        } else if self.document().is_empty() {
-            insert_at_handle = self.document_handle().child_handle(0);
+
+            if insert_at_handle.index_in_parent() > 0
+                && self.next_sibling(&insert_at_handle).is_some()
+            {
+                insert_at_handle = insert_at_handle.next_sibling();
+            }
+
+            insert_at_handle
         }
-        insert_at_handle
     }
 }
 


### PR DESCRIPTION
## What?

Change how we calculate where to insert the new code block/quotes when we're just creating them. The old way caused some issues for wrapping paragraphs in the middle of a block node into code blocks and quotes.

## Why?

Fixes #458 .