### PR TITLE
[iOS] Fix nbsp parsing with discardable text

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTCoreText/DTHTMLElement.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTCoreText/DTHTMLElement.swift
@@ -25,6 +25,10 @@ extension DTHTMLElement {
            let child = childNodes.first as? DTTextHTMLElement,
            child.text() == .nbsp {
             removeAllChildNodes()
+            let newChild = DiscardableTextHTMLElement(from: child)
+            addChildNode(newChild)
+            newChild.inheritAttributes(from: self)
+            newChild.interpretAttributes()
         } else {
             for childNode in childNodes {
                 childNode.clearNbspNodes()

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTCoreText/DiscardableTextHTMLElement.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTCoreText/DiscardableTextHTMLElement.swift
@@ -15,12 +15,21 @@
 //
 
 import DTCoreText
-import Foundation
 
-extension NSAttributedString.Key {
-    static let DTTextBlocks: NSAttributedString.Key = .init(rawValue: DTTextBlocksAttribute)
-    static let backgroundStyle: NSAttributedString.Key = .init(rawValue: "BackgroundStyleAttributeKey")
-    static let DTField: NSAttributedString.Key = .init(rawValue: DTFieldAttribute)
-    static let DTTextLists: NSAttributedString.Key = .init(rawValue: DTTextListsAttribute)
-    static let discardableText: NSAttributedString.Key = .init(rawValue: "DiscardableAttributeKey")
+final class DiscardableTextHTMLElement: DTTextHTMLElement {
+    /// Init.
+    ///
+    /// - Parameters:
+    ///   - textNode: text node that should be copied into the element.
+    init(from textNode: DTTextHTMLElement) {
+        super.init()
+        setText(textNode.text())
+    }
+
+    override func attributesForAttributedStringRepresentation() -> [AnyHashable: Any]! {
+        var dict = super.attributesForAttributedStringRepresentation() ?? [AnyHashable: Any]()
+        // Insert a key to mark this as discardable post-parsing.
+        dict[NSAttributedString.Key.discardableText] = true
+        return dict
+    }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
@@ -50,4 +50,13 @@ extension NSMutableAttributedString {
             addAttribute(.backgroundColor, value: codeBackgroundColor, range: range)
         }
     }
+
+    /// Removes any text that has been marked as discardable.
+    func removeDiscardableText() {
+        enumerateTypedAttribute(.discardableText) { (discardable: Bool, range: NSRange, _) in
+            guard discardable == true else { return }
+
+            self.deleteCharacters(in: range)
+        }
+    }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
@@ -114,6 +114,7 @@ public final class HTMLParser {
         
         mutableAttributedString.applyBackgroundStyles(style: style)
         mutableAttributedString.applyInlineCodeBackgroundStyle(codeBackgroundColor: style.codeBackgroundColor)
+        mutableAttributedString.removeDiscardableText()
         
         // FIXME: This solution might not fit for everything.
         mutableAttributedString.addAttribute(.paragraphStyle,

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
@@ -128,15 +128,12 @@ public final class HTMLParser {
     private static func removeTrailingNewlineIfNeeded(from mutableAttributedString: NSMutableAttributedString, given html: String) {
         // DTCoreText always adds a \n at the end of the document, which we need to remove
         // however it does not add it if </code> </a> are the last nodes.
-        // Also we don't want to remove it if blockquote and codeblock contain that newline
-        // and are not empty, because DTCoreText does not add a newline if these blocks
+        // Also we don't want to remove it if q codeblock contains that newline
+        // and is not empty, because DTCoreText does not add a newline if these blocks
         // contain one at the end.
         if mutableAttributedString.string.last == "\n",
            !html.hasSuffix("</code>"),
            !html.hasSuffix("</a>"),
-           !html.hasSuffix("</p><p>\(Character.nbsp)</p></blockquote>"),
-           !html.hasSuffix("</ul><p>\(Character.nbsp)</p></blockquote>"),
-           !html.hasSuffix("</ol><p>\(Character.nbsp)</p></blockquote>"),
            !html.hasSuffix("\n</pre>") {
             mutableAttributedString.deleteCharacters(in: NSRange(location: mutableAttributedString.length - 1, length: 1))
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
@@ -128,7 +128,7 @@ public final class HTMLParser {
     private static func removeTrailingNewlineIfNeeded(from mutableAttributedString: NSMutableAttributedString, given html: String) {
         // DTCoreText always adds a \n at the end of the document, which we need to remove
         // however it does not add it if </code> </a> are the last nodes.
-        // Also we don't want to remove it if q codeblock contains that newline
+        // Also we don't want to remove it if a codeblock contains that newline
         // and is not empty, because DTCoreText does not add a newline if these blocks
         // contain one at the end.
         if mutableAttributedString.string.last == "\n",


### PR DESCRIPTION
Should fix issue with nbsp parsing by marking it for removal instead of removing immediately. 