### PR TITLE
[Android] Paragraphs: allow backspacing in index 0

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -198,7 +198,6 @@ internal class InterceptInputConnection(
     internal fun onHardwareBackspaceKey(): Boolean {
         val start = Selection.getSelectionStart(editable)
         val end = Selection.getSelectionEnd(editable)
-        if (start == 0 && end == 0) return false
 
         val toDelete = if (start == end) 1 else abs(start - end)
         // We're going to copy backspace behaviour, the selection must be at the greater value


### PR DESCRIPTION
Just removed a check that prevented backspacing from working on index 0. Should fix [`PSU-1091`](https://element-io.atlassian.net/browse/PSU-1091).