### PR TITLE
Only remove non-useful NBSP and fix some broken tests

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTHTMLElement.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTHTMLElement.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import DTCoreText
+
+extension DTHTMLElement {
+    /// Clears any only child consisting of a single non-breaking space.
+    func clearNbspNodes() {
+        guard let childNodes = childNodes as? [DTHTMLElement] else { return }
+
+        if childNodes.count == 1,
+           let child = childNodes.first as? DTTextHTMLElement,
+           child.text() == "\u{00A0}" {
+            removeAllChildNodes()
+        } else {
+            for childNode in childNodes {
+                childNode.clearNbspNodes()
+            }
+        }
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/TestConstants.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/TestConstants.swift
@@ -19,4 +19,5 @@ enum TestConstants {
     /// String is actually 6 char long "abc🎉🎉👩🏿‍🚀" and represents 14 UTF-16 code units (3+2+2+7)
     static let testStringWithEmojis = "abc🎉\u{1f389}\u{1F469}\u{1F3FF}\u{200D}\u{1F680}"
     static let testStringAfterBackspace = "abc🎉🎉"
+    static let nbsp = "\u{00A0}"
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
@@ -18,7 +18,7 @@
 import XCTest
 
 private enum Constants {
-    static let resultHtml = "<pre>Some code\n\tmore code</pre><p></p>"
+    static let resultHtml = "<pre>Some code\n\tmore code</pre><p>\(TestConstants.nbsp)</p>"
     static let resultTree =
         """
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Lists.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Lists.swift
@@ -33,7 +33,7 @@ extension WysiwygComposerTests {
         // Remove it
         _ = composer.enter()
         XCTAssertEqual(composer.getContentAsHtml(),
-                       "<ol><li>Item 1</li><li>Item 2</li></ol><p></p>")
+                       "<ol><li>Item 1</li><li>Item 2</li></ol><p>\(TestConstants.nbsp)</p>")
         XCTAssertEqual(composer.getCurrentDomState().start, composer.getCurrentDomState().end)
         XCTAssertEqual(composer.getCurrentDomState().start, 14)
         // Insert some text afterwards

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Quotes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Quotes.swift
@@ -18,7 +18,7 @@
 import XCTest
 
 private enum Constants {
-    static let resultHtml = "<blockquote><p>Some quote</p><p>More text</p></blockquote><p></p>"
+    static let resultHtml = "<blockquote><p>Some quote</p><p>More text</p></blockquote><p>\(TestConstants.nbsp)</p>"
     static let resultTree =
         """
 


### PR DESCRIPTION
* Removes NBSP from only child text nodes instead of all of them.
* Fixes broken tests that now involves some created NBSP.