### PR TITLE
Add editor HTMLElement in inputEventProcessor

### DIFF
--- a/platforms/web/lib/composer.test.ts
+++ b/platforms/web/lib/composer.test.ts
@@ -107,6 +107,8 @@ const testCases: testCase[] = [
     },
 ];
 
+const editor = document.createElement('div');
+
 describe('processInput', () => {
     beforeEach(() => {
         vi.resetAllMocks();
@@ -134,6 +136,7 @@ describe('processInput', () => {
                 mockComposerModel,
                 mockAction,
                 mockFormattingFunctions,
+                editor,
             );
 
             // check the calls to the composerModel and the action function
@@ -160,6 +163,7 @@ describe('processInput', () => {
             mockComposerModel,
             mockAction,
             mockFormattingFunctions,
+            editor,
             mockInputEventProcessor,
         );
 
@@ -184,6 +188,7 @@ describe('processInput', () => {
                 mockComposerModel,
                 mockAction,
                 mockFormattingFunctions,
+                editor,
             );
 
             expect(mockGetter).toHaveBeenCalledTimes(1);
@@ -204,6 +209,7 @@ describe('processInput', () => {
             mockComposerModel,
             mockAction,
             mockFormattingFunctions,
+            editor,
         );
 
         // Then mockAction have is not called
@@ -220,6 +226,7 @@ describe('processInput', () => {
             mockComposerModel,
             mockAction,
             mockFormattingFunctions,
+            editor,
         );
 
         // Then mockAction have is not called
@@ -236,6 +243,7 @@ describe('processInput', () => {
             mockComposerModel,
             mockAction,
             mockFormattingFunctions,
+            editor,
         );
 
         // Then mockAction is not called and we get null back
@@ -253,6 +261,7 @@ describe('processInput', () => {
             mockComposerModel,
             mockAction,
             mockFormattingFunctions,
+            editor,
         );
 
         // Then mockAction is not called, we get null back and there is an error

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -28,10 +28,11 @@ import { TestUtilities } from './useTestCases/types';
 export function processEvent<T extends WysiwygEvent>(
     e: T,
     wysiwyg: Wysiwyg,
+    editor: HTMLElement,
     inputEventProcessor?: InputEventProcessor,
 ): T | null {
     if (inputEventProcessor) {
-        return inputEventProcessor(e, wysiwyg) as T | null;
+        return inputEventProcessor(e, wysiwyg, editor) as T | null;
     } else {
         return e;
     }
@@ -42,6 +43,7 @@ export function processInput(
     composerModel: ComposerModel,
     action: TestUtilities['traceAction'],
     formattingFunctions: FormattingFunctions,
+    editor: HTMLElement,
     inputEventProcessor?: InputEventProcessor,
 ) {
     const event = processEvent(
@@ -50,6 +52,7 @@ export function processInput(
             actions: formattingFunctions,
             content: () => composerModel.get_content_as_html(),
         },
+        editor,
         inputEventProcessor,
     );
     if (!event) {

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -53,4 +53,5 @@ export type Wysiwyg = {
 export type InputEventProcessor = (
     event: WysiwygEvent,
     wysiwyg: Wysiwyg,
+    editor: HTMLElement,
 ) => WysiwygEvent | null;

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -64,6 +64,7 @@ function getInputFromKeyDown(
     e: KeyboardEvent,
     composerModel: ComposerModel,
     formattingFunctions: FormattingFunctions,
+    editor: HTMLElement,
     inputEventProcessor?: InputEventProcessor,
 ): BlockType | null {
     if (e.shiftKey && e.altKey) {
@@ -98,6 +99,7 @@ function getInputFromKeyDown(
             actions: formattingFunctions,
             content: () => composerModel.get_content_as_html(),
         },
+        editor,
         inputEventProcessor,
     );
     return null;
@@ -119,6 +121,7 @@ export function handleKeyDown(
         e,
         composerModel,
         formattingFunctions,
+        editor,
         inputEventProcessor,
     );
     if (inputType) {
@@ -167,6 +170,7 @@ export function handleInput(
         composerModel,
         testUtilities.traceAction,
         formattingFunctions,
+        editor,
         inputEventProcessor,
     );
     if (update) {

--- a/platforms/web/lib/useWysiwyg.inputEventProcessor.test.tsx
+++ b/platforms/web/lib/useWysiwyg.inputEventProcessor.test.tsx
@@ -43,6 +43,7 @@ describe('inputEventProcessor', () => {
                     code: 'KeyA',
                 }),
                 expect.anything(),
+                textbox,
             );
         });
     });


### PR DESCRIPTION
I added the current editor as parameter of the inputEventProcessor (I need it in the react-sdk)

The code coverage is kinda lying, the editor variable is checked in [useWysiwyg.inputEventProcessor.test.tsx](https://github.com/matrix-org/matrix-rich-text-editor/pull/512/files#diff-9ff31a1c6708b82f544f5f4bbe90d85aa70200ae0a5ef435824eb1a877fb34ea)