### PR TITLE
Soft delete line backwards implementation

### DIFF
--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -71,6 +71,13 @@ export function processInput(
             return action(composerModel.backspace(), 'backspace');
         case 'deleteWordBackward':
             return action(composerModel.backspace_word(), 'backspace_word');
+        case 'deleteSoftLineBackward': {
+            document
+                .getSelection()
+                ?.modify('extend', 'backward', 'lineboundary');
+            document.dispatchEvent(new CustomEvent('selectionchange'));
+            return action(composerModel.delete(), 'backspace_line');
+        }
         case 'deleteContentForward':
             return action(composerModel.delete(), 'delete');
         case 'deleteWordForward':

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -72,10 +72,11 @@ export function processInput(
         case 'deleteWordBackward':
             return action(composerModel.backspace_word(), 'backspace_word');
         case 'deleteSoftLineBackward': {
-            document
-                .getSelection()
-                ?.modify('extend', 'backward', 'lineboundary');
-            document.dispatchEvent(new CustomEvent('selectionchange'));
+            const selection = document.getSelection();
+            if (selection) {
+                selection.modify('extend', 'backward', 'lineboundary');
+                document.dispatchEvent(new CustomEvent('selectionchange'));
+            }
             return action(composerModel.delete(), 'backspace_line');
         }
         case 'deleteContentForward':

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -90,6 +90,8 @@ function getInputFromKeyDown(
                 return 'historyRedo';
             case 'Enter':
                 return 'sendMessage';
+            case 'Backspace':
+                return 'deleteSoftLineBackward';
         }
     }
 
@@ -216,7 +218,6 @@ export function handleSelectionChange(
     { traceAction, getSelectionAccordingToActions }: TestUtilities,
 ): AllActionStates | undefined {
     const [start, end] = getCurrentSelection(editor, document.getSelection());
-
     const prevStart = composeModel.selection_start();
     const prevEnd = composeModel.selection_end();
 

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -218,6 +218,7 @@ export function handleSelectionChange(
     { traceAction, getSelectionAccordingToActions }: TestUtilities,
 ): AllActionStates | undefined {
     const [start, end] = getCurrentSelection(editor, document.getSelection());
+
     const prevStart = composeModel.selection_start();
     const prevEnd = composeModel.selection_end();
 

--- a/platforms/web/lib/useWysiwyg.delete.test.tsx
+++ b/platforms/web/lib/useWysiwyg.delete.test.tsx
@@ -100,4 +100,27 @@ describe('delete content', () => {
             expect(textbox).toHaveAttribute('data-content', 'fooar');
         });
     });
+
+    // eslint-disable-next-line max-len
+    it('Should call Selection.modify with the correct arguments when using meta + backspace', async () => {
+        // this test is the best we can do given the limitation that jsdom does
+        // not implement Selection.modify
+        const mockModify = vi.fn();
+        Object.assign(Selection.prototype, { modify: mockModify });
+
+        fireEvent.input(textbox, {
+            data: 'foobar',
+            inputType: 'insertText',
+        });
+        select(textbox, 6, 6);
+        fireEvent.keyDown(textbox, { key: 'Backspace', metaKey: true });
+
+        expect(mockModify).toHaveBeenCalledWith(
+            'extend',
+            'backward',
+            'lineboundary',
+        );
+
+        mockModify.mockRestore();
+    });
 });


### PR DESCRIPTION
This work is done to address [issue 456](https://github.com/matrix-org/matrix-rich-text-editor/issues/456).

Implementation has to be done on the web side, not the rust side, as we need to know the width of what is being rendered.

The testing is limited because jsdom does not implement `Selection.modify`. I'm not surprised it doesn't, because the functionality is surprisingly clever and would involve a whole heap of modelling that (I'm guessing) jsdom probably doesn't do at the moment.