### PR TITLE
Add cmd e shortcut for inline code

### DIFF
--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -82,6 +82,8 @@ function getInputFromKeyDown(
                 return 'formatItalic';
             case 'u':
                 return 'formatUnderline';
+            case 'e':
+                return 'formatInlineCode';
             case 'y':
                 return 'historyRedo';
             case 'z':


### PR DESCRIPTION
Tiny one - we missed the shortcut (as listed in element web) when adding inline code. This makes the shortcut work.