### PR TITLE
Paragraphs edge cases

### DIFF
--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -40,20 +40,6 @@ function setEditorHtml(html: string) {
     editor.innerHTML = html + '<br />';
 }
 
-describe('WIP', () => {
-    it('formatting inside lists', () => {
-        // When
-        setEditorHtml('<ol><li>reg <strong>b</strong></li></ol>');
-        const { node, offset } = computeNodeAndOffset(editor, 5);
-
-        // Then
-        expect(node).toBe(
-            editor.childNodes[0].childNodes[0].childNodes[1].childNodes[0],
-        );
-        expect(offset).toBe(1);
-    });
-});
-
 describe('computeNodeAndOffset', () => {
     it('Should find at the start of simple text', () => {
         // When
@@ -1034,5 +1020,15 @@ describe('textNodeNeedsExtraOffset', () => {
             editor.childNodes[0].childNodes[1].childNodes[0],
         );
         expect(textNodeNeedsExtraOffset(wordsNode)).toBe(true);
+    });
+
+    it('can handle formatting inside list items with nested formatting', () => {
+        // When
+        setEditorHtml('<ol><li>reg <strong>b</strong></li></ol>');
+        const { node } = computeNodeAndOffset(editor, 0);
+
+        // Then
+        expect(node).toBe(editor.childNodes[0].childNodes[0].childNodes[0]);
+        expect(textNodeNeedsExtraOffset(node)).toBe(false);
     });
 });

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -40,6 +40,20 @@ function setEditorHtml(html: string) {
     editor.innerHTML = html + '<br />';
 }
 
+describe('WIP', () => {
+    it('formatting inside lists', () => {
+        // When
+        setEditorHtml('<ol><li>reg <strong>b</strong></li></ol>');
+        const { node, offset } = computeNodeAndOffset(editor, 5);
+
+        // Then
+        expect(node).toBe(
+            editor.childNodes[0].childNodes[0].childNodes[1].childNodes[0],
+        );
+        expect(offset).toBe(1);
+    });
+});
+
 describe('computeNodeAndOffset', () => {
     it('Should find at the start of simple text', () => {
         // When

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -20,7 +20,6 @@ import {
     getCurrentSelection,
     textNodeNeedsExtraOffset,
 } from './dom';
-
 let beforeEditor: HTMLDivElement;
 let editor: HTMLDivElement;
 let afterEditor: HTMLDivElement;

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -462,7 +462,7 @@ export function textNodeNeedsExtraOffset(node: Node | null) {
     while (checkNode) {
         // break the loop and return false if
         // either we find an inline node next
-        // or we have a formatting ancestor and the next sibng is not
+        // or we have a formatting ancestor and the next sibling is not
         // a container node
         const nextSibling = checkNode.nextSibling;
         if (

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -460,13 +460,16 @@ export function textNodeNeedsExtraOffset(node: Node | null) {
     // make sure that we don't add the offset more than once when we have
     // multiple adjacent inline formatting nodes.
     while (checkNode) {
-        // if we have a formatting ancestor and the next sibling is not a
-        // container node, stop looking (and return false)
+        // break the loop and return false if
+        // either we find an inline node next
+        // or we have a formatting ancestor and the next sibng is not
+        // a container node
         const nextSibling = checkNode.nextSibling;
         if (
-            hasFormattingParent &&
-            nextSibling &&
-            !isNodeRequiringExtraOffset(nextSibling)
+            (nextSibling && isInlineNode(nextSibling)) ||
+            (hasFormattingParent &&
+                nextSibling &&
+                !isNodeRequiringExtraOffset(nextSibling))
         ) {
             break;
         }


### PR DESCRIPTION
The web integration had an issue with bold tags appearing part way into list items. The cursor would appear in the wrong place. This fixes that issue and adds a test to cover it.

Behaviour before:

https://user-images.githubusercontent.com/56027671/215111116-be174ed3-0001-4f0d-9f07-1077b031664e.mov


Behaviour after:

https://user-images.githubusercontent.com/56027671/215111136-8231dba9-f12c-496a-b252-b06067962218.mov


