### PR TITLE
Fix menu state when adding inline_code to `toggled_format_types`

### DIFF
--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -210,7 +210,15 @@ where
         if !self.can_unindent(&top_most_list_locations) {
             disabled_actions.insert(UnIndent);
         }
-        if contains_inline_code(locations) {
+        // XOR on inline code in selection & toggled format types.
+        // If selection is not a cursor, toggled format types is always
+        // empty, which makes `contains_inline_code` the only condition.
+        if contains_inline_code(locations)
+            ^ self
+                .state
+                .toggled_format_types
+                .contains(&InlineFormatType::InlineCode)
+        {
             // Remove the rest of inline formatting options
             disabled_actions.extend(vec![
                 ComposerAction::Bold,

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -230,6 +230,27 @@ fn code_block_doesnt_affect_cursor_if_its_outside() {
     assert!(model.action_is_enabled(ComposerAction::OrderedList));
 }
 
+#[test]
+fn enable_inline_code_with_cursor_immediately_updates_disabled_actions() {
+    let mut model = cm("|");
+    model.inline_code();
+    assert_formatting_actions_and_links_are_disabled(&model);
+}
+
+#[test]
+fn disable_inline_code_with_cursor_immediately_updates_disabled_actions() {
+    let mut model = cm("<code>some code|</code>");
+    model.inline_code();
+    // Inline code is not marked as reversed anymore
+    assert!(!model.action_is_reversed(ComposerAction::InlineCode));
+    // Other format types and link are enabled again
+    assert!(model.action_is_enabled(ComposerAction::Bold));
+    assert!(model.action_is_enabled(ComposerAction::Italic));
+    assert!(model.action_is_enabled(ComposerAction::Underline));
+    assert!(model.action_is_enabled(ComposerAction::StrikeThrough));
+    assert!(model.action_is_enabled(ComposerAction::Link));
+}
+
 fn assert_formatting_actions_and_links_are_disabled(
     model: &ComposerModel<Utf16String>,
 ) {


### PR DESCRIPTION
Menu state is now properly and immediately updated when hitting the inline code button while on a cursor (zero-length selection). 

Fixes #495 