### PR TITLE
Fix `enter` behaviour on empty list item with formatting

### DIFF
--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -145,7 +145,7 @@ where
         let list_item_node = self.state.dom.lookup_node(list_item_handle);
         let list_node_handle = list_item_node.handle().parent_handle();
         if let DomNode::Container(list_item) = list_item_node {
-            if list_item.is_empty_list_item()
+            if list_item.has_no_text()
                 || list_item_handle.index_in_parent() == 0
             {
                 self.state.dom.extract_list_items(

--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -94,12 +94,12 @@ where
                 }
             }
             ListItem => {
-                let list_item_is_empty = self
+                let list_item_has_no_text = self
                     .state
                     .dom
                     .lookup_node(&block_location.node_handle)
-                    .is_empty_list_item();
-                if list_item_is_empty {
+                    .has_no_text();
+                if list_item_has_no_text {
                     let list_handle =
                         block_location.node_handle.parent_handle();
                     // Remove the current list item
@@ -121,7 +121,7 @@ where
                         let DomNode::Container(list_item) = li else {
                             panic!("List item is not a container")
                         };
-                        // An empty list item might still contain some formatting nodes that
+                        // A list item without text might still contain some formatting nodes that
                         // should be transferred to the new paragraph.
                         self.state.dom.insert_at(
                             &list_handle.next_sibling(),

--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -102,29 +102,32 @@ where
                 if list_item_is_empty {
                     let list_handle =
                         block_location.node_handle.parent_handle();
+                    // Remove the current list item
+                    let li = self.state.dom.remove(&block_location.node_handle);
+
                     if let Some(ancestor_list_handle) =
                         self.find_closest_ancestor_of_kind(&list_handle, List)
                     {
-                        // If this is a nested list, we should create a new list item in the
+                        // If this is a nested list, we should insert the list item in the
                         // ancestor list instead of creating a new paragraph.
                         let new_item_index = list_handle
                             .sub_handle_up_to(ancestor_list_handle.depth() + 1)
                             .index_in_parent();
                         let insert_at = ancestor_list_handle
                             .child_handle(new_item_index + 1);
-                        self.state.dom.insert_at(
-                            &insert_at,
-                            DomNode::new_list_item(Vec::new()),
-                        );
+                        self.state.dom.insert_at(&insert_at, li);
                     } else {
                         // Otherwise, add new paragraph after the current list
+                        let DomNode::Container(list_item) = li else {
+                            panic!("List item is not a container")
+                        };
+                        // An empty list item might still contain some formatting nodes that
+                        // should be transferred to the new paragraph.
                         self.state.dom.insert_at(
                             &list_handle.next_sibling(),
-                            DomNode::new_paragraph(Vec::new()),
+                            DomNode::new_paragraph(list_item.take_children()),
                         );
                     }
-                    // And remove the current list item
-                    self.state.dom.remove(&block_location.node_handle);
                     // If list becomes empty, remove it too
                     if self
                         .state

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -376,7 +376,7 @@ where
 
     pub fn is_empty_list_item(&self) -> bool {
         match self.kind {
-            ContainerNodeKind::ListItem => self.is_empty(),
+            ContainerNodeKind::ListItem => self.text_len() == 0,
             _ => false,
         }
     }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -374,13 +374,6 @@ where
         }
     }
 
-    pub fn is_empty_list_item(&self) -> bool {
-        match self.kind {
-            ContainerNodeKind::ListItem => self.text_len() == 0,
-            _ => false,
-        }
-    }
-
     pub(crate) fn get_list_type(&self) -> Option<&ListType> {
         match &self.kind {
             ContainerNodeKind::List(t) => Some(t),
@@ -531,6 +524,11 @@ where
     /// Returns true if the ContainerNode has no children.
     pub fn is_empty(&self) -> bool {
         self.children.is_empty()
+    }
+
+    /// Returns true if there is no text in this ContainerNode.
+    pub fn has_no_text(&self) -> bool {
+        self.children.iter().all(|c| c.has_no_text())
     }
 
     fn find_slice_location(

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -173,11 +173,6 @@ where
     }
 
     #[allow(dead_code)]
-    pub(crate) fn is_empty_list_item(&self) -> bool {
-        matches!(self, Self::Container(container) if container.is_empty_list_item())
-    }
-
-    #[allow(dead_code)]
     pub(crate) fn is_list(&self) -> bool {
         matches!(self, Self::Container(container) if container.is_list())
     }
@@ -331,6 +326,15 @@ where
         match self {
             DomNode::Container(container) => container.is_empty(),
             DomNode::Text(text_node) => text_node.data().is_empty(),
+            _ => false,
+        }
+    }
+
+    /// Returns true if there is no text in this DomNode.
+    pub fn has_no_text(&self) -> bool {
+        match self {
+            DomNode::Container(c) => c.has_no_text(),
+            DomNode::Text(t) => t.data().is_empty(),
             _ => false,
         }
     }

--- a/crates/wysiwyg/src/tests/test_lists.rs
+++ b/crates/wysiwyg/src/tests/test_lists.rs
@@ -250,6 +250,38 @@ fn removing_trailing_list_item_with_list_toggle() {
 }
 
 #[test]
+fn removing_formatted_trailing_list_item_with_enter() {
+    let mut model =
+        cm("<ol><li><strong>abc</strong></li><li><strong>|</strong></li></ol>");
+    model.enter();
+    assert_eq!(
+        tx(&model),
+        "<ol><li><strong>abc</strong></li></ol><p><strong>|</strong></p>"
+    )
+}
+
+#[test]
+fn removing_formatted_trailing_list_item_with_list_toggle() {
+    let mut model =
+        cm("<ol><li><strong>abc</strong></li><li><strong>|</strong></li></ol>");
+    model.ordered_list();
+    assert_eq!(
+        tx(&model),
+        "<ol><li><strong>abc</strong></li></ol><p><strong>|</strong></p>"
+    )
+}
+
+#[test]
+fn enter_in_empty_indented_and_formatted_list_item() {
+    let mut model = cm("<ol><li><p><strong>abc</strong></p><ol><li><strong>|</strong></li></ol></li></ol>");
+    model.enter();
+    assert_eq!(
+        tx(&model),
+        "<ol><li><strong>abc</strong></li><li><strong>|</strong></li></ol>"
+    )
+}
+
+#[test]
 fn removing_trailing_list_item_then_replace_text() {
     let mut model = cm("<ol><li>abc</li><li>|</li></ol>");
     model.enter();


### PR DESCRIPTION
Fixes #546 

* A list item is now considered empty as long as its text_len is 0 (since it can contain some empty formatting nodes)
* Contained formatting nodes are transferred to the new paragraph or list item