### PR TITLE
Fix reversed actions in nested/indented lists

### DIFF
--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -21,7 +21,7 @@ use crate::dom::range::DomLocationPosition;
 use crate::dom::range::DomLocationPosition::Before;
 use crate::dom::{DomLocation, Range};
 use crate::menu_state::MenuStateUpdate;
-use crate::ComposerAction::{Indent, UnIndent};
+use crate::ComposerAction::{Indent, OrderedList, UnIndent, UnorderedList};
 use crate::{
     ComposerAction, ComposerModel, DomHandle, DomNode, InlineFormatType,
     ListType, MenuState, UnicodeString,
@@ -134,24 +134,42 @@ where
         &self,
         handle: &DomHandle,
     ) -> HashSet<ComposerAction> {
-        let mut reversed_actions = HashSet::new();
-        let node = self.state.dom.lookup_node(handle);
-        if let DomNode::Container(container) = node {
-            let active_button = Self::active_button_for_container(container);
-            if let Some(button) = active_button {
-                reversed_actions.insert(button);
-            }
+        fn has_list_in(set: &HashSet<ComposerAction>) -> bool {
+            set.contains(&OrderedList) || set.contains(&UnorderedList)
         }
 
-        if handle.has_parent() {
-            reversed_actions = reversed_actions
-                .union(&self.compute_reversed_actions(&handle.parent_handle()))
-                .into_iter()
-                .cloned()
-                .collect();
+        let mut reversed_actions = HashSet::new();
+        let mut cur_handle = handle.clone();
+
+        while !cur_handle.is_root() {
+            let active_button = self.active_button_for_handle(&cur_handle);
+            if let Some(button) = active_button {
+                match button {
+                    // If there is multiple list types in the hierarchy we
+                    // only keep the deepest list type.
+                    OrderedList | UnorderedList
+                        if has_list_in(&reversed_actions) => {}
+                    _ => {
+                        reversed_actions.insert(button);
+                    }
+                }
+            }
+            cur_handle = cur_handle.parent_handle();
         }
 
         reversed_actions
+    }
+
+    fn active_button_for_handle(
+        &self,
+        handle: &DomHandle,
+    ) -> Option<ComposerAction> {
+        let node = self.state.dom.lookup_node(handle);
+        if let DomNode::Container(container) = node {
+            Self::active_button_for_container(container)
+        } else {
+            None
+        }
     }
 
     fn active_button_for_container(

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -142,15 +142,15 @@ where
         let mut cur_handle = handle.clone();
 
         while !cur_handle.is_root() {
-            let active_button = self.active_button_for_handle(&cur_handle);
-            if let Some(button) = active_button {
-                match button {
+            let reversed_action = self.reversed_action_for_handle(&cur_handle);
+            if let Some(action) = reversed_action {
+                match action {
                     // If there is multiple list types in the hierarchy we
                     // only keep the deepest list type.
                     OrderedList | UnorderedList
                         if has_list_in(&reversed_actions) => {}
                     _ => {
-                        reversed_actions.insert(button);
+                        reversed_actions.insert(action);
                     }
                 }
             }
@@ -160,19 +160,19 @@ where
         reversed_actions
     }
 
-    fn active_button_for_handle(
+    fn reversed_action_for_handle(
         &self,
         handle: &DomHandle,
     ) -> Option<ComposerAction> {
         let node = self.state.dom.lookup_node(handle);
         if let DomNode::Container(container) = node {
-            Self::active_button_for_container(container)
+            Self::reversed_action_for_container(container)
         } else {
             None
         }
     }
 
-    fn active_button_for_container(
+    fn reversed_action_for_container(
         container: &ContainerNode<S>,
     ) -> Option<ComposerAction> {
         match container.kind() {

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -190,6 +190,28 @@ fn formatting_is_disabled_when_selection_covers_inline_code_node_and_others() {
 }
 
 #[test]
+fn selecting_indented_list_only_marks_the_deepest_list_type_as_reversed() {
+    let model = cm("<ol><li><p>Item 1</p><ul><li>Item 1|A</li></ul></li></ol>");
+    assert!(!model.action_is_reversed(ComposerAction::OrderedList));
+    assert!(model.action_is_reversed(ComposerAction::UnorderedList));
+}
+
+#[test]
+fn selecting_cross_unmatching_indented_list_exclude_both_list_types() {
+    let model =
+        cm("<ol><li><p>It{em 1</p><ul><li>Item 1}|A</li></ul></li></ol>");
+    assert!(!model.action_is_reversed(ComposerAction::OrderedList));
+    assert!(!model.action_is_reversed(ComposerAction::UnorderedList));
+}
+
+#[test]
+fn selecting_cross_matching_indented_list_include_list_type() {
+    let model =
+        cm("<ol><li><p>It{em 1</p><ol><li>Item 1}|A</li></ol></li></ol>");
+    assert!(model.action_is_reversed(ComposerAction::OrderedList));
+}
+
+#[test]
 fn clicking_code_block_disables_expected_formatting_functions() {
     let mut model = cm("|");
     model.code_block();

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -191,9 +191,13 @@ fn formatting_is_disabled_when_selection_covers_inline_code_node_and_others() {
 
 #[test]
 fn selecting_indented_list_only_marks_the_deepest_list_type_as_reversed() {
-    let model = cm("<ol><li><p>Item 1</p><ul><li>Item 1|A</li></ul></li></ol>");
+    let mut model = cm("<ol><li><p>Item 1</p><ul><li><p>Item 1|A</p><ol><li>Item1A1</li></ol></li></ul></li></ol>");
     assert!(!model.action_is_reversed(ComposerAction::OrderedList));
     assert!(model.action_is_reversed(ComposerAction::UnorderedList));
+    // Select inside deeper ordered list.
+    model.select(Location::from(15), Location::from(15));
+    assert!(!model.action_is_reversed(ComposerAction::UnorderedList));
+    assert!(model.action_is_reversed(ComposerAction::OrderedList));
 }
 
 #[test]


### PR DESCRIPTION
* Fixes issue with unmatching(type) indented lists marking both list types as reversed
* Renaming `active_button` to `reversed_action` to match rest of the naming

Fixes #510 