### PR TITLE
[Android] Fix crashes in `EditorStyledTextView`

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
@@ -1,0 +1,25 @@
+package io.element.android.wysiwyg
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import io.element.android.wysiwyg.test.R
+import io.element.android.wysiwyg.test.utils.TestActivity
+import io.element.android.wysiwyg.test.utils.TextViewActions
+import org.junit.Rule
+import org.junit.Test
+
+internal class EditorStyledTextViewTest {
+
+    @get:Rule
+    val scenarioRule = ActivityScenarioRule(TestActivity::class.java)
+
+    @Test
+    fun testSetText() {
+        onView(ViewMatchers.withId(R.id.styledTextView))
+            .perform(TextViewActions.setText("Hello, world"))
+            .check(matches(withText("Hello, world")))
+    }
+}

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/TextViewActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/TextViewActions.kt
@@ -1,0 +1,28 @@
+package io.element.android.wysiwyg.test.utils
+
+import android.view.View
+import android.widget.TextView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import org.hamcrest.Matcher
+
+object TextViewAction {
+    class SetText(
+        private val text: String,
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Set text to $text"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val textView = view as? TextView ?: return
+            textView.setText(text)
+        }
+    }
+
+}
+
+object TextViewActions {
+    fun setText(text: String) = TextViewAction.SetText(text)
+}

--- a/platforms/android/library/src/androidTest/res/layout/activity_test.xml
+++ b/platforms/android/library/src/androidTest/res/layout/activity_test.xml
@@ -6,6 +6,14 @@
     android:layout_height="match_parent"
     tools:context="io.element.android.wysiwyg.test.utils.TestActivity">
 
+    <io.element.android.wysiwyg.EditorStyledTextView
+        android:id="@+id/styledTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <com.google.android.material.textfield.TextInputLayout
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -13,7 +21,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/styledTextView">
 
         <io.element.android.wysiwyg.EditorEditText
             android:id="@id/rich_text_edit_text"

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -16,6 +16,7 @@ import io.element.android.wysiwyg.utils.*
 class EditorStyledTextView : AppCompatTextView {
     private lateinit var inlineCodeStyleConfig: InlineCodeStyleConfig
     private lateinit var codeBlockStyleConfig: CodeBlockStyleConfig
+    private var styleAttributesReady = false
     private val inlineCodeBgHelper: SpanBackgroundHelper by lazy {
         SpanBackgroundHelperFactory.createInlineCodeBackgroundHelper(inlineCodeStyleConfig)
     }
@@ -29,6 +30,7 @@ class EditorStyledTextView : AppCompatTextView {
         val attrReader = EditorStyledTextViewAttributeReader(context, attrs)
         inlineCodeStyleConfig = attrReader.inlineCodeStyleConfig
         codeBlockStyleConfig = attrReader.codeBlockStyleConfig
+        styleAttributesReady = true
     }
 
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
@@ -36,6 +38,10 @@ class EditorStyledTextView : AppCompatTextView {
 
     override fun setText(text: CharSequence?, type: BufferType?) {
         super.setText(text, type)
+
+        // setText may be called during initialisation when we're not yet
+        // ready to load the background helpers
+        if(!styleAttributesReady) return
 
         inlineCodeBgHelper.clearCachedPositions()
         codeBlockBgHelper.clearCachedPositions()

--- a/platforms/android/library/src/main/res/values/styles.xml
+++ b/platforms/android/library/src/main/res/values/styles.xml
@@ -8,14 +8,14 @@
         <item name="inlineCodeMultiLineBgLeft">@drawable/inline_code_multi_line_bg_left</item>
         <item name="inlineCodeMultiLineBgMid">@drawable/inline_code_multi_line_bg_mid</item>
         <item name="inlineCodeMultiLineBgRight">@drawable/inline_code_multi_line_bg_right</item>
+        <item name="codeBlockRelativeTextSize">@integer/defaultCodeTextSizeProportion</item>
+        <item name="codeBlockLeadingMargin">10dp</item>
+        <item name="codeBlockVerticalPadding">4dp</item>
+        <item name="codeBlockBackgroundDrawable">@drawable/code_block_bg</item>
     </style>
 
     <style name="EditorEditText" parent="EditorStyledTextView">
         <item name="bulletGap">2dp</item>
         <item name="bulletRadius">2dp</item>
-        <item name="codeBlockRelativeTextSize">@integer/defaultCodeTextSizeProportion</item>
-        <item name="codeBlockLeadingMargin">10dp</item>
-        <item name="codeBlockVerticalPadding">4dp</item>
-        <item name="codeBlockBackgroundDrawable">@drawable/code_block_bg</item>
     </style>
 </resources>


### PR DESCRIPTION
- Fix crash caused by unsafe access of lateinit vars
- Fix crash caused by missing default styles
- Add a simple test for the `EditorStyledTextView`
