### PR TITLE
Empty paragraphs will return NBSP inside of them

### DIFF
--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -231,7 +231,7 @@ mod test {
                     <p>multi-line</p>\
                     <p>quote</p>\
                 </blockquote>\
-                <p></p>\
+                <p>&nbsp;</p>\
                 <p>Some text</p>\
                 <pre>A\n\tcode\nblock</pre>\
                 <p>Some <code>inline</code> code</p>",
@@ -241,7 +241,7 @@ mod test {
             "<blockquote>\
                 <p>Some</p><p>multi-line</p><p>quote</p>\
             </blockquote>\
-            <p></p>\
+            <p>&nbsp;</p>\
             <p>Some text</p>\
             <pre>A\n\tcode\nblock</pre>\
             <p>Some <code>inline</code> code|</p>"

--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -441,7 +441,7 @@ mod test {
         model.code_block();
         assert_eq!(tx(&model), "<pre>|</pre>");
         model.code_block();
-        assert_eq!(tx(&model), "<p>|</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;|</p>");
     }
 
     #[test]

--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -294,7 +294,7 @@ mod test {
     fn test_new_line_in_empty_dom() {
         let mut model = cm("|");
         model.enter();
-        assert_eq!(tx(&model), "<p></p><p>|</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p>");
     }
 
     #[test]
@@ -308,7 +308,7 @@ mod test {
     fn test_new_line_at_start() {
         let mut model = cm("|Test lines");
         model.enter();
-        assert_eq!(tx(&model), "<p></p><p>|Test lines</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;</p><p>|Test lines</p>");
     }
 
     #[test]
@@ -366,18 +366,18 @@ mod test {
     fn add_line_at_start_of_paragraph() {
         let mut model = cm("<p>|Test</p>");
         model.enter();
-        assert_eq!(tx(&model), "<p></p><p>|Test</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;</p><p>|Test</p>");
         model.select(0.into(), 0.into());
         assert_eq!(tx(&model), "<p>|</p><p>Test</p>");
         model.enter();
-        assert_eq!(tx(&model), "<p></p><p>|</p><p>Test</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p><p>Test</p>");
     }
 
     #[test]
     fn add_line_at_start_of_empty_paragraph() {
         let mut model = cm("<p>|</p><p>Test</p>");
         model.enter();
-        assert_eq!(tx(&model), "<p></p><p>|</p><p>Test</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p><p>Test</p>");
     }
 
     #[test]
@@ -391,7 +391,7 @@ mod test {
         model.enter();
         assert_eq!(
             tx(&model),
-            "<blockquote><p>First</p><p></p><p>|Second</p></blockquote>"
+            "<blockquote><p>First</p><p>&nbsp;</p><p>|Second</p></blockquote>"
         );
         model.select(6.into(), 6.into());
         model.enter();

--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -294,7 +294,7 @@ mod test {
     fn test_new_line_in_empty_dom() {
         let mut model = cm("|");
         model.enter();
-        assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;</p><p>&nbsp;|</p>");
     }
 
     #[test]
@@ -315,7 +315,7 @@ mod test {
     fn test_new_line_at_end() {
         let mut model = cm("Test lines|");
         model.enter();
-        assert_eq!(tx(&model), "<p>Test lines</p><p>|</p>");
+        assert_eq!(tx(&model), "<p>Test lines</p><p>&nbsp;|</p>");
     }
 
     #[test]
@@ -368,16 +368,16 @@ mod test {
         model.enter();
         assert_eq!(tx(&model), "<p>&nbsp;</p><p>|Test</p>");
         model.select(0.into(), 0.into());
-        assert_eq!(tx(&model), "<p>|</p><p>Test</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;|</p><p>Test</p>");
         model.enter();
-        assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p><p>Test</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;</p><p>&nbsp;|</p><p>Test</p>");
     }
 
     #[test]
     fn add_line_at_start_of_empty_paragraph() {
         let mut model = cm("<p>|</p><p>Test</p>");
         model.enter();
-        assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p><p>Test</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;</p><p>&nbsp;|</p><p>Test</p>");
     }
 
     #[test]
@@ -395,7 +395,7 @@ mod test {
         );
         model.select(6.into(), 6.into());
         model.enter();
-        assert_eq!(tx(&model), "<blockquote><p>First</p></blockquote><p>|</p><blockquote><p>Second</p></blockquote>");
+        assert_eq!(tx(&model), "<blockquote><p>First</p></blockquote><p>&nbsp;|</p><blockquote><p>Second</p></blockquote>");
     }
 
     #[test]
@@ -405,7 +405,7 @@ mod test {
         model.enter();
         assert_eq!(
             tx(&model),
-            "<blockquote><p>First</p></blockquote><p>|</p><blockquote><p>Second</p></blockquote>"
+            "<blockquote><p>First</p></blockquote><p>&nbsp;|</p><blockquote><p>Second</p></blockquote>"
         );
     }
 

--- a/crates/wysiwyg/src/composer_model/quotes.rs
+++ b/crates/wysiwyg/src/composer_model/quotes.rs
@@ -142,7 +142,7 @@ mod test {
     fn apply_quote_to_empty_dom() {
         let mut model = cm("|");
         model.quote();
-        assert_eq!(tx(&model), "<blockquote><p>|</p></blockquote>")
+        assert_eq!(tx(&model), "<blockquote><p>&nbsp;|</p></blockquote>")
     }
 
     #[test]
@@ -313,9 +313,9 @@ mod test {
     fn create_and_remove_quote() {
         let mut model = cm("|");
         model.quote();
-        assert_eq!(tx(&model), "<blockquote><p>|</p></blockquote>");
+        assert_eq!(tx(&model), "<blockquote><p>&nbsp;|</p></blockquote>");
         model.quote();
-        assert_eq!(tx(&model), "<p>|</p>");
+        assert_eq!(tx(&model), "<p>&nbsp;|</p>");
     }
 
     #[test]
@@ -324,7 +324,7 @@ mod test {
         model.quote();
         assert_eq!(
             tx(&model),
-            "<ul><li><blockquote><p>|</p></blockquote></li></ul>"
+            "<ul><li><blockquote><p>&nbsp;|</p></blockquote></li></ul>"
         )
     }
 }

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -402,9 +402,9 @@ mod test {
             "<p>abc<strong>de<em>f</em></strong></p><p><strong><em>gh</em>i</strong>jkl|</p>",
         );
         list_roundtrips("<p>abc|</p>");
-        list_roundtrips("<p>&nbsp;</p><p>abc</p><p>|</p>");
+        list_roundtrips("<p>&nbsp;</p><p>abc</p><p>&nbsp;|</p>");
         list_roundtrips("<p><em>ab|c</em></p>");
-        list_roundtrips("<p>{</p><p>}|</p>");
+        list_roundtrips("<p>{&nbsp;</p><p>&nbsp;}|</p>");
     }
 
     fn list_roundtrips(text: &str) {

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -402,7 +402,7 @@ mod test {
             "<p>abc<strong>de<em>f</em></strong></p><p><strong><em>gh</em>i</strong>jkl|</p>",
         );
         list_roundtrips("<p>abc|</p>");
-        list_roundtrips("<p></p><p>abc</p><p>|</p>");
+        list_roundtrips("<p>&nbsp;</p><p>abc</p><p>|</p>");
         list_roundtrips("<p><em>ab|c</em></p>");
         list_roundtrips("<p>{</p><p>}|</p>");
     }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -14,6 +14,7 @@
 
 use std::ops::ControlFlow;
 
+use crate::char::CharExt;
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::dom_node::{DomNode, DomNodeKind};
@@ -618,6 +619,12 @@ where
             let mut state = state;
             if matches!(self.kind, ContainerNodeKind::CodeBlock) {
                 state.is_inside_code_block = true;
+            }
+
+            if matches!(self.kind, ContainerNodeKind::Paragraph)
+                && self.is_empty()
+            {
+                formatter.push(char::nbsp());
             }
 
             self.fmt_children_html(formatter, selection_writer, state);

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -276,15 +276,15 @@ fn newline_characters_insert_br_tags() {
 fn leading_and_trailing_newline_characters_insert_br_tags() {
     let mut model = cm("|");
     replace_text(&mut model, "\nabc");
-    assert_eq!(tx(&model), "<p></p><p>abc|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;</p><p>abc|</p>");
 
     let mut model = cm("|");
     replace_text(&mut model, "abc\n");
-    assert_eq!(tx(&model), "<p>abc</p><p>|</p>");
+    assert_eq!(tx(&model), "<p>abc</p><p>&nbsp;|</p>");
 
     let mut model = cm("|");
     replace_text(&mut model, "\nabc\n");
-    assert_eq!(tx(&model), "<p></p><p>abc</p><p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;</p><p>abc</p><p>&nbsp;|</p>");
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -50,7 +50,7 @@ fn can_create_list_in_empty_model() {
 fn removing_list_item() {
     let mut model = cm("<ol><li>abcd</li><li>|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "<ol><li>abcd</li></ol><p>|</p>");
+    assert_eq!(tx(&model), "<ol><li>abcd</li></ol><p>&nbsp;|</p>");
 
     let mut model = cm("<ol><li>abcd</li><li>|</li></ol>");
     model.backspace();
@@ -58,7 +58,7 @@ fn removing_list_item() {
 
     let mut model = cm("<ol><li>|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "<p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p>");
 
     let mut model = cm("<ol><li>|</li></ol>");
     model.backspace();
@@ -145,21 +145,21 @@ fn backspacing_trailing_part_of_a_list_item_with_formatting() {
 fn entering_with_entire_selection_in_one_node_deletes_list() {
     let mut model = cm("<ol><li>{abcd}|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "<p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p>");
 }
 
 #[test]
 fn entering_with_entire_selection_across_multiple_nodes_deletes_list() {
     let mut model = cm("<ol><li>{abcd</li><li>}|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "<p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p>");
 }
 
 #[test]
 fn entering_with_entire_selection_with_formatting() {
     let mut model = cm("<ol><li><b>{abcd}|</b></li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "<p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p>");
 }
 
 #[test]
@@ -232,28 +232,28 @@ fn removing_list() {
     let mut model = cm("|");
     model.ordered_list();
     model.enter();
-    assert_eq!(tx(&model), "<p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p>");
 }
 
 #[test]
 fn removing_trailing_list_item_with_enter() {
     let mut model = cm("<ol><li>abc</li><li>|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "<ol><li>abc</li></ol><p>|</p>")
+    assert_eq!(tx(&model), "<ol><li>abc</li></ol><p>&nbsp;|</p>")
 }
 
 #[test]
 fn removing_trailing_list_item_with_list_toggle() {
     let mut model = cm("<ol><li>abc</li><li>|</li></ol>");
     model.ordered_list();
-    assert_eq!(tx(&model), "<ol><li>abc</li></ol><p>|</p>")
+    assert_eq!(tx(&model), "<ol><li>abc</li></ol><p>&nbsp;|</p>")
 }
 
 #[test]
 fn removing_trailing_list_item_then_replace_text() {
     let mut model = cm("<ol><li>abc</li><li>|</li></ol>");
     model.enter();
-    assert_eq!(tx(&model), "<ol><li>abc</li></ol><p>|</p>");
+    assert_eq!(tx(&model), "<ol><li>abc</li></ol><p>&nbsp;|</p>");
     replace_text(&mut model, "def");
     assert_eq!(tx(&model), "<ol><li>abc</li></ol><p>def|</p>");
 }
@@ -464,7 +464,7 @@ fn multiple_list_toggle() {
     model.ordered_list();
     assert_eq!(tx(&model), "<ol><li>|</li></ol>");
     model.ordered_list();
-    assert_eq!(tx(&model), "<p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p>");
     model.ordered_list();
     assert_eq!(tx(&model), "<ol><li>|</li></ol>");
 }
@@ -473,7 +473,7 @@ fn multiple_list_toggle() {
 fn new_list_after_linebreak() {
     let mut model = cm("start|");
     model.enter();
-    assert_eq!(tx(&model), "<p>start</p><p>|</p>");
+    assert_eq!(tx(&model), "<p>start</p><p>&nbsp;|</p>");
 
     model.unordered_list();
     // TODO: make 'start' be contained into a paragraph

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -40,11 +40,11 @@ fn adding_line_break_after_replacing_with_empty_html() {
 fn pressing_enter_after_backspacing_a_paragraph() {
     let mut model = cm("|");
     model.enter();
-    assert_eq!(tx(&model), "<p></p><p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p>");
     model.backspace();
     assert_eq!(tx(&model), "<p>|</p>");
     model.enter();
-    assert_eq!(tx(&model), "<p></p><p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p>");
 }
 
 #[test]
@@ -353,14 +353,14 @@ fn text_typed_after_line_break_goes_into_last_paragraph() {
     model.enter();
     model.select(1.into(), 1.into());
     model.replace_text("Test".into());
-    assert_eq!(tx(&model), "<p></p><p>Test|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;</p><p>Test|</p>");
 }
 
 #[test]
 fn backspace_after_several_empty_paragraphs_deletes_only_one() {
-    let mut model = cm("<p></p><p></p><p>|</p>");
+    let mut model = cm("<p>&nbsp;</p><p>&nbsp;</p><p>|</p>");
     model.backspace();
-    assert_eq!(tx(&model), "<p></p><p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p>");
 }
 
 #[test]
@@ -369,7 +369,7 @@ fn new_line_at_start_of_link_does_not_extend_it() {
     model.enter();
     assert_eq!(
         tx(&model),
-        "<p></p>\
+        "<p>&nbsp;</p>\
         <p>\
             <b>\
                 <a href=\"test\">|Test</a>\

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -40,11 +40,11 @@ fn adding_line_break_after_replacing_with_empty_html() {
 fn pressing_enter_after_backspacing_a_paragraph() {
     let mut model = cm("|");
     model.enter();
-    assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;</p><p>&nbsp;|</p>");
     model.backspace();
-    assert_eq!(tx(&model), "<p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p>");
     model.enter();
-    assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;</p><p>&nbsp;|</p>");
 }
 
 #[test]
@@ -207,7 +207,7 @@ fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_co
     assert_eq!(tx(&model), "<pre>\n|Test</pre>");
     model.select(0.into(), 0.into());
     model.enter();
-    assert_eq!(tx(&model), "<p>|</p><pre>Test</pre>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p><pre>Test</pre>");
 }
 
 #[test]
@@ -216,7 +216,10 @@ fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_co
     // The initial line break will be removed, so it's the same as having a single line break at the start
     let mut model = cm("<p>ASDA</p><pre>\n|\nTest</pre><p>ASD</p>");
     model.enter();
-    assert_eq!(tx(&model), "<p>ASDA</p><p>|</p><pre>Test</pre><p>ASD</p>")
+    assert_eq!(
+        tx(&model),
+        "<p>ASDA</p><p>&nbsp;|</p><pre>Test</pre><p>ASD</p>"
+    )
 }
 
 #[test]
@@ -234,21 +237,24 @@ fn enter_in_code_block_at_start_with_a_line_break_after_it_adds_another_one() {
 fn enter_in_code_block_after_line_break_in_middle_splits_code_block() {
     let mut model = cm("<pre>Test\n|\ncode blocks</pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>Test</pre><p>|</p><pre>code blocks</pre>")
+    assert_eq!(
+        tx(&model),
+        "<pre>Test</pre><p>&nbsp;|</p><pre>code blocks</pre>"
+    )
 }
 
 #[test]
 fn enter_in_code_block_after_nested_line_break_in_middle_splits_code_block() {
     let mut model = cm("<pre><b><i>Test\n|\ncode blocks</i></b></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre><b><i>Test</i></b></pre><p>|</p><pre><b><i>code blocks</i></b></pre>")
+    assert_eq!(tx(&model), "<pre><b><i>Test</i></b></pre><p>&nbsp;|</p><pre><b><i>code blocks</i></b></pre>")
 }
 
 #[test]
 fn enter_in_code_block_after_line_break_at_end_exits_it() {
     let mut model = cm("<pre><b>Bold</b> plain\n|</pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre><b>Bold</b> plain</pre><p>|</p>")
+    assert_eq!(tx(&model), "<pre><b>Bold</b> plain</pre><p>&nbsp;|</p>")
 }
 
 #[test]
@@ -268,7 +274,7 @@ fn double_enter_in_quote_exits_the_quote() {
     model.enter();
     assert_eq!(
         tx(&model),
-        "<blockquote><p>Left</p></blockquote><p>|</p><blockquote><p>Right</p></blockquote>"
+        "<blockquote><p>Left</p></blockquote><p>&nbsp;|</p><blockquote><p>Right</p></blockquote>"
     );
 }
 
@@ -276,21 +282,27 @@ fn double_enter_in_quote_exits_the_quote() {
 fn double_enter_in_quote_at_start_when_empty() {
     let mut model = cm("<blockquote><p>|</p></blockquote>");
     model.enter();
-    assert_eq!(tx(&model), "<p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p>");
 }
 
 #[test]
 fn double_enter_in_quote_at_start_when_not_empty() {
     let mut model = cm("<blockquote><p>|</p><p>Text</p></blockquote>");
     model.enter();
-    assert_eq!(tx(&model), "<p>|</p><blockquote><p>Text</p></blockquote>");
+    assert_eq!(
+        tx(&model),
+        "<p>&nbsp;|</p><blockquote><p>Text</p></blockquote>"
+    );
 }
 
 #[test]
 fn double_enter_in_quote_at_end_when_not_empty_exits_it() {
     let mut model = cm("<blockquote><p>Text</p><p>|</p></blockquote>");
     model.enter();
-    assert_eq!(tx(&model), "<blockquote><p>Text</p></blockquote><p>|</p>");
+    assert_eq!(
+        tx(&model),
+        "<blockquote><p>Text</p></blockquote><p>&nbsp;|</p>"
+    );
 }
 
 #[test]
@@ -299,7 +311,7 @@ fn double_enter_in_code_block_when_empty_removes_it_and_adds_new_line() {
     model.code_block();
     assert_eq!(tx(&model), "<pre>|</pre>");
     model.enter();
-    assert_eq!(tx(&model), "<p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p>");
     model.replace_text("asd".into());
     assert_eq!(tx(&model), "<p>asd|</p>");
 }
@@ -318,7 +330,7 @@ fn double_enter_in_quote_in_nested_nodes() {
         "<blockquote>\
             <p><i><b>Left</b></i></p>\
         </blockquote>\
-        <p>|</p>\
+        <p>&nbsp;|</p>\
         <blockquote>\
             <p><b><i>Right</i></b></p>\
         </blockquote>"
@@ -358,9 +370,9 @@ fn text_typed_after_line_break_goes_into_last_paragraph() {
 
 #[test]
 fn backspace_after_several_empty_paragraphs_deletes_only_one() {
-    let mut model = cm("<p>&nbsp;</p><p>&nbsp;</p><p>|</p>");
+    let mut model = cm("<p></p><p></p><p>|</p>");
     model.backspace();
-    assert_eq!(tx(&model), "<p>&nbsp;</p><p>|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;</p><p>&nbsp;|</p>");
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_undo_redo.rs
+++ b/crates/wysiwyg/src/tests/test_undo_redo.rs
@@ -173,11 +173,11 @@ fn deleting_a_selection_with_enter_only_adds_one_to_undo_stack() {
 fn undoing_enter_only_undoes_one() {
     let mut model = cm("Test|");
     model.enter();
-    assert_eq!(tx(&model), "<p>Test</p><p>|</p>");
+    assert_eq!(tx(&model), "<p>Test</p><p>&nbsp;|</p>");
     model.enter();
-    assert_eq!(tx(&model), "<p>Test</p><p>&nbsp;</p><p>|</p>");
+    assert_eq!(tx(&model), "<p>Test</p><p>&nbsp;</p><p>&nbsp;|</p>");
     model.undo();
-    assert_eq!(tx(&model), "<p>Test</p><p>|</p>");
+    assert_eq!(tx(&model), "<p>Test</p><p>&nbsp;|</p>");
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_undo_redo.rs
+++ b/crates/wysiwyg/src/tests/test_undo_redo.rs
@@ -175,7 +175,7 @@ fn undoing_enter_only_undoes_one() {
     model.enter();
     assert_eq!(tx(&model), "<p>Test</p><p>|</p>");
     model.enter();
-    assert_eq!(tx(&model), "<p>Test</p><p></p><p>|</p>");
+    assert_eq!(tx(&model), "<p>Test</p><p>&nbsp;</p><p>|</p>");
     model.undo();
     assert_eq!(tx(&model), "<p>Test</p><p>|</p>");
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
@@ -119,7 +119,7 @@ extension NSAttributedString {
     func attributedPosition(at htmlIndex: Int) throws -> Int {
         let prefixes = listPrefixesRanges()
         var actualIndex: Int = htmlIndex
-                
+
         for listPrefix in prefixes {
             if listPrefix.location < actualIndex {
                 actualIndex += listPrefix.length
@@ -132,7 +132,7 @@ extension NSAttributedString {
                 }
             }
         }
-                        
+
         guard actualIndex <= length else {
             throw AttributedRangeError
                 .outOfBoundsHtmlIndex(index: htmlIndex)

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
@@ -66,7 +66,7 @@ public final class HTMLParser {
         guard !html.isEmpty else {
             return NSAttributedString(string: "")
         }
-                
+
         guard let data = html.data(using: encoding) else {
             throw BuildHtmlAttributedError.dataError(encoding: encoding)
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
@@ -66,7 +66,7 @@ public final class HTMLParser {
         guard !html.isEmpty else {
             return NSAttributedString(string: "")
         }
-        
+                
         guard let data = html.data(using: encoding) else {
             throw BuildHtmlAttributedError.dataError(encoding: encoding)
         }
@@ -112,6 +112,18 @@ public final class HTMLParser {
         mutableAttributedString.addAttribute(.paragraphStyle,
                                              value: NSParagraphStyle.default,
                                              range: .init(location: 0, length: mutableAttributedString.length))
+        
+        // Removing NBSP character from <p>&nbsp;</p> since is only used to
+        // make DTCoreText able to easily parse new lines
+        mutableAttributedString.mutableString.replaceOccurrences(
+            of: "\u{00A0}",
+            with: "",
+            options: NSString.CompareOptions.literal,
+            range: NSRange(
+                location: 0,
+                length: mutableAttributedString.length
+            )
+        )
         
         removeTrailingNewlineIfNeeded(from: mutableAttributedString, given: html)
         return mutableAttributedString


### PR DESCRIPTION
This should allow DTCoreText and Web to easily parse empty paragraphs as new lines, however this character should then be removed on the client.