### PR TITLE
Ctrl/cmd a behaviour web

### DIFF
--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -612,7 +612,7 @@ describe('getCurrentSelection', () => {
         expect(sel.focusNode).toBe(secondParagrahStrongTextNode);
         expect(sel.focusOffset).toBe(secondNodeOffset);
 
-        // We should see ourselves as on code unit 8, because a paragraph tag
+        // We should see ourselves as on code unit 9, because a paragraph tag
         // will add an extra offset, so our total offset is the length of the
         // first paragraph, plus the extra offset, plus the second node offset
         // ie 6 + 1 + 2 = 8
@@ -632,10 +632,10 @@ describe('getCurrentSelection', () => {
         );
         sel.extend(firstParagraphTextNode, firstOffset);
 
-        // Sanity: the focusNode and anchorNode are the first text node
-        // and the offset tells you how far into that text node we are
+        // Sanity: the anchorNode is where we started, in the second text node,
+        // and the focusNode is where we moved to, the first text node
         expect(sel.anchorNode).toBe(secondParagraphTextNode);
-        expect(sel.anchorOffset).toBe(6);
+        expect(sel.anchorOffset).toBe(secondNodeOffset);
         expect(sel.focusNode).toBe(firstParagraphTextNode);
         expect(sel.focusOffset).toBe(firstOffset);
 
@@ -644,7 +644,8 @@ describe('getCurrentSelection', () => {
 
     it('handles selecting all with ctrl-a', () => {
         setEditorHtml('<p>para 1</p><p>para 2</p>');
-        expect(getCurrentSelection(editor, selectAll())).toEqual([0, 13]);
+        const sel = selectAll();
+        expect(getCurrentSelection(editor, sel)).toEqual([0, 13]);
     });
 
     it('handles selecting all by dragging from start to end', () => {

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -812,7 +812,9 @@ describe('getCurrentSelection', () => {
     });
 
     it('correctly locates the cursor on a new line inside another tag', () => {
-        setEditorHtml('pa<strong>ra 1<br /><br />pa</strong>ra 2');
+        setEditorHtml(
+            '<p>pa<strong>ra 1</strong></p><p><strong>pa</strong>ra 2</p>',
+        );
         const strong = editor.childNodes[1];
         const secondBr = strong.childNodes[2];
         assert(secondBr);

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -873,7 +873,6 @@ describe('textLength', () => {
 /* HELPER FUNCTIONS */
 /* The editor always needs an extra BR after your HTML */
 function setEditorHtml(html: string) {
-    // The editor always needs an extra BR after your HTML
     editor.innerHTML = html + '<br />';
 }
 

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -521,6 +521,9 @@ describe('countCodeunit', () => {
 });
 
 describe('getCurrentSelection', () => {
+    // think I'm going to have to rewrite this entire suite of tests, making a mock
+    // selection using vite and then getting rid of all the br tag tests
+    // ...eurgh
     class FakeSelection {
         anchorNode: Node | null = null;
         anchorOffset = 0;
@@ -846,11 +849,11 @@ describe('getCurrentSelection', () => {
     });
 
     it('handles selecting all with ctrl-a', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para1</p><p>para2</p>');
         const sel = selectAll();
 
         // Do not count the last BR
-        expect(getCurrentSelection(editor, sel)).toEqual([0, 14]);
+        expect(getCurrentSelection(editor, sel)).toEqual([0, 11]);
     });
 
     it('handles selecting all by dragging', () => {

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -546,19 +546,20 @@ describe('getCurrentSelection', () => {
 
         return selection;
     }
-    function selectAll() {
-        // select all works in the browse} by selecting the first text node as
+    function selectAll(): Selection | null {
+        // select all works in the browser by selecting the first text node as
         // the anchor with an offset of 0, and the focus node as the editor,
         // with the offset equal to the number of paragraph nodes
-        const select = document.getSelection();
-        select?.removeAllRanges();
+        const selection = document.getSelection();
+
+        selection?.removeAllRanges();
 
         const firstTextNode = document
             .createNodeIterator(editor, NodeFilter.SHOW_TEXT)
             .nextNode();
 
         if (firstTextNode) {
-            select?.setBaseAndExtent(
+            selection?.setBaseAndExtent(
                 firstTextNode,
                 0,
                 editor,
@@ -566,7 +567,7 @@ describe('getCurrentSelection', () => {
             );
         }
 
-        return select;
+        return selection;
     }
     function cursorToAfterEnd(): Selection {
         const sel = document.getSelection();

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -776,7 +776,7 @@ describe('getCurrentSelection', () => {
     });
 
     it('correctly locates the cursor after a br tag', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         const secondBr = editor.childNodes[2];
         assert(secondBr);
         const sel = cursorToNode(secondBr, 0);
@@ -795,7 +795,7 @@ describe('getCurrentSelection', () => {
     });
 
     it('correctly locates the cursor after a br tag selected directly', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         const secondBr = editor.childNodes[2];
         assert(secondBr);
         const sel = cursorToNodeDirectly(secondBr, 0);
@@ -832,7 +832,7 @@ describe('getCurrentSelection', () => {
     });
 
     it('correctly finds backward selections ending after a BR', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         const secondBr = editor.childNodes[2];
         assert(secondBr);
         const sel = selectEndTo(secondBr, 0);
@@ -857,19 +857,19 @@ describe('getCurrentSelection', () => {
     });
 
     it('handles selecting all by dragging', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         const sel = selectStartToEnd();
         expect(getCurrentSelection(editor, sel)).toEqual([0, 14]);
     });
 
     it('handles selecting all by dragging backwards', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         const sel = selectEndToStart();
         expect(getCurrentSelection(editor, sel)).toEqual([14, 0]);
     });
 
     it('handles selecting across multiple newlines', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         const p1 = editor.childNodes[0];
         const p2 = editor.childNodes[3];
         const sel = select(p1, 2, p2, 3);
@@ -877,26 +877,26 @@ describe('getCurrentSelection', () => {
     });
 
     it('handles cursor after end', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         // Simulate going to end of doc and pressing down arrow
         const sel = cursorToAfterEnd();
         expect(getCurrentSelection(editor, sel)).toEqual([14, 14]);
     });
 
     it('handles cursor at start', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         const sel = cursorToBeginning();
         expect(getCurrentSelection(editor, sel)).toEqual([0, 0]);
     });
 
     it('handles selection before the start by returning 0, 0', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         const sel = selectionBeforeEditor();
         expect(getCurrentSelection(editor, sel)).toEqual([0, 0]);
     });
 
     it('handles selection after the end by returning last character', () => {
-        setEditorHtml('para 1<br /><br />para 2');
+        setEditorHtml('<p>para 1</p><p>para 2</p>');
         const sel = selectionAfterEditor();
         expect(getCurrentSelection(editor, sel)).toEqual([14, 14]);
     });
@@ -929,7 +929,7 @@ describe('textNodeNeedsExtraOffset', () => {
             const openingTag = wrappingTag ? `<${wrappingTag}>` : '';
             const closingTag = wrappingTag ? `<${wrappingTag}>` : '';
             setEditorHtml(
-                `${openingTag}<${testTag}>test test</${testTag}>${closingTag}`,
+                `${openingTag}<${testTag}>test test</${testTag}>${closingTag}<p>some adjacent text</p>`,
             );
             const { node } = computeNodeAndOffset(editor, 1);
 
@@ -986,6 +986,17 @@ describe('textNodeNeedsExtraOffset', () => {
 
         // Then
         expect(node).toBe(editor.childNodes[0].childNodes[0].childNodes[0]);
+        expect(textNodeNeedsExtraOffset(node)).toBe(false);
+    });
+
+    it('does not apply offset to the last child node', () => {
+        // When
+        setEditorHtml('<p>single child</p>');
+
+        const { node } = computeNodeAndOffset(editor, 0);
+
+        // Then
+        expect(node).toBe(editor.childNodes[0].childNodes[0]);
         expect(textNodeNeedsExtraOffset(node)).toBe(false);
     });
 });

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -521,30 +521,30 @@ describe('countCodeunit', () => {
 });
 
 describe('getCurrentSelection', () => {
-    function putCaretInTextNodeAtOffset(node: Node, offset: number): Selection {
+    function putCaretInTextNodeAtOffset(
+        node: Node,
+        offset: number,
+    ): Selection | null {
         if (node.nodeName !== '#text') {
             throw new Error(
                 'Called putCaretInTextNodeAtOffset with a non-text node',
             );
         }
 
+        // create a new range and selection for us to amend
         const range = new Range();
-        const select = document.getSelection();
+        const selection = document.getSelection();
 
         range.setStart(node, offset);
         range.setEnd(node, offset);
-        range.collapse(true); // collapse to it's boundary point
 
-        select?.removeAllRanges(); // clear out all except anchor and focus
-        select?.addRange(range);
-
-        if (select === null) {
-            throw new Error(
-                'putCaretInTextNodeAtOffset tried to return null Selection',
-            );
+        if (selection) {
+            // if we have a selection, clear it out and then add the new range
+            selection.removeAllRanges();
+            selection.addRange(range);
         }
 
-        return select;
+        return selection;
     }
     function selectAll() {
         // select all works in the browse} by selecting the first text node as

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -546,7 +546,7 @@ describe('getCurrentSelection', () => {
 
         return select;
     }
-    function _selectAll() {
+    function selectAll() {
         // select all works in the browse} by selecting the first text node as
         // the anchor with an offset of 0, and the focus node as the editor,
         // with the offset equal to the number of paragraph nodes
@@ -568,7 +568,7 @@ describe('getCurrentSelection', () => {
 
         return select;
     }
-    function _cursorToAfterEnd(): Selection {
+    function cursorToAfterEnd(): Selection {
         const sel = document.getSelection();
         const offset = editor.childNodes.length - 1;
         sel?.setBaseAndExtent(editor, offset, editor, offset);
@@ -579,7 +579,7 @@ describe('getCurrentSelection', () => {
 
         return sel;
     }
-    function _cursorToBeginning(): Selection {
+    function cursorToBeginning(): Selection {
         const sel = document.getSelection();
         const firstTextNode = document
             .createNodeIterator(editor, NodeFilter.SHOW_TEXT)
@@ -597,7 +597,7 @@ describe('getCurrentSelection', () => {
 
         return sel;
     }
-    function _selectionBeforeEditor(): Selection {
+    function selectionBeforeEditor(): Selection {
         const sel = document.getSelection();
         sel?.setBaseAndExtent(beforeEditor, 0, beforeEditor, 0);
         if (sel === null) {
@@ -607,7 +607,7 @@ describe('getCurrentSelection', () => {
         }
         return sel;
     }
-    function _selectionAfterEditor(): Selection {
+    function selectionAfterEditor(): Selection {
         const sel = document.getSelection();
         sel?.setBaseAndExtent(afterEditor, 0, afterEditor, 0);
         if (sel === null) {
@@ -620,7 +620,7 @@ describe('getCurrentSelection', () => {
 
     it('correctly locates the cursor in an empty editor', () => {
         setEditorHtml('');
-        const sel = _selectAll();
+        const sel = selectAll();
         expect(getCurrentSelection(editor, sel)).toEqual([0, 0]);
     });
 
@@ -746,7 +746,7 @@ describe('getCurrentSelection', () => {
 
     it('handles selecting all with ctrl-a', () => {
         setEditorHtml('<p>para 1</p><p>para 2</p>');
-        expect(getCurrentSelection(editor, _selectAll())).toEqual([0, 13]);
+        expect(getCurrentSelection(editor, selectAll())).toEqual([0, 13]);
     });
 
     it('handles selecting all by dragging from start to end', () => {
@@ -800,25 +800,25 @@ describe('getCurrentSelection', () => {
     it('handles cursor after end', () => {
         setEditorHtml('<p>para 1</p><p>para 2</p>');
         // Simulate going to end of doc and pressing down arrow
-        const sel = _cursorToAfterEnd();
+        const sel = cursorToAfterEnd();
         expect(getCurrentSelection(editor, sel)).toEqual([13, 13]);
     });
 
     it('handles cursor at start', () => {
         setEditorHtml('<p>para 1</p><p>para 2</p>');
-        const sel = _cursorToBeginning();
+        const sel = cursorToBeginning();
         expect(getCurrentSelection(editor, sel)).toEqual([0, 0]);
     });
 
     it('handles selection before the start by returning 0, 0', () => {
         setEditorHtml('<p>para 1</p><p>para 2</p>');
-        const sel = _selectionBeforeEditor();
+        const sel = selectionBeforeEditor();
         expect(getCurrentSelection(editor, sel)).toEqual([0, 0]);
     });
 
     it('handles selection after the end by returning last character', () => {
         setEditorHtml('<p>para 1</p><p>para 2</p>');
-        const sel = _selectionAfterEditor();
+        const sel = selectionAfterEditor();
         expect(getCurrentSelection(editor, sel)).toEqual([13, 13]);
     });
 });

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -591,25 +591,19 @@ describe('getCurrentSelection', () => {
 
         return selection;
     }
-    function selectionBeforeEditor(): Selection {
-        const sel = document.getSelection();
-        sel?.setBaseAndExtent(beforeEditor, 0, beforeEditor, 0);
-        if (sel === null) {
-            throw new Error(
-                '_selectionAfterEditor tried to return null Selection',
-            );
+    function selectionBeforeEditor(): Selection | null {
+        const selection = document.getSelection();
+        if (selection) {
+            selection.setBaseAndExtent(beforeEditor, 0, beforeEditor, 0);
         }
-        return sel;
+        return selection;
     }
-    function selectionAfterEditor(): Selection {
-        const sel = document.getSelection();
-        sel?.setBaseAndExtent(afterEditor, 0, afterEditor, 0);
-        if (sel === null) {
-            throw new Error(
-                '_selectionAfterEditor tried to return null Selection',
-            );
+    function selectionAfterEditor(): Selection | null {
+        const selection = document.getSelection();
+        if (selection) {
+            selection.setBaseAndExtent(afterEditor, 0, afterEditor, 0);
         }
-        return sel;
+        return selection;
     }
 
     it('correctly locates the cursor in an empty editor', () => {

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -579,23 +579,17 @@ describe('getCurrentSelection', () => {
 
         return selection;
     }
-    function cursorToBeginning(): Selection {
-        const sel = document.getSelection();
+    function cursorToBeginning(): Selection | null {
+        const selection = document.getSelection();
         const firstTextNode = document
             .createNodeIterator(editor, NodeFilter.SHOW_TEXT)
             .nextNode();
 
-        if (firstTextNode === null) {
-            throw new Error('_cursorToBeginning could not find a text node ');
-        }
-        sel?.setBaseAndExtent(firstTextNode, 0, firstTextNode, 0);
-        if (sel === null) {
-            throw new Error(
-                '_cursorToBeginning tried to return null Selection',
-            );
+        if (firstTextNode) {
+            selection?.setBaseAndExtent(firstTextNode, 0, firstTextNode, 0);
         }
 
-        return sel;
+        return selection;
     }
     function selectionBeforeEditor(): Selection {
         const sel = document.getSelection();

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -871,11 +871,13 @@ describe('textLength', () => {
 });
 
 /* HELPER FUNCTIONS */
+/* The editor always needs an extra BR after your HTML */
 function setEditorHtml(html: string) {
     // The editor always needs an extra BR after your HTML
     editor.innerHTML = html + '<br />';
 }
 
+/* Given a text node, place the cursor at the given   */
 function putCaretInTextNodeAtOffset(node: Node, offset: number): Selection {
     if (node.nodeName !== '#text') {
         throw new Error(
@@ -883,20 +885,14 @@ function putCaretInTextNodeAtOffset(node: Node, offset: number): Selection {
         );
     }
 
-    // create a new range and selection for us to amend
-    const range = new Range();
-
     // nb typing here is a little strange, we will only get a null back if
     // this is called on an iFrame with display:none from Firefox
     // ref: https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#return_value
     const selection = document.getSelection();
 
-    range.setStart(node, offset);
-    range.setEnd(node, offset);
-
-    // clear out the selection and then add the new range
+    // clear out the selection and then set base and extent
     selection?.removeAllRanges();
-    selection?.addRange(range);
+    selection?.setBaseAndExtent(node, offset, node, offset);
 
     if (selection === null) {
         throw new Error('null selection created in putCaretInTextNodeAtOffset');
@@ -929,6 +925,7 @@ function selectAll(): Selection | null {
     return selection;
 }
 
+/* Click at the end then press down arrow */
 function cursorToAfterEnd(): Selection | null {
     const selection = document.getSelection();
     const offset = editor.childNodes.length - 1;
@@ -936,6 +933,7 @@ function cursorToAfterEnd(): Selection | null {
     return selection;
 }
 
+/** Click at the beginning */
 function cursorToBeginning(): Selection | null {
     const selection = document.getSelection();
     const firstTextNode = document
@@ -949,6 +947,7 @@ function cursorToBeginning(): Selection | null {
     return selection;
 }
 
+/* Like selecting something before or after the editor */
 function selectionOutsideEditor(
     location: 'before' | 'after',
 ): Selection | null {

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -18,6 +18,7 @@ import {
     computeNodeAndOffset,
     countCodeunit,
     getCurrentSelection,
+    textLength,
     textNodeNeedsExtraOffset,
 } from './dom';
 let beforeEditor: HTMLDivElement;
@@ -819,6 +820,43 @@ describe('textNodeNeedsExtraOffset', () => {
         // Then
         expect(node).toBe(editor.childNodes[0].childNodes[0]);
         expect(textNodeNeedsExtraOffset(node)).toBe(false);
+    });
+});
+
+describe('textLength', () => {
+    const testString = 'string for testing';
+    const testStringLength = testString.length;
+    it('calculates the length of a plain string inside a div correcly', () => {
+        // this represents when the user initially starts typing, before any
+        // paragraphs have been added
+        const divNode = document.createElement('div');
+        divNode.textContent = testString;
+        expect(textLength(divNode, -1)).toBe(testStringLength);
+    });
+
+    it('calculates the length of a string inside a paragraph correctly', () => {
+        // when we have a string inside a paragraph, the length needs to be
+        // given an extra offset to match up with the rust model indices
+        const paragraphNode = document.createElement('p');
+        paragraphNode.textContent = testString;
+        expect(textLength(paragraphNode, -1)).toBe(testStringLength + 1);
+    });
+
+    it('calculates the length of a strings inside a list correctly', () => {
+        // when we have a list item inside a list, check that we only apply the
+        // offset to the list items, not to the list container as well
+        const listNode = document.createElement('ul');
+        const numberOfListItems = 3;
+
+        for (let i = 0; i < numberOfListItems; i++) {
+            const listItem = document.createElement('li');
+            listItem.textContent = testString;
+            listNode.appendChild(listItem);
+        }
+
+        expect(textLength(listNode, -1)).toBe(
+            numberOfListItems * (testStringLength + 1),
+        );
     });
 });
 

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -877,7 +877,8 @@ function setEditorHtml(html: string) {
     editor.innerHTML = html + '<br />';
 }
 
-/* Given a text node, place the cursor at the given   */
+/* Given a text node, place the a caret (ie zero length selection) 
+at the given offset */
 function putCaretInTextNodeAtOffset(node: Node, offset: number): Selection {
     if (node.nodeName !== '#text') {
         throw new Error(
@@ -901,6 +902,7 @@ function putCaretInTextNodeAtOffset(node: Node, offset: number): Selection {
     return selection;
 }
 
+/* Press cmd/ctrl + a */
 function selectAll(): Selection | null {
     // select all works in the browser by selecting the first text node as
     // the anchor with an offset of 0, and the focus node as the editor,

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -569,16 +569,15 @@ describe('getCurrentSelection', () => {
 
         return selection;
     }
-    function cursorToAfterEnd(): Selection {
-        const sel = document.getSelection();
+    function cursorToAfterEnd(): Selection | null {
+        const selection = document.getSelection();
         const offset = editor.childNodes.length - 1;
-        sel?.setBaseAndExtent(editor, offset, editor, offset);
 
-        if (sel === null) {
-            throw new Error('_cursorToAfterEnd tried to return null Selection');
+        if (selection) {
+            selection.setBaseAndExtent(editor, offset, editor, offset);
         }
 
-        return sel;
+        return selection;
     }
     function cursorToBeginning(): Selection {
         const sel = document.getSelection();

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -424,6 +424,16 @@ describe('computeNodeAndOffset', () => {
 });
 
 describe('countCodeunit', () => {
+    it('Returns the end of the editor when whole editor selected', () => {
+        const plainString = 'abcdefgh';
+        const htmlString = '<p>text in</p><p>paragraph tags</p>';
+
+        setEditorHtml(plainString);
+        expect(countCodeunit(editor, editor, 1)).toBe(plainString.length);
+
+        setEditorHtml(htmlString);
+        expect(countCodeunit(editor, editor, 2)).toBe(22);
+    });
     it('Should count ASCII', () => {
         // When
         setEditorHtml('abcdefgh');

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -281,9 +281,9 @@ export function getCurrentSelection(
 
 /**
  * How many codeunits are there inside node, stopping counting if you get to
- * stopAtNode?
+ * stopAtNode? Exported for testing purposes
  */
-function textLength(node: Node, stopChildNumber: number): number {
+export function textLength(node: Node, stopChildNumber: number): number {
     if (node.nodeType === Node.TEXT_NODE) {
         // for a text node, we may have to add an extra offset if it's inside a
         // certain container

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -281,7 +281,11 @@ export function getCurrentSelection(
  */
 function textLength(node: Node, stopChildNumber: number): number {
     if (node.nodeType === Node.TEXT_NODE) {
-        return node.textContent?.length ?? 0;
+        // for a text node, we may have to add an extra offset if it's inside a
+        // certain container
+        const shouldAddOffset = textNodeNeedsExtraOffset(node);
+        const extraOffset = shouldAddOffset ? 1 : 0;
+        return (node.textContent?.length ?? 0) + extraOffset;
     } else if (node.nodeName === 'BR') {
         // Treat br tags as being 1 character long, unless we are
         // looking for location 0 inside one, in which case it's 0 length
@@ -408,7 +412,10 @@ export function countCodeunit(
 ): number {
     // Special case - if asked for after the last node of the editor (which we
     // get if we do select-all), return the end of the editor.
-    if (node === editor && offset === editor.childNodes.length) {
+
+    // change this to account for the fact that there's always
+    // a br tag at the end of the childNodes list
+    if (node === editor && offset === editor.childNodes.length - 1) {
         return textLength(editor, -1) - 1;
     }
 

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -253,8 +253,7 @@ export function getCurrentSelection(
 ) {
     // return [0,0] when selection is null, or we have an empty editor
     const editorIsEmpty =
-        editor.childNodes.length === 1 &&
-        editor.childNodes[0].nodeName === 'BR';
+        editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR';
 
     if (!selection || editorIsEmpty) {
         return [0, 0];
@@ -416,11 +415,9 @@ export function countCodeunit(
     node: Node,
     offset: number,
 ): number {
-    // Special case - if asked for after the last node of the editor (which we
-    // get if we do select-all), return the end of the editor.
-
-    // change this to account for the fact that there's always
-    // a br tag at the end of the childNodes list
+    // Special case - if asked for after the last node of the editor excluding
+    // the line break tag (which we get if we do select-all), then we
+    // return the end of the editor.
     if (node === editor && offset === editor.childNodes.length - 1) {
         return textLength(editor, -1) - 1;
     }

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -285,13 +285,11 @@ export function getCurrentSelection(
  * stopAtNode?
  */
 function textLength(node: Node, stopChildNumber: number): number {
-    console.log(node, stopChildNumber);
     if (node.nodeType === Node.TEXT_NODE) {
         // for a text node, we may have to add an extra offset if it's inside a
         // certain container
         const shouldAddOffset = textNodeNeedsExtraOffset(node);
         const extraOffset = shouldAddOffset ? 1 : 0;
-        console.log({ shouldAddOffset });
         return (node.textContent?.length ?? 0) + extraOffset;
     } else if (node.nodeName === 'BR') {
         // Treat br tags as being 1 character long, unless we are

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -251,7 +251,12 @@ export function getCurrentSelection(
     editor: HTMLElement,
     selection: Selection | null,
 ) {
-    if (!selection) {
+    // return [0,0] when selection is null, or we have an empty editor
+    const editorIsEmpty =
+        editor.childNodes.length === 1 &&
+        editor.childNodes[0].nodeName === 'BR';
+
+    if (!selection || editorIsEmpty) {
         return [0, 0];
     }
 
@@ -280,15 +285,18 @@ export function getCurrentSelection(
  * stopAtNode?
  */
 function textLength(node: Node, stopChildNumber: number): number {
+    console.log(node, stopChildNumber);
     if (node.nodeType === Node.TEXT_NODE) {
         // for a text node, we may have to add an extra offset if it's inside a
         // certain container
         const shouldAddOffset = textNodeNeedsExtraOffset(node);
         const extraOffset = shouldAddOffset ? 1 : 0;
+        console.log({ shouldAddOffset });
         return (node.textContent?.length ?? 0) + extraOffset;
     } else if (node.nodeName === 'BR') {
         // Treat br tags as being 1 character long, unless we are
         // looking for location 0 inside one, in which case it's 0 length
+
         return stopChildNumber === 0 ? 0 : 1;
     } else {
         // Add up lengths until we hit the stop node.
@@ -471,12 +479,14 @@ export function textNodeNeedsExtraOffset(node: Node | null) {
         // either we find an inline node next
         // or we have a formatting ancestor and the next sibling is not
         // a container node
+        // or the next node is a <br/> tag, as this is the end of the document
         const nextSibling = checkNode.nextSibling;
         if (
             (nextSibling && isInlineNode(nextSibling)) ||
             (hasFormattingParent &&
                 nextSibling &&
-                !isNodeRequiringExtraOffset(nextSibling))
+                !isNodeRequiringExtraOffset(nextSibling)) ||
+            (nextSibling && nextSibling.nodeName === 'BR')
         ) {
             break;
         }

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -216,11 +216,13 @@ export function handleSelectionChange(
     { traceAction, getSelectionAccordingToActions }: TestUtilities,
 ): AllActionStates | undefined {
     const [start, end] = getCurrentSelection(editor, document.getSelection());
-
+    // console.log(`web: ${start} - ${end}`);
     const prevStart = composeModel.selection_start();
     const prevEnd = composeModel.selection_end();
+    // console.log(`rust: ${prevStart} - ${prevEnd}`);
 
     const [actStart, actEnd] = getSelectionAccordingToActions();
+    // console.log(`act: ${actStart} - ${actEnd}`);
 
     // Ignore selection changes that do nothing
     if (

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -216,13 +216,10 @@ export function handleSelectionChange(
     { traceAction, getSelectionAccordingToActions }: TestUtilities,
 ): AllActionStates | undefined {
     const [start, end] = getCurrentSelection(editor, document.getSelection());
-    // console.log(`web: ${start} - ${end}`);
     const prevStart = composeModel.selection_start();
     const prevEnd = composeModel.selection_end();
-    // console.log(`rust: ${prevStart} - ${prevEnd}`);
 
     const [actStart, actEnd] = getSelectionAccordingToActions();
-    // console.log(`act: ${actStart} - ${actEnd}`);
 
     // Ignore selection changes that do nothing
     if (

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -216,6 +216,7 @@ export function handleSelectionChange(
     { traceAction, getSelectionAccordingToActions }: TestUtilities,
 ): AllActionStates | undefined {
     const [start, end] = getCurrentSelection(editor, document.getSelection());
+
     const prevStart = composeModel.selection_start();
     const prevEnd = composeModel.selection_end();
 


### PR DESCRIPTION
This will close [issue 540](https://github.com/matrix-org/matrix-rich-text-editor/issues/540).

The fix for the cmd a behaviour is small, we just needed to count the extra offsets that are introduced by certain tags after the paragraph refactor.

That work, however, made me realise that a lot of the dom tests for `getCurrentSelection` needed rewriting as they no longer represented what a user would be writing in the composer. This is why the diff is so large.

Behaviour:

https://user-images.githubusercontent.com/56027671/216019885-bb68cc26-156d-4aa8-95a5-2980e0492352.mov

