### PR TITLE
Fix: insert paragraph at the start of a block node with enter

### DIFF
--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -230,7 +230,7 @@ where
             };
             let mut new_paragraph_handle =
                 first_leaf.node_handle.sub_handle_up_to(depth);
-            if self.state.dom.contains(&new_paragraph_handle) {
+            if paragraph_location.start_offset > 0 {
                 new_paragraph_handle = new_paragraph_handle.next_sibling();
             }
             self.state
@@ -253,7 +253,15 @@ where
             } else if block_node_is_paragraph && cur_block_node_was_removed {
                 let new_paragraph = DomNode::new_paragraph(Vec::new());
                 self.state.dom.insert_at(&block_node_handle, new_paragraph);
-                // self.state.advance_selection();
+            } else if paragraph_location.node_handle.index_in_parent() == 0
+                && paragraph_location.start_offset == 0
+            {
+                // Special case when we need to insert a new paragraph at the start of the parent
+                // block handle
+                self.state.dom.insert_at(
+                    &paragraph_location.node_handle,
+                    DomNode::new_paragraph(Vec::new()),
+                );
             }
         } else {
             // Just add a new paragraph before the current block

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -412,3 +412,20 @@ fn pressing_enter_after_wrapping_text_in_code_block_works() {
     model.enter();
     assert_eq!(tx(&model), "<pre>Some code\n&nbsp;|</pre>")
 }
+
+#[test]
+fn pressing_enter_at_the_start_of_a_multiline_code_block() {
+    let mut model = cm("<pre>|line_1\nline_2</pre>");
+    model.enter();
+    assert_eq!(tx(&model), "<pre>&nbsp;\n|line_1\nline_2</pre>")
+}
+
+#[test]
+fn pressing_enter_at_the_start_of_a_multiline_block_quote() {
+    let mut model = cm("<blockquote><p>|line_1</p><p>line_2</p></blockquote>");
+    model.enter();
+    assert_eq!(
+        tx(&model),
+        "<blockquote><p>&nbsp;</p><p>|line_1</p><p>line_2</p></blockquote>"
+    )
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -220,12 +220,12 @@ internal class HtmlToSpansParser(
                 val last = getLastPending<PlaceholderSpan.CodeBlock>() ?: return
                 val start = last.start
 
-                val lastNewLine = max(text.lastIndexOf('\n') + 1, start);
-                handleNbspInBlock(lastNewLine)
-
-                if (text.lastOrNull() == '\n') {
-                    // Extra char to properly render empty new lines in code blocks
-                    handleNbspInBlock(text.length)
+                handleNbspInBlock(start)
+                for (i in start+1 until text.length) {
+                    if (text[i] == NBSP) {
+                        // Extra char to properly render empty new lines in code blocks
+                        handleNbspInBlock(i)
+                    }
                 }
 
                 val codeSpan = CodeBlockSpan(styleConfig.codeBlock.leadingMargin, styleConfig.codeBlock.verticalPadding)
@@ -346,9 +346,9 @@ internal class HtmlToSpansParser(
             // If there was no NBSP char, add a new one as an extra character
             text.append(NBSP)
             addPendingSpan(ExtraCharacterSpan(), pos, pos + 1, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
-        } else if (text.length - pos == 1 && text.last() == NBSP) {
+        } else if (text.length > pos && text[pos] == NBSP) {
             // If there was one, set it as an extra character
-            addPendingSpan(ExtraCharacterSpan(), pos, text.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+            addPendingSpan(ExtraCharacterSpan(), pos, pos+1, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
         }
     }
 


### PR DESCRIPTION
## What?

We had an issue where adding a new line at the start of the 1st paragraph inside a block node with multiple children wouldn't actually create a new paragraph at the start and would move the selected paragraph around instead.

We now check for this particular case and fix this behaviour. It also fixes a bug related to this issue in Android.

## Why?

Fixes [`PSU-1092`](https://element-io.atlassian.net/browse/PSU-1092) <del>and  #491</del> (my bad, it's not the same issue).