### PR TITLE
Rendering improvement for codeblock and quoteblocks

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTHTMLElement.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTHTMLElement.swift
@@ -23,7 +23,7 @@ extension DTHTMLElement {
 
         if childNodes.count == 1,
            let child = childNodes.first as? DTTextHTMLElement,
-           child.text() == "\u{00A0}" {
+           child.text() == .nbsp {
             removeAllChildNodes()
         } else {
             for childNode in childNodes {

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/String+Character.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/String+Character.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The Matrix.org Foundation C.I.C
+// Copyright 2023 The Matrix.org Foundation C.I.C
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
 // limitations under the License.
 //
 
-enum TestConstants {
-    /// Test string with emojis inputed both with codepoints and Xcode emoji insertion.
-    /// String is actually 6 char long "abc🎉🎉👩🏿‍🚀" and represents 14 UTF-16 code units (3+2+2+7)
-    static let testStringWithEmojis = "abc🎉\u{1f389}\u{1F469}\u{1F3FF}\u{200D}\u{1F680}"
-    static let testStringAfterBackspace = "abc🎉🎉"
+extension String {
+    static let nbsp = "\(Character.nbsp)"
+}
+
+public extension Character {
+    static let nbsp = Character("\u{00A0}")
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
@@ -133,9 +133,9 @@ public final class HTMLParser {
         if mutableAttributedString.string.last == "\n",
            !html.hasSuffix("</code>"),
            !html.hasSuffix("</a>"),
-           !html.hasSuffix("</p><p></p></blockquote>"),
-           !html.hasSuffix("</ul><p></p></blockquote>"),
-           !html.hasSuffix("</ol><p></p></blockquote>"),
+           !html.hasSuffix("</p><p>\(Character.nbsp)</p></blockquote>"),
+           !html.hasSuffix("</ul><p>\(Character.nbsp)</p></blockquote>"),
+           !html.hasSuffix("</ol><p>\(Character.nbsp)</p></blockquote>"),
            !html.hasSuffix("\n</pre>") {
             mutableAttributedString.deleteCharacters(in: NSRange(location: mutableAttributedString.length - 1, length: 1))
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -240,6 +240,9 @@ public extension WysiwygComposerViewModel {
             shouldAcceptChange = false
         } else if replacementText.count == 1, replacementText[String.Index(utf16Offset: 0, in: replacementText)].isNewline {
             update = model.enter()
+            if model.actionStates()[.codeBlock] == .reversed || model.actionStates()[.quote] == .reversed {
+                hasPendingFormats = true
+            }
             shouldAcceptChange = false
         } else {
             update = model.replaceText(newText: replacementText)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
@@ -117,7 +117,7 @@ private struct StringDiff {
 private extension String {
     /// Converts all whitespaces to NBSP to avoid diffs caused by HTML translations.
     var withNBSP: String {
-        String(map { $0.isWhitespace ? Character("\u{00A0}") : $0 })
+        String(map { $0.isWhitespace ? Character.nbsp : $0 })
     }
 
     /// Computes the diff from provided string to self. Outputs UTF16 locations and lengths.

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
@@ -65,7 +65,7 @@ final class StringDifferTests: XCTestCase {
                 .filter(\.isWhitespace)
         )
         XCTAssertNil(try StringDiffer.replacement(from: whitespaceString,
-                                                  to: String(repeating: "\u{00A0}", count: whitespaceString.utf16Length)))
+                                                  to: String(repeating: .nbsp, count: whitespaceString.utf16Length)))
     }
 }
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
@@ -18,7 +18,7 @@
 import XCTest
 
 private enum Constants {
-    static let resultHtml = "<pre>Some code\n\tmore code</pre><p>\(TestConstants.nbsp)</p>"
+    static let resultHtml = "<pre>Some code\n\tmore code</pre><p>\(Character.nbsp)</p>"
     static let resultTree =
         """
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Lists.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Lists.swift
@@ -33,7 +33,7 @@ extension WysiwygComposerTests {
         // Remove it
         _ = composer.enter()
         XCTAssertEqual(composer.getContentAsHtml(),
-                       "<ol><li>Item 1</li><li>Item 2</li></ol><p>\(TestConstants.nbsp)</p>")
+                       "<ol><li>Item 1</li><li>Item 2</li></ol><p>\(Character.nbsp)</p>")
         XCTAssertEqual(composer.getCurrentDomState().start, composer.getCurrentDomState().end)
         XCTAssertEqual(composer.getCurrentDomState().start, 14)
         // Insert some text afterwards

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Quotes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Quotes.swift
@@ -18,7 +18,7 @@
 import XCTest
 
 private enum Constants {
-    static let resultHtml = "<blockquote><p>Some quote</p><p>More text</p></blockquote><p>\(TestConstants.nbsp)</p>"
+    static let resultHtml = "<blockquote><p>Some quote</p><p>More text</p></blockquote><p>\(Character.nbsp)</p>"
     static let resultTree =
         """
 


### PR DESCRIPTION
- The pending format is also added when a newline is entered and either blockquote or codeblock are reversed (now the rendering is triggered as soon as a character is typed also on lines that are not the first)
- Fixed a bug, that deleted blockquotes last newline
- nbsp is now as static variable in String and Character