### PR TITLE
NBSP Char in empty paragraphs in `<pre>`

### DIFF
--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -253,7 +253,7 @@ mod test {
     fn add_code_block_to_empty_dom() {
         let mut model = cm("|");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>|</pre>");
+        assert_eq!(tx(&model), "<pre>&nbsp;|</pre>");
     }
 
     #[test]
@@ -432,14 +432,14 @@ mod test {
     fn test_creating_code_block_at_the_end_of_editor() {
         let mut model = cm("<p>Test</p><p>|</p>");
         model.code_block();
-        assert_eq!(tx(&model), "<p>Test</p><pre>|</pre>");
+        assert_eq!(tx(&model), "<p>Test</p><pre>&nbsp;|</pre>");
     }
 
     #[test]
     fn creating_and_removing_code_block_works() {
         let mut model = cm("|");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>|</pre>");
+        assert_eq!(tx(&model), "<pre>&nbsp;|</pre>");
         model.code_block();
         assert_eq!(tx(&model), "<p>&nbsp;|</p>");
     }
@@ -448,7 +448,7 @@ mod test {
     fn add_code_block_to_empty_list_item() {
         let mut model = cm("<ul><li>|</li></ul>");
         model.code_block();
-        assert_eq!(tx(&model), "<ul><li><pre>|</pre></li></ul>");
+        assert_eq!(tx(&model), "<ul><li><pre>&nbsp;|</pre></li></ul>");
         assert_eq!(
             model.to_tree().to_string(),
             indoc! {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -594,6 +594,9 @@ where
         if matches!(self.kind, ContainerNodeKind::Paragraph)
             && state.is_inside_code_block
         {
+            if self.is_empty() {
+                formatter.push(char::nbsp());
+            }
             self.fmt_children_html(formatter, selection_writer, state);
             if !state.is_last_node_in_parent {
                 formatter.push('\n');

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -184,14 +184,14 @@ fn backspace_merges_formatting_nodes() {
 fn enter_in_code_block_in_text_node_adds_line_break_as_text() {
     let mut model = cm("<pre>Test|</pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>Test\n|</pre>")
+    assert_eq!(tx(&model), "<pre>Test\n&nbsp;|</pre>")
 }
 
 #[test]
 fn enter_in_code_block_at_start_adds_the_line_break() {
     let mut model = cm("<pre>|Test</pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>\n|Test</pre>")
+    assert_eq!(tx(&model), "<pre>&nbsp;\n|Test</pre>")
 }
 
 #[test]
@@ -204,7 +204,7 @@ fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_co
     model.select(0.into(), 0.into());
     assert_eq!(tx(&model), "<pre>|Test</pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>\n|Test</pre>");
+    assert_eq!(tx(&model), "<pre>&nbsp;\n|Test</pre>");
     model.select(0.into(), 0.into());
     model.enter();
     assert_eq!(tx(&model), "<p>&nbsp;|</p><pre>Test</pre>");
@@ -225,12 +225,9 @@ fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_co
 #[test]
 fn enter_in_code_block_at_start_with_a_line_break_after_it_adds_another_one() {
     // The initial line break will be removed, so it's the same as having a single line break at the start
-    let mut model = cm("\
-    <pre>\n\
-        \n|Test\
-    </pre>");
+    let mut model = cm("<pre>\n\n|Test</pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>\n\n|Test</pre>")
+    assert_eq!(tx(&model), "<pre>&nbsp;\n&nbsp;\n|Test</pre>")
 }
 
 #[test]
@@ -413,5 +410,5 @@ fn pressing_enter_after_wrapping_text_in_code_block_works() {
     model.replace_text("Some code".into());
     model.code_block();
     model.enter();
-    assert_eq!(tx(&model), "<pre>Some code\n|</pre>")
+    assert_eq!(tx(&model), "<pre>Some code\n&nbsp;|</pre>")
 }

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -309,7 +309,7 @@ fn double_enter_in_quote_at_end_when_not_empty_exits_it() {
 fn double_enter_in_code_block_when_empty_removes_it_and_adds_new_line() {
     let mut model = cm("|");
     model.code_block();
-    assert_eq!(tx(&model), "<pre>|</pre>");
+    assert_eq!(tx(&model), "<pre>&nbsp;|</pre>");
     model.enter();
     assert_eq!(tx(&model), "<p>&nbsp;|</p>");
     model.replace_text("asd".into());


### PR DESCRIPTION
Empty paragraphs in `<pre>` will now be added as an nbsp character in the `fmt_html` function.
At first I just wanted to have this character present for empty `<pre>` and on trailing newlines, but it seems we might actually need it on iOS for each newline (since DTCoreText seems to ignore newlines in cases like this: `<pre>\nTest</pre>
`)