### PR TITLE
Fix cursor position, web

### DIFF
--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -18,6 +18,7 @@ import {
     computeNodeAndOffset,
     countCodeunit,
     getCurrentSelection,
+    isPlaceholderParagraphNode,
     textLength,
     textNodeNeedsExtraOffset,
 } from './dom';
@@ -428,7 +429,6 @@ describe('computeNodeAndOffset', () => {
         // case when we have <strong>bold</strong> line2 then move cursor to
         // just before the l and press enter
         setEditorHtml('<p><strong>bold</strong>&nbsp;</p><p>line2</p>');
-        console.log(editor.innerHTML);
         const { node, offset } = computeNodeAndOffset(editor, 6);
 
         // Then
@@ -881,6 +881,32 @@ describe('textLength', () => {
         expect(textLength(listNode, -1)).toBe(
             numberOfListItems * (testStringLength + 1),
         );
+    });
+});
+
+describe('isPlaceholderParagraphNode', () => {
+    it('returns true for placeholder paragraph', () => {
+        setEditorHtml('<p>&nbsp;</p>');
+        const node = editor.childNodes[0].childNodes[0];
+        expect(isPlaceholderParagraphNode(node)).toBe(true);
+    });
+
+    it('returns false for whitespace paragraph', () => {
+        setEditorHtml('<p> </p>');
+        const node = editor.childNodes[0].childNodes[0];
+        expect(isPlaceholderParagraphNode(node)).toBe(false);
+    });
+
+    it('returns false for node with sibling', () => {
+        setEditorHtml('<p>text<em>italic</em></p>');
+        const node = editor.childNodes[0].childNodes[0];
+        expect(isPlaceholderParagraphNode(node)).toBe(false);
+    });
+
+    it('returns false for node with non paragraph parent', () => {
+        setEditorHtml('<div>text</div>');
+        const node = editor.childNodes[0].childNodes[0];
+        expect(isPlaceholderParagraphNode(node)).toBe(false);
     });
 });
 

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -421,6 +421,20 @@ describe('computeNodeAndOffset', () => {
         expect(node).toBe(editor.childNodes[3].childNodes[0]);
         expect(offset).toBe(0);
     });
+
+    // eslint-disable-next-line max-len
+    it('should deal with nbsp caused by line breaking part way through a tag', () => {
+        // When
+        // case when we have <strong>bold</strong> line2 then move cursor to
+        // just before the l and press enter
+        setEditorHtml('<p><strong>bold</strong>&nbsp;</p><p>line2</p>');
+        console.log(editor.innerHTML);
+        const { node, offset } = computeNodeAndOffset(editor, 6);
+
+        // Then
+        expect(node).toBe(editor.childNodes[1].childNodes[0]);
+        expect(offset).toBe(0);
+    });
 });
 
 describe('countCodeunit', () => {

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -164,28 +164,34 @@ export function computeNodeAndOffset(
     node: Node | null;
     offset: number;
 } {
+    // console.log(`node: ${currentNode.nodeName} offset: ${codeunits}`);
     const isEmptyListItem =
         currentNode.nodeName === 'LI' && !currentNode.hasChildNodes();
 
     if (currentNode.nodeType === Node.TEXT_NODE) {
+        // console.log(currentNode.textContent?.length);
         // For a text node, we need to check to see if it needs an extra offset
         // which involves climbing the tree through it's ancestors checking for
         // any of the nodes that require the extra offset.
         const shouldAddOffset = textNodeNeedsExtraOffset(currentNode);
         const extraOffset = shouldAddOffset ? 1 : 0;
 
+        // TODO the issue is coming from handling the nbsp that is inserted when
+        // we split like <p><strong>bold</strong>&nbsp;</p><p>line2</p>
+        // FIXME
+
         // We also have a special case for a text node that is a single &nbsp;
         // which is used as a placeholder for an empty paragraph - we don't want
         // to count it's length
-        if (textContentIsNbsp(currentNode)) {
-            if (codeunits === 0) {
-                // this is the only time we would 'find' this node
-                return { node: currentNode, offset: codeunits };
-            } else {
-                // otherwise we need to keep looking, but count this as 0 length
-                return { node: null, offset: codeunits - extraOffset };
-            }
-        }
+        // if (isNbspParagraphNode(currentNode)) {
+        //     if (codeunits === 0) {
+        //         // this is the only time we would 'find' this node
+        //         return { node: currentNode, offset: codeunits };
+        //     } else {
+        //         // otherwise we need to keep looking, but count this as 0 length
+        //         return { node: null, offset: codeunits - extraOffset };
+        //     }
+        // }
 
         if (codeunits <= (currentNode.textContent?.length || 0)) {
             // we don't need to use that extra offset if we've found the answer
@@ -364,9 +370,9 @@ function findCharacter(
             // ...but also have a special case where we don't count a textnode
             // if it is an nbsp, as this is what we use to mark out empty
             // paragraphs
-            if (textContentIsNbsp(currentNode)) {
-                return { found: false, offset: extraOffset };
-            }
+            // if (isNbspParagraphNode(currentNode)) {
+            //     return { found: false, offset: extraOffset };
+            // }
 
             return {
                 found: false,
@@ -517,7 +523,7 @@ function isEmptyInlineNode(node: Node) {
     );
 }
 
-function textContentIsNbsp(node: Node) {
+function isNbspParagraphNode(node: Node) {
     const nbsp = String.fromCharCode(160); // &nbsp;
     return node.textContent === nbsp;
 }

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -183,15 +183,15 @@ export function computeNodeAndOffset(
         // We also have a special case for a text node that is a single &nbsp;
         // which is used as a placeholder for an empty paragraph - we don't want
         // to count it's length
-        // if (isNbspParagraphNode(currentNode)) {
-        //     if (codeunits === 0) {
-        //         // this is the only time we would 'find' this node
-        //         return { node: currentNode, offset: codeunits };
-        //     } else {
-        //         // otherwise we need to keep looking, but count this as 0 length
-        //         return { node: null, offset: codeunits - extraOffset };
-        //     }
-        // }
+        if (isPlaceholderParagraphNode(currentNode)) {
+            if (codeunits === 0) {
+                // this is the only time we would 'find' this node
+                return { node: currentNode, offset: codeunits };
+            } else {
+                // otherwise we need to keep looking, but count this as 0 length
+                return { node: null, offset: codeunits - extraOffset };
+            }
+        }
 
         if (codeunits <= (currentNode.textContent?.length || 0)) {
             // we don't need to use that extra offset if we've found the answer
@@ -370,9 +370,9 @@ function findCharacter(
             // ...but also have a special case where we don't count a textnode
             // if it is an nbsp, as this is what we use to mark out empty
             // paragraphs
-            // if (isNbspParagraphNode(currentNode)) {
-            //     return { found: false, offset: extraOffset };
-            // }
+            if (isPlaceholderParagraphNode(currentNode)) {
+                return { found: false, offset: extraOffset };
+            }
 
             return {
                 found: false,
@@ -523,7 +523,11 @@ function isEmptyInlineNode(node: Node) {
     );
 }
 
-function isNbspParagraphNode(node: Node) {
-    const nbsp = String.fromCharCode(160); // &nbsp;
-    return node.textContent === nbsp;
+function isPlaceholderParagraphNode(node: Node) {
+    // a placeholder paragraph will have single child that is a text node with
+    // a content that is an nbsp
+    const hasNoSiblings = node.parentNode?.childNodes.length === 1;
+    const hasParagraphParent = node.parentNode?.nodeName === 'P';
+    const hasNbspContent = node.textContent === String.fromCharCode(160);
+    return hasParagraphParent && hasNoSiblings && hasNbspContent;
 }

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -517,7 +517,7 @@ function isEmptyInlineNode(node: Node) {
     );
 }
 
-function isPlaceholderParagraphNode(node: Node) {
+export function isPlaceholderParagraphNode(node: Node) {
     // a placeholder paragraph will have single child that is a text node with
     // a content that is an nbsp
     const hasNoSiblings = node.parentNode?.childNodes.length === 1;

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -169,16 +169,11 @@ export function computeNodeAndOffset(
         currentNode.nodeName === 'LI' && !currentNode.hasChildNodes();
 
     if (currentNode.nodeType === Node.TEXT_NODE) {
-        // console.log(currentNode.textContent?.length);
         // For a text node, we need to check to see if it needs an extra offset
         // which involves climbing the tree through it's ancestors checking for
         // any of the nodes that require the extra offset.
         const shouldAddOffset = textNodeNeedsExtraOffset(currentNode);
         const extraOffset = shouldAddOffset ? 1 : 0;
-
-        // TODO the issue is coming from handling the nbsp that is inserted when
-        // we split like <p><strong>bold</strong>&nbsp;</p><p>line2</p>
-        // FIXME
 
         // We also have a special case for a text node that is a single &nbsp;
         // which is used as a placeholder for an empty paragraph - we don't want

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -164,7 +164,6 @@ export function computeNodeAndOffset(
     node: Node | null;
     offset: number;
 } {
-    // console.log(`node: ${currentNode.nodeName} offset: ${codeunits}`);
     const isEmptyListItem =
         currentNode.nodeName === 'LI' && !currentNode.hasChildNodes();
 


### PR DESCRIPTION
This fixes the issue where breaking an element part way through (by pressing enter) puts the cursor in the wrong position.

An example of the previous breaking behaviour would have been:

- enter `<em>italic</em> |line2` (note cursor position has been moved to between " " and "l"
- press enter
- the nbsp that appears between the closing em tag and the first closing paragraph was messing up the counting

This code makes the check for an empty placeholder paragraph (ie `<p>&nbsp;</p>`) more strict to avoid misidentification and adds a test for the edge case that raised the issue.

Current behaviour is now:

https://user-images.githubusercontent.com/56027671/216332205-de964b95-ed47-4c6a-99d5-728b194ae052.mov

