### PR TITLE
Add transaction functionality to Dom

### DIFF
--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -32,6 +32,7 @@ where
     S: UnicodeString,
 {
     document: DomNode<S>,
+    is_transaction_in_progress: bool,
 }
 
 impl<S> Dom<S>
@@ -45,6 +46,7 @@ where
 
         Self {
             document: DomNode::Container(document),
+            is_transaction_in_progress: false,
         }
     }
 
@@ -57,6 +59,7 @@ where
 
         Self {
             document: root_node,
+            is_transaction_in_progress: false,
         }
     }
 
@@ -106,6 +109,36 @@ where
 
     pub fn children(&self) -> &Vec<DomNode<S>> {
         self.document().children()
+    }
+
+    /// Check if a transaction is in progress.
+    /// Inside a transaction, multiple DOM operations can be performed without
+    /// the need to keep the DOM in a consistent state between them.
+    pub fn is_transaction_in_progress(&self) -> bool {
+        self.is_transaction_in_progress
+    }
+
+    /// Asserts the DOM is in a good state and starts a transaction.
+    /// See [is_transaction_in_progress()].
+    pub fn start_transaction(&mut self) {
+        if self.is_transaction_in_progress() {
+            panic!("Cannot start transaction as one is already in progress");
+        }
+        #[cfg(any(test, feature = "assert-invariants"))]
+        self.assert_invariants();
+        self.is_transaction_in_progress = true;
+    }
+
+    /// Ends the current transaction and asserts the DOM is still in a good
+    /// state.
+    /// See [is_transaction_in_progress()].
+    pub fn end_transaction(&mut self) {
+        if !self.is_transaction_in_progress() {
+            panic!("Cannot end transaction as no transaction is in progress");
+        }
+        self.is_transaction_in_progress = false;
+        #[cfg(any(test, feature = "assert-invariants"))]
+        self.assert_invariants();
     }
 
     /// Returns the last node handle of the Dom. It's useful for reverse iterators that should start
@@ -894,6 +927,51 @@ mod test {
         let actual_range = d.find_range(0, 12);
 
         assert_eq!(range_by_node, actual_range);
+    }
+
+    #[test]
+    fn transaction_succeeds() {
+        let mut d = cm("|").state.dom;
+        d.start_transaction();
+        d.end_transaction();
+    }
+
+    #[test]
+    #[should_panic(expected = "More than one generic container node found")]
+    fn transaction_start_asserts() {
+        let mut bad_dom =
+            dom(vec![&DomNode::Container(ContainerNode::default())]);
+        bad_dom.start_transaction();
+    }
+
+    #[test]
+    #[should_panic(expected = "More than one generic container node found")]
+    fn transaction_end_asserts() {
+        let mut dom = dom(vec![]);
+        dom.start_transaction();
+        let container =
+            DomNode::<Utf16String>::Container(ContainerNode::default());
+        dom.insert(&DomHandle::root().child_handle(0), vec![container]);
+        dom.end_transaction();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Cannot start transaction as one is already in progress"
+    )]
+    fn transaction_start_twice() {
+        let mut d = cm("|").state.dom;
+        d.start_transaction();
+        d.start_transaction();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Cannot end transaction as no transaction is in progress"
+    )]
+    fn transaction_end_without_start() {
+        let mut d = cm("|").state.dom;
+        d.end_transaction();
     }
 
     const NO_CHILDREN: &Vec<DomNode<Utf16String>> = &Vec::new();


### PR DESCRIPTION
## What?
Adds the ability to perform a set of operations in a transactional manner on the Dom class. The transaction is indicated by the new member variable `is_transaction_in_progess`, which is set to `true` when the operations start and `false` when they complete. The class now includes methods for starting and ending a transaction, which enforce class invariants and ensure that only one transaction can be active at a time.

## Why?

Sometimes we need to carry out a number of operations without maintaining consistency of the DOM between them. However, some DOM methods assert invariants each time they are run. Transactions allow us to run these methods until we reach a good state, at which point we can safely assert the invariants.