### PR TITLE
[Android] Add configuration options for code size

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditTextAttributeReader.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditTextAttributeReader.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import androidx.core.content.res.getDimensionOrThrow
 import androidx.core.content.res.getDimensionPixelSizeOrThrow
 import androidx.core.content.res.getDrawableOrThrow
+import androidx.core.content.res.getFloatOrThrow
 import io.element.android.wysiwyg.utils.BulletListStyleConfig
 import io.element.android.wysiwyg.utils.CodeBlockStyleConfig
 import io.element.android.wysiwyg.utils.InlineCodeStyleConfig
@@ -28,14 +29,17 @@ internal class EditorEditTextAttributeReader(context: Context, attrs: AttributeS
             inlineCode = InlineCodeStyleConfig(
                 horizontalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_inlineCodeHorizontalPadding),
                 verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_inlineCodeVerticalPadding),
+                relativeTextSize = typedArray.getFloatOrThrow(R.styleable.EditorEditText_inlineCodeRelativeTextSize),
                 singleLineBg = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeSingleLineBg),
                 multiLineBgLeft = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgLeft),
                 multiLineBgMid = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgMid),
                 multiLineBgRight = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgRight),
+
             ),
             codeBlock = CodeBlockStyleConfig(
                 leadingMargin = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockLeadingMargin),
                 verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockVerticalPadding),
+                relativeTextSize = typedArray.getFloatOrThrow(R.styleable.EditorEditText_codeBlockRelativeTextSize),
                 backgroundDrawable = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_codeBlockBackgroundDrawable),
             )
         )

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextViewAttributeReader.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextViewAttributeReader.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.core.content.res.getDimensionPixelSizeOrThrow
 import androidx.core.content.res.getDrawableOrThrow
+import androidx.core.content.res.getFloatOrThrow
 import io.element.android.wysiwyg.utils.InlineCodeStyleConfig
 
 internal class EditorStyledTextViewAttributeReader(context: Context, attrs: AttributeSet?) {
@@ -19,6 +20,7 @@ internal class EditorStyledTextViewAttributeReader(context: Context, attrs: Attr
         inlineCodeStyleConfig = InlineCodeStyleConfig(
             horizontalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorStyledTextView_inlineCodeHorizontalPadding),
             verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorStyledTextView_inlineCodeVerticalPadding),
+            relativeTextSize = typedArray.getFloatOrThrow(R.styleable.EditorStyledTextView_inlineCodeRelativeTextSize),
             singleLineBg = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeSingleLineBg),
             multiLineBgLeft = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgLeft),
             multiLineBgMid = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgMid),

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/CodeBlockSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/CodeBlockSpan.kt
@@ -5,15 +5,9 @@ import android.graphics.Paint
 import android.text.Layout
 import android.text.Spanned
 import android.text.TextPaint
-import android.text.style.LeadingMarginSpan
-import android.text.style.LineBackgroundSpan
-import android.text.style.LineHeightSpan
-import android.text.style.MetricAffectingSpan
-import android.text.style.TypefaceSpan
-import android.text.style.UpdateAppearance
-import androidx.annotation.ColorInt
+import android.text.style.*
+import androidx.annotation.FloatRange
 import androidx.annotation.Px
-import kotlin.math.roundToInt
 
 /**
  * Code block (```some code``` in Markdown, <pre> in HTML) Span that applies a monospaced font style
@@ -22,15 +16,20 @@ import kotlin.math.roundToInt
 class CodeBlockSpan(
     @Px private val leadingMargin: Int,
     @Px private val verticalPadding: Int,
+    @FloatRange(from = 0.0) relativeSizeProportion: Float =
+        CodeSpanConstants.DEFAULT_RELATIVE_SIZE_PROPORTION,
 ) : MetricAffectingSpan(), BlockSpan, LeadingMarginSpan, LineHeightSpan, UpdateAppearance {
 
     private val monoTypefaceSpan = TypefaceSpan("monospace")
+    private val relativeSizeSpan = RelativeSizeSpan(relativeSizeProportion)
 
     override fun updateDrawState(tp: TextPaint) {
+        relativeSizeSpan.updateDrawState(tp)
         monoTypefaceSpan.updateDrawState(tp)
     }
 
     override fun updateMeasureState(textPaint: TextPaint) {
+        relativeSizeSpan.updateMeasureState(textPaint)
         monoTypefaceSpan.updateMeasureState(textPaint)
     }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/CodeSpanConstants.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/CodeSpanConstants.kt
@@ -1,0 +1,5 @@
+package io.element.android.wysiwyg.spans
+
+internal object CodeSpanConstants {
+    const val DEFAULT_RELATIVE_SIZE_PROPORTION = 0.87f
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/InlineCodeSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/spans/InlineCodeSpan.kt
@@ -1,6 +1,9 @@
 package io.element.android.wysiwyg.spans
 
+import android.text.TextPaint
+import android.text.style.RelativeSizeSpan
 import android.text.style.TypefaceSpan
+import androidx.annotation.FloatRange
 
 /**
  * Inline code (`some code` in Markdown, <code> in HTML) Span that applies a monospaced font style.
@@ -17,4 +20,19 @@ import android.text.style.TypefaceSpan
  * - https://medium.com/androiddevelopers/drawing-a-rounded-corner-background-on-text-5a610a95af5
  * - https://github.com/googlearchive/android-text/tree/996fdb65bbfbb786c3ca4e4e40b30509067201fc/RoundedBackground-Kotlin
  */
-class InlineCodeSpan: TypefaceSpan("monospace")
+class InlineCodeSpan(
+    @FloatRange(from = 0.0) relativeSizeProportion: Float =
+        CodeSpanConstants.DEFAULT_RELATIVE_SIZE_PROPORTION,
+) : TypefaceSpan("monospace") {
+    private val relativeSizeSpan = RelativeSizeSpan(relativeSizeProportion)
+
+    override fun updateMeasureState(paint: TextPaint) {
+        super.updateMeasureState(paint)
+        relativeSizeSpan.updateMeasureState(paint)
+    }
+
+    override fun updateDrawState(ds: TextPaint) {
+        super.updateDrawState(ds)
+        relativeSizeSpan.updateMeasureState(ds)
+    }
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -164,7 +164,11 @@ internal class HtmlToSpansParser(
                 val start = addLeadingLineBreakIfNeeded(text.getSpanStart(last))
                 text.removeSpan(last)
 
-                val codeSpan = CodeBlockSpan(styleConfig.codeBlock.leadingMargin, styleConfig.codeBlock.verticalPadding)
+                val codeSpan = CodeBlockSpan(
+                    leadingMargin = styleConfig.codeBlock.leadingMargin,
+                    verticalPadding = styleConfig.codeBlock.verticalPadding,
+                    relativeSizeProportion = styleConfig.codeBlock.relativeTextSize,
+                )
 
                 addZWSP(text.length)
 
@@ -215,7 +219,9 @@ internal class HtmlToSpansParser(
             InlineFormat.Italic -> StyleSpan(Typeface.ITALIC)
             InlineFormat.Underline -> UnderlineSpan()
             InlineFormat.StrikeThrough -> StrikethroughSpan()
-            InlineFormat.InlineCode -> InlineCodeSpan()
+            InlineFormat.InlineCode -> InlineCodeSpan(
+                relativeSizeProportion = styleConfig.inlineCode.relativeTextSize
+            )
         }
         setSpanFromMark(format, span)
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/StyleConfig.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/StyleConfig.kt
@@ -19,6 +19,7 @@ data class BulletListStyleConfig(
 data class InlineCodeStyleConfig(
     @Px val horizontalPadding: Int,
     @Px val verticalPadding: Int,
+    val relativeTextSize: Float,
     val singleLineBg: Drawable,
     val multiLineBgLeft: Drawable,
     val multiLineBgMid: Drawable,
@@ -28,5 +29,6 @@ data class InlineCodeStyleConfig(
 data class CodeBlockStyleConfig(
     @Px val leadingMargin: Int,
     @Px val verticalPadding: Int,
+    val relativeTextSize: Float,
     val backgroundDrawable: Drawable,
 )

--- a/platforms/android/library/src/main/res/values/attrs.xml
+++ b/platforms/android/library/src/main/res/values/attrs.xml
@@ -5,12 +5,14 @@
     <attr name="codeBlockLeadingMargin" format="dimension" />
     <attr name="codeBlockVerticalPadding" format="dimension" />
     <attr name="codeBlockBackgroundDrawable" format="reference" />
+    <attr name="codeBlockRelativeTextSize" format="float" />
     <attr name="inlineCodeHorizontalPadding" format="dimension" />
     <attr name="inlineCodeVerticalPadding" format="dimension" />
     <attr name="inlineCodeSingleLineBg" format="reference" />
     <attr name="inlineCodeMultiLineBgLeft" format="reference" />
     <attr name="inlineCodeMultiLineBgMid" format="reference" />
     <attr name="inlineCodeMultiLineBgRight" format="reference" />
+    <attr name="inlineCodeRelativeTextSize" format="float" />
 
     <declare-styleable name="EditorEditText">
         <attr name="bulletGap" />
@@ -18,12 +20,14 @@
         <attr name="codeBlockLeadingMargin" />
         <attr name="codeBlockVerticalPadding" />
         <attr name="codeBlockBackgroundDrawable" />
+        <attr name="codeBlockRelativeTextSize" />
         <attr name="inlineCodeHorizontalPadding" />
         <attr name="inlineCodeVerticalPadding" />
         <attr name="inlineCodeSingleLineBg" />
         <attr name="inlineCodeMultiLineBgLeft" />
         <attr name="inlineCodeMultiLineBgMid" />
         <attr name="inlineCodeMultiLineBgRight" />
+        <attr name="inlineCodeRelativeTextSize" />
     </declare-styleable>
 
     <declare-styleable name="EditorStyledTextView">
@@ -33,5 +37,6 @@
         <attr name="inlineCodeMultiLineBgLeft" />
         <attr name="inlineCodeMultiLineBgMid" />
         <attr name="inlineCodeMultiLineBgRight" />
+        <attr name="inlineCodeRelativeTextSize" />
     </declare-styleable>
 </resources>

--- a/platforms/android/library/src/main/res/values/integers.xml
+++ b/platforms/android/library/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="defaultCodeTextSizeProportion" type="integer" format="float">0.87</item>
+</resources>

--- a/platforms/android/library/src/main/res/values/styles.xml
+++ b/platforms/android/library/src/main/res/values/styles.xml
@@ -3,6 +3,7 @@
     <style name="EditorStyledTextView">
         <item name="inlineCodeHorizontalPadding">2dp</item>
         <item name="inlineCodeVerticalPadding">0dp</item>
+        <item name="inlineCodeRelativeTextSize">@integer/defaultCodeTextSizeProportion</item>
         <item name="inlineCodeSingleLineBg">@drawable/inline_code_single_line_bg</item>
         <item name="inlineCodeMultiLineBgLeft">@drawable/inline_code_multi_line_bg_left</item>
         <item name="inlineCodeMultiLineBgMid">@drawable/inline_code_multi_line_bg_mid</item>
@@ -12,6 +13,7 @@
     <style name="EditorEditText" parent="EditorStyledTextView">
         <item name="bulletGap">2dp</item>
         <item name="bulletRadius">2dp</item>
+        <item name="codeBlockRelativeTextSize">@integer/defaultCodeTextSizeProportion</item>
         <item name="codeBlockLeadingMargin">10dp</item>
         <item name="codeBlockVerticalPadding">4dp</item>
         <item name="codeBlockBackgroundDrawable">@drawable/code_block_bg</item>


### PR DESCRIPTION
## What?

- Allow the size of inline code and code blocks to be configured.
- Add default size for inline code and code blocks.

## Why?

Design feedback on the Element Android integration:
- https://github.com/vector-im/element-android/pull/8011

## Screenshots
| Before | After (with new defaults) |
|-|-|
|![before](https://user-images.githubusercontent.com/4940864/215124026-6b0d7b2d-4024-41c8-b1ff-90d5ccf0d8fb.png)|![after](https://user-images.githubusercontent.com/4940864/215124057-e87a696f-2db6-43e7-b492-2f26eb4ac986.png)|
