### PR TITLE
Fix line indent after quotes & code blocks

### DIFF
--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -70,7 +70,13 @@ internal extension WysiwygUITests {
                                _ message: @autoclosure () -> String = "",
                                file: StaticString = #filePath,
                                line: UInt = #line) {
-        XCTAssertEqual(textView.value as? String, try content(), message(), file: file, line: line)
+        guard var text = textView.value as? String else {
+            XCTFail("Unable to retrieve text view content")
+            return
+        }
+        // Remove occurences of ZWSP to avoid issues with expected content.
+        text = text.replacingOccurrences(of: "\u{200B}", with: "")
+        XCTAssertEqual(text, try content(), message(), file: file, line: line)
     }
 
     /// Focus the composer text view inside given app and

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
@@ -60,11 +60,7 @@ extension NSMutableAttributedString {
     func replaceOrDeleteDiscardableText() {
         enumerateTypedAttribute(.discardableText) { (discardable: Bool, range: NSRange, _) in
             guard discardable == true else { return }
-            if self.attribute(.blockStyle, at: range.location, effectiveRange: nil) != nil {
-                self.replaceCharacters(in: range, with: String.zwsp)
-            } else {
-                self.deleteCharacters(in: range)
-            }
+            self.replaceCharacters(in: range, with: String.zwsp)
         }
     }
 


### PR DESCRIPTION
Fixes line indent issues by replacing all `discardable texts` by ZWSP within the text view. ZWSP located right after an indented block will hold the expected attributes to fix the indent on the very next new line. 