### PR TITLE
Fix code block HTML rendering

### DIFF
--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -233,7 +233,7 @@ mod test {
                 </blockquote>\
                 <p>&nbsp;</p>\
                 <p>Some text</p>\
-                <pre>A\n\tcode\nblock</pre>\
+                <pre><code>A\n\tcode\nblock</code></pre>\
                 <p>Some <code>inline</code> code</p>",
         ));
         assert_eq!(
@@ -243,7 +243,7 @@ mod test {
             </blockquote>\
             <p>&nbsp;</p>\
             <p>Some text</p>\
-            <pre>A\n\tcode\nblock</pre>\
+            <pre><code>A\n\tcode\nblock</code></pre>\
             <p>Some <code>inline</code> code|</p>"
         )
     }

--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -233,12 +233,12 @@ mod test {
 
     #[test]
     fn code_block_roundtrips() {
-        let model = cm("<pre>Test|\nCode</pre>");
+        let model = cm("<pre><code>Test|\nCode</code></pre>");
         // <pre> internally works as any other block node, with paragraphs
         let tree = model.to_tree().to_string();
         let expected_tree = indoc! { r#"
         
-            └>pre
+            └>codeblock
               ├>p
               │ └>"Test"
               └>p
@@ -246,21 +246,21 @@ mod test {
         "#};
         assert_eq!(tree, expected_tree);
         // But it gets translated back to the proper HTML output
-        assert_eq!(tx(&model), "<pre>Test|\nCode</pre>");
+        assert_eq!(tx(&model), "<pre><code>Test|\nCode</code></pre>");
     }
 
     #[test]
     fn add_code_block_to_empty_dom() {
         let mut model = cm("|");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>&nbsp;|</pre>");
+        assert_eq!(tx(&model), "<pre><code>&nbsp;|</code></pre>");
     }
 
     #[test]
     fn add_code_block_to_simple_text() {
         let mut model = cm("Some text|");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>Some text|</pre>");
+        assert_eq!(tx(&model), "<pre><code>Some text|</code></pre>");
     }
 
     #[test]
@@ -269,7 +269,7 @@ mod test {
         model.code_block();
         assert_eq!(
             tx(&model),
-            "<pre>Some text| <b>and bold </b><i>and italic</i></pre>"
+            "<pre><code>Some text| <b>and bold </b><i>and italic</i></code></pre>"
         );
     }
 
@@ -280,7 +280,7 @@ mod test {
         model.code_block();
         assert_eq!(
             tx(&model),
-            "<pre>Some text| <b>and bold </b></pre><p><i>and italic</i></p>"
+            "<pre><code>Some text| <b>and bold </b></code></pre><p><i>and italic</i></p>"
         );
     }
 
@@ -292,7 +292,7 @@ mod test {
         model.code_block();
         assert_eq!(
             tx(&model),
-            "<ul><li><pre>Some text <b>and bold |</b><i>and italic</i></pre></li></ul>"
+            "<ul><li><pre><code>Some text <b>and bold |</b><i>and italic</i></code></pre></li></ul>"
         );
     }
 
@@ -304,7 +304,7 @@ mod test {
         model.code_block();
         assert_eq!(
             tx(&model),
-            "<ul><li><p>Some text <b>and bold&nbsp;</b></p><pre><i>and| italic</i></pre></li></ul>"
+            "<ul><li><p>Some text <b>and bold&nbsp;</b></p><pre><code><i>and| italic</i></code></pre></li></ul>"
         );
     }
 
@@ -313,7 +313,10 @@ mod test {
         let mut model =
             cm("<ul><li>{First item</li><li>Second}| item</li></ul>");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>{First item\nSecond}| item</pre>");
+        assert_eq!(
+            tx(&model),
+            "<pre><code>{First item\nSecond}| item</code></pre>"
+        );
     }
 
     #[test]
@@ -321,7 +324,7 @@ mod test {
         let mut model =
             cm("<ul><li>{First item</li><li>Second item</li></ul><p>Some text</p><ul><li>Third}| item</li><li>Fourth one</li></ul>");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>{First item\nSecond item\nSome text\nThird}| item</pre><ul><li>Fourth one</li></ul>");
+        assert_eq!(tx(&model), "<pre><code>{First item\nSecond item\nSome text\nThird}| item</code></pre><ul><li>Fourth one</li></ul>");
     }
 
     #[test]
@@ -330,24 +333,27 @@ mod test {
             "<p>{Text</p><ul><li>First item</li><li>Second}| item</li></ul>",
         );
         model.code_block();
-        assert_eq!(tx(&model), "<pre>{Text\nFirst item\nSecond}| item</pre>");
+        assert_eq!(
+            tx(&model),
+            "<pre><code>{Text\nFirst item\nSecond}| item</code></pre>"
+        );
     }
 
     #[test]
     fn add_code_block_to_existing_code_block() {
-        let mut model = cm("<p>{Text</p><pre>code}|</pre>");
+        let mut model = cm("<p>{Text</p><pre><code>code}|</code></pre>");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>{Text\ncode}|</pre>");
+        assert_eq!(tx(&model), "<pre><code>{Text\ncode}|</code></pre>");
     }
 
     #[test]
     fn add_code_block_to_existing_code_block_partially_selected() {
         let mut model =
-            cm("<p>{Text</p><pre><b>code}|</b><i> and italic</i></pre>");
+            cm("<p>{Text</p><pre><code><b>code}|</b><i> and italic</i></code></pre>");
         model.code_block();
         assert_eq!(
             tx(&model),
-            "<pre>{Text\n<b>code}|</b><i> and italic</i></pre>"
+            "<pre><code>{Text\n<b>code}|</b><i> and italic</i></code></pre>"
         );
     }
 
@@ -358,7 +364,7 @@ mod test {
         model.code_block();
         assert_eq!(
             tx(&model),
-            "<p><b>Text</b></p><pre><b><i>{in italic}|</i></b></pre>"
+            "<p><b>Text</b></p><pre><code><b><i>{in italic}|</i></b></code></pre>"
         );
     }
 
@@ -370,7 +376,7 @@ mod test {
         model.code_block();
         assert_eq!(
             tx(&model),
-            "<p><u><b>Text</b></u></p><pre><u><b><i>{in italic}|</i></b></u></pre>"
+            "<p><u><b>Text</b></u></p><pre><code><u><b><i>{in italic}|</i></b></u></code></pre>"
         );
     }
 
@@ -378,7 +384,7 @@ mod test {
     fn add_code_block_to_quote() {
         let mut model = cm("<blockquote><p>Quot|e</p></blockquote>");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>Quot|e</pre>");
+        assert_eq!(tx(&model), "<pre><code>Quot|e</code></pre>");
     }
 
     #[test]
@@ -386,7 +392,7 @@ mod test {
         let mut model =
             cm("<p>Te{xt </p><blockquote><p>Quot}|e</p></blockquote>");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>Te{xt \nQuot}|e</pre>");
+        assert_eq!(tx(&model), "<pre><code>Te{xt \nQuot}|e</code></pre>");
     }
 
     #[test]
@@ -394,13 +400,14 @@ mod test {
         let mut model =
             cm("<blockquote><p>Quo{te</p></blockquote><p>Te}|xt</p>");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>Quo{te\nTe}|xt</pre>");
+        assert_eq!(tx(&model), "<pre><code>Quo{te\nTe}|xt</code></pre>");
     }
 
     #[test]
     fn remove_code_block_moves_its_children_out() {
-        let mut model =
-            cm("<p>Text</p><pre><b>code|</b><i> and italic</i></pre>");
+        let mut model = cm(
+            "<p>Text</p><pre><code><b>code|</b><i> and italic</i></code></pre>",
+        );
         model.code_block();
         assert_eq!(
             tx(&model),
@@ -410,7 +417,8 @@ mod test {
 
     #[test]
     fn remove_code_block_moves_its_children_and_restores_line_breaks() {
-        let mut model = cm("<p>Text</p><pre>with|\nline\nbreaks</pre>");
+        let mut model =
+            cm("<p>Text</p><pre><code>with|\nline\nbreaks</code></pre>");
         model.code_block();
         assert_eq!(
             tx(&model),
@@ -420,7 +428,8 @@ mod test {
 
     #[test]
     fn remove_code_block_moves_its_children_and_keeps_selection_in_place() {
-        let mut model = cm("<p>Text</p><pre>wi{th\nline\nbrea}|ks</pre>");
+        let mut model =
+            cm("<p>Text</p><pre><code>wi{th\nline\nbrea}|ks</code></pre>");
         model.code_block();
         assert_eq!(
             tx(&model),
@@ -432,14 +441,14 @@ mod test {
     fn test_creating_code_block_at_the_end_of_editor() {
         let mut model = cm("<p>Test</p><p>|</p>");
         model.code_block();
-        assert_eq!(tx(&model), "<p>Test</p><pre>&nbsp;|</pre>");
+        assert_eq!(tx(&model), "<p>Test</p><pre><code>&nbsp;|</code></pre>");
     }
 
     #[test]
     fn creating_and_removing_code_block_works() {
         let mut model = cm("|");
         model.code_block();
-        assert_eq!(tx(&model), "<pre>&nbsp;|</pre>");
+        assert_eq!(tx(&model), "<pre><code>&nbsp;|</code></pre>");
         model.code_block();
         assert_eq!(tx(&model), "<p>&nbsp;|</p>");
     }
@@ -448,7 +457,10 @@ mod test {
     fn add_code_block_to_empty_list_item() {
         let mut model = cm("<ul><li>|</li></ul>");
         model.code_block();
-        assert_eq!(tx(&model), "<ul><li><pre>&nbsp;|</pre></li></ul>");
+        assert_eq!(
+            tx(&model),
+            "<ul><li><pre><code>&nbsp;|</code></pre></li></ul>"
+        );
         assert_eq!(
             model.to_tree().to_string(),
             indoc! {
@@ -456,7 +468,7 @@ mod test {
                 
                 └>ul
                   └>li
-                    └>pre
+                    └>codeblock
                       └>p
                 "#
             }
@@ -473,7 +485,7 @@ mod test {
         assert_eq!(
             tx(&model),
             "\
-        <pre>|A</pre>\
+        <pre><code>|A</code></pre>\
         <p>B</p>\
         <p>C</p>"
         );
@@ -490,7 +502,7 @@ mod test {
             tx(&model),
             "\
         <p>A</p>\
-        <pre>B|</pre>\
+        <pre><code>B|</code></pre>\
         <p>C</p>"
         );
     }
@@ -507,7 +519,7 @@ mod test {
             "\
         <p>A</p>\
         <p>B</p>\
-        <pre>|C</pre>"
+        <pre><code>|C</code></pre>"
         );
     }
 }

--- a/crates/wysiwyg/src/composer_model/quotes.rs
+++ b/crates/wysiwyg/src/composer_model/quotes.rs
@@ -269,9 +269,12 @@ mod test {
 
     #[test]
     fn apply_quote_to_code_block() {
-        let mut model = cm("<pre>Some| code</pre>");
+        let mut model = cm("<pre><code>Some| code</code></pre>");
         model.quote();
-        assert_eq!(tx(&model), "<blockquote><pre>Some| code</pre></blockquote>")
+        assert_eq!(
+            tx(&model),
+            "<blockquote><pre><code>Some| code</code></pre></blockquote>"
+        )
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -1171,8 +1171,8 @@ mod test {
 
     #[test]
     fn delete_text_at_end_of_code_block_appends_next_content() {
-        let mut model = cm("<pre>Te{st</pre>AA}|BB");
+        let mut model = cm("<pre><code>Te{st</code></pre>AA}|BB");
         model.delete();
-        assert_eq!(tx(&model), "<pre>Te|BB</pre>");
+        assert_eq!(tx(&model), "<pre><code>Te|BB</code></pre>");
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -151,7 +151,7 @@ where
 
     pub fn new_code_block(children: Vec<DomNode<S>>) -> Self {
         Self {
-            name: "pre".into(),
+            name: "codeblock".into(),
             kind: ContainerNodeKind::CodeBlock,
             attrs: None,
             children,
@@ -604,7 +604,11 @@ where
             let name = self.name();
             if !name.is_empty() {
                 formatter.push('<');
-                formatter.push(name);
+                if matches!(self.kind, ContainerNodeKind::CodeBlock) {
+                    formatter.push("pre");
+                } else {
+                    formatter.push(name);
+                }
                 if let Some(attrs) = &self.attrs {
                     for attr in attrs {
                         let (attr_name, value) = attr;
@@ -621,6 +625,7 @@ where
             let mut state = state;
             if matches!(self.kind, ContainerNodeKind::CodeBlock) {
                 state.is_inside_code_block = true;
+                formatter.push("<code>");
             }
 
             if matches!(self.kind, ContainerNodeKind::Paragraph)
@@ -631,9 +636,17 @@ where
 
             self.fmt_children_html(formatter, selection_writer, state);
 
+            if matches!(self.kind, ContainerNodeKind::CodeBlock) {
+                formatter.push("</code>");
+            }
+
             if !name.is_empty() {
                 formatter.push("</");
-                formatter.push(name);
+                if matches!(self.kind, ContainerNodeKind::CodeBlock) {
+                    formatter.push("pre");
+                } else {
+                    formatter.push(name);
+                }
                 formatter.push('>');
             }
         }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -403,7 +403,7 @@ mod sys {
         }
 
         #[test]
-        fn parse_code_block_removes_internal_code_tag() {
+        fn parse_code_block_keeps_internal_code_tag() {
             let html = "\
                 <p>foo</p>\
                 <pre><code>Some code</code></pre>\
@@ -418,7 +418,7 @@ mod sys {
                 
                 ├>p
                 │ └>"foo"
-                ├>pre
+                ├>codeblock
                 │ └>p
                 │   └>"Some code"
                 └>p
@@ -429,8 +429,10 @@ mod sys {
 
         #[test]
         fn parse_code_block_roundtrips() {
-            assert_that!("<p>foo</p><pre>Some code</pre><p>bar</p>")
-                .roundtrips();
+            assert_that!(
+                "<p>foo</p><pre><code>Some code</code></pre><p>bar</p>"
+            )
+            .roundtrips();
         }
 
         #[test]
@@ -444,7 +446,7 @@ mod sys {
             // First, line breaks are added as placeholders for paragraphs
             assert_eq!(
                 dom.to_html().to_string(),
-                "<pre><b>Test<br />Code</b></pre>"
+                "<pre><code><b>Test<br />Code</b></code></pre>"
             );
             // Then these line breaks are post-processed and we get the actual paragraphs
             let dom = post_process_code_blocks_lines(
@@ -453,7 +455,7 @@ mod sys {
             );
             assert_eq!(
                 dom.to_html().to_string(),
-                "<pre><b>Test</b>\n<b>Code</b></pre>"
+                "<pre><code><b>Test</b>\n<b>Code</b></code></pre>"
             );
         }
 
@@ -485,7 +487,7 @@ mod sys {
                 r#"
                 
                 ├>p
-                ├>pre
+                ├>codeblock
                 │ ├>p
                 │ └>p
                 └>p
@@ -508,7 +510,7 @@ mod sys {
                 r#"
                 
                 ├>p
-                ├>pre
+                ├>codeblock
                 │ ├>p
                 │ └>p
                 └>p
@@ -934,7 +936,7 @@ mod js {
 
         #[wasm_bindgen_test]
         fn pre() {
-            roundtrip("foo <pre>~Some code</pre> bar");
+            roundtrip("foo <pre><code>~Some code</code></pre> bar");
         }
 
         #[wasm_bindgen_test]
@@ -954,7 +956,7 @@ mod js {
         
                 ├>p
                 │ └>"foo"
-                ├>pre
+                ├>codeblock
                 │ └>p
                 │   └>"Some code"
                 └>p
@@ -982,7 +984,7 @@ mod js {
                 r#"
                 
                 ├>p
-                ├>pre
+                ├>codeblock
                 │ ├>p
                 │ └>p
                 └>p
@@ -1004,7 +1006,7 @@ mod js {
                 r#"
                 
                 ├>p
-                ├>pre
+                ├>codeblock
                 │ ├>p
                 │ └>p
                 └>p

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -228,7 +228,7 @@ fn clicking_code_block_disables_expected_formatting_functions() {
 
 #[test]
 fn code_block_disables_expected_formatting_functions_with_cursor() {
-    let model = cm("<pre>Some code| as text</pre> and text");
+    let model = cm("<pre><code>Some code| as text</code></pre> and text");
     assert!(model.action_is_disabled(ComposerAction::InlineCode));
     assert!(model.action_is_disabled(ComposerAction::OrderedList));
     assert!(model.action_is_disabled(ComposerAction::UnorderedList));
@@ -238,7 +238,7 @@ fn code_block_disables_expected_formatting_functions_with_cursor() {
 
 #[test]
 fn code_block_disables_expected_formatting_functions_with_selection() {
-    let model = cm("<pre>Some {code as text</pre> and}| text");
+    let model = cm("<pre><code>Some {code as text</code></pre> and}| text");
     assert!(model.action_is_disabled(ComposerAction::InlineCode));
     assert!(model.action_is_disabled(ComposerAction::OrderedList));
     assert!(model.action_is_disabled(ComposerAction::UnorderedList));
@@ -248,7 +248,7 @@ fn code_block_disables_expected_formatting_functions_with_selection() {
 
 #[test]
 fn code_block_doesnt_affect_cursor_if_its_outside() {
-    let model = cm("<pre>Some code</pre><p>|And text</p>");
+    let model = cm("<pre><code>Some code</code></pre><p>|And text</p>");
     assert!(!model.action_is_reversed(ComposerAction::CodeBlock));
     assert!(model.action_is_enabled(ComposerAction::InlineCode));
     assert!(model.action_is_enabled(ComposerAction::Quote));

--- a/crates/wysiwyg/src/tests/test_paragraphs.rs
+++ b/crates/wysiwyg/src/tests/test_paragraphs.rs
@@ -182,16 +182,16 @@ fn backspace_merges_formatting_nodes() {
 
 #[test]
 fn enter_in_code_block_in_text_node_adds_line_break_as_text() {
-    let mut model = cm("<pre>Test|</pre>");
+    let mut model = cm("<pre><code>Test|</code></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>Test\n&nbsp;|</pre>")
+    assert_eq!(tx(&model), "<pre><code>Test\n&nbsp;|</code></pre>")
 }
 
 #[test]
 fn enter_in_code_block_at_start_adds_the_line_break() {
-    let mut model = cm("<pre>|Test</pre>");
+    let mut model = cm("<pre><code>|Test</code></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>&nbsp;\n|Test</pre>")
+    assert_eq!(tx(&model), "<pre><code>&nbsp;\n|Test</code></pre>")
 }
 
 #[test]
@@ -202,56 +202,58 @@ fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_co
     model.code_block();
     model.replace_text("Test".into());
     model.select(0.into(), 0.into());
-    assert_eq!(tx(&model), "<pre>|Test</pre>");
+    assert_eq!(tx(&model), "<pre><code>|Test</code></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>&nbsp;\n|Test</pre>");
+    assert_eq!(tx(&model), "<pre><code>&nbsp;\n|Test</code></pre>");
     model.select(0.into(), 0.into());
     model.enter();
-    assert_eq!(tx(&model), "<p>&nbsp;|</p><pre>Test</pre>");
+    assert_eq!(tx(&model), "<p>&nbsp;|</p><pre><code>Test</code></pre>");
 }
 
 #[test]
 fn enter_in_code_block_at_start_with_previous_line_break_moves_it_outside_the_code_block_with_text_around(
 ) {
-    // The initial line break will be removed, so it's the same as having a single line break at the start
-    let mut model = cm("<p>ASDA</p><pre>\n|\nTest</pre><p>ASD</p>");
+    let mut model = cm("<p>ASDA</p><pre><code>|\nTest</code></pre><p>ASD</p>");
     model.enter();
     assert_eq!(
         tx(&model),
-        "<p>ASDA</p><p>&nbsp;|</p><pre>Test</pre><p>ASD</p>"
+        "<p>ASDA</p><p>&nbsp;|</p><pre><code>Test</code></pre><p>ASD</p>"
     )
 }
 
 #[test]
 fn enter_in_code_block_at_start_with_a_line_break_after_it_adds_another_one() {
-    // The initial line break will be removed, so it's the same as having a single line break at the start
-    let mut model = cm("<pre>\n\n|Test</pre>");
+    let mut model = cm("<pre><code>\n\n|Test</code></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>&nbsp;\n\n|Test</pre>")
+    assert_eq!(tx(&model), "<pre><code>&nbsp;\n\n\n|Test</code></pre>")
 }
 
 #[test]
 fn enter_in_code_block_after_line_break_in_middle_splits_code_block() {
-    let mut model = cm("<pre>Test\n|\ncode blocks</pre>");
+    let mut model = cm("<pre><code>Test\n|\ncode blocks</code></pre>");
     model.enter();
     assert_eq!(
         tx(&model),
-        "<pre>Test</pre><p>&nbsp;|</p><pre>code blocks</pre>"
+        "<pre><code>Test</code></pre><p>&nbsp;|</p><pre><code>code blocks</code></pre>"
     )
 }
 
 #[test]
 fn enter_in_code_block_after_nested_line_break_in_middle_splits_code_block() {
-    let mut model = cm("<pre><b><i>Test\n|\ncode blocks</i></b></pre>");
+    let mut model =
+        cm("<pre><code><b><i>Test\n|\ncode blocks</i></b></code></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre><b><i>Test</i></b></pre><p>&nbsp;|</p><pre><b><i>code blocks</i></b></pre>")
+    assert_eq!(tx(&model), "<pre><code><b><i>Test</i></b></code></pre><p>&nbsp;|</p><pre><code><b><i>code blocks</i></b></code></pre>")
 }
 
 #[test]
 fn enter_in_code_block_after_line_break_at_end_exits_it() {
-    let mut model = cm("<pre><b>Bold</b> plain\n|</pre>");
+    let mut model = cm("<pre><code><b>Bold</b> plain\n|</code></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre><b>Bold</b> plain</pre><p>&nbsp;|</p>")
+    assert_eq!(
+        tx(&model),
+        "<pre><code><b>Bold</b> plain</code></pre><p>&nbsp;|</p>"
+    )
 }
 
 #[test]
@@ -306,7 +308,7 @@ fn double_enter_in_quote_at_end_when_not_empty_exits_it() {
 fn double_enter_in_code_block_when_empty_removes_it_and_adds_new_line() {
     let mut model = cm("|");
     model.code_block();
-    assert_eq!(tx(&model), "<pre>&nbsp;|</pre>");
+    assert_eq!(tx(&model), "<pre><code>&nbsp;|</code></pre>");
     model.enter();
     assert_eq!(tx(&model), "<p>&nbsp;|</p>");
     model.replace_text("asd".into());
@@ -336,7 +338,7 @@ fn double_enter_in_quote_in_nested_nodes() {
 
 #[test]
 fn backspace_at_start_of_code_block_moves_contents_to_previous_block() {
-    let mut model = cm("<p>Test</p><pre>|code</pre>");
+    let mut model = cm("<p>Test</p><pre><code>|code</code></pre>");
     model.backspace();
     assert_eq!(tx(&model), "<p>Test|code</p>");
 }
@@ -344,14 +346,18 @@ fn backspace_at_start_of_code_block_moves_contents_to_previous_block() {
 #[test]
 fn backspace_at_end_of_code_block_adds_the_content_of_the_next_block_node_to_it(
 ) {
-    let mut model = cm("<p>Test</p><pre>code</pre><p>|and more</p>");
+    let mut model =
+        cm("<p>Test</p><pre><code>code</code></pre><p>|and more</p>");
     model.backspace();
-    assert_eq!(tx(&model), "<p>Test</p><pre>code|and more</pre>");
+    assert_eq!(
+        tx(&model),
+        "<p>Test</p><pre><code>code|and more</code></pre>"
+    );
 }
 
 #[test]
 fn backspace_emptying_code_block_removes_it() {
-    let mut model = cm("<p>Test</p><pre>|</pre>");
+    let mut model = cm("<p>Test</p><pre><code>|</code></pre>");
     model.backspace();
     assert_eq!(tx(&model), "<p>Test|</p>");
 }
@@ -410,14 +416,17 @@ fn pressing_enter_after_wrapping_text_in_code_block_works() {
     model.replace_text("Some code".into());
     model.code_block();
     model.enter();
-    assert_eq!(tx(&model), "<pre>Some code\n&nbsp;|</pre>")
+    assert_eq!(tx(&model), "<pre><code>Some code\n&nbsp;|</code></pre>")
 }
 
 #[test]
 fn pressing_enter_at_the_start_of_a_multiline_code_block() {
-    let mut model = cm("<pre>|line_1\nline_2</pre>");
+    let mut model = cm("<pre><code>|line_1\nline_2</code></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>&nbsp;\n|line_1\nline_2</pre>")
+    assert_eq!(
+        tx(&model),
+        "<pre><code>&nbsp;\n|line_1\nline_2</code></pre>"
+    )
 }
 
 #[test]
@@ -433,16 +442,22 @@ fn pressing_enter_at_the_start_of_a_multiline_block_quote() {
 #[test]
 fn pressing_enter_in_the_middle_of_a_multiline_code_block_with_empty_starting_paragraphs(
 ) {
-    let mut model = cm("<pre>|line_1\nline_2</pre>");
+    let mut model = cm("<pre><code>|line_1\nline_2</code></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>&nbsp;\n|line_1\nline_2</pre>")
+    assert_eq!(
+        tx(&model),
+        "<pre><code>&nbsp;\n|line_1\nline_2</code></pre>"
+    )
 }
 
 #[test]
 fn pressing_enter_in_the_middle_of_a_multiline_code_block() {
-    let mut model = cm("<pre>line_0\n|line_1\nline_2</pre>");
+    let mut model = cm("<pre><code>line_0\n|line_1\nline_2</code></pre>");
     model.enter();
-    assert_eq!(tx(&model), "<pre>line_0\n\n|line_1\nline_2</pre>")
+    assert_eq!(
+        tx(&model),
+        "<pre><code>line_0\n\n|line_1\nline_2</code></pre>"
+    )
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_set_content.rs
+++ b/crates/wysiwyg/src/tests/test_set_content.rs
@@ -51,6 +51,6 @@ fn clear() {
 fn set_contents_with_line_break_in_code_block() {
     // The first line break inside a block node will be removed as it can be used to just give
     // structure to the node
-    let model = cm("<pre>\n|Test</pre>");
-    assert_eq!(tx(&model), "<pre>|Test</pre>");
+    let model = cm("<pre>\n<code>|Test</code></pre>");
+    assert_eq!(tx(&model), "<pre><code>|Test</code></pre>");
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -25,7 +25,6 @@ import org.xml.sax.ContentHandler
 import org.xml.sax.InputSource
 import org.xml.sax.Locator
 import java.io.StringReader
-import kotlin.math.max
 import kotlin.math.roundToInt
 
 /**
@@ -142,7 +141,10 @@ internal class HtmlToSpansParser(
             "i", "em" -> handleFormatStartTag(InlineFormat.Italic)
             "u" -> handleFormatStartTag(InlineFormat.Underline)
             "del" -> handleFormatStartTag(InlineFormat.StrikeThrough)
-            "code" -> handleFormatStartTag(InlineFormat.InlineCode)
+            "code" -> {
+                if(getLastPending<PlaceholderSpan.CodeBlock>() != null) return
+                handleFormatStartTag(InlineFormat.InlineCode)
+            }
             "a" -> {
                 val url = attrs?.getValue("href") ?: return
                 handleHyperlinkStart(url)

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+CodeBlocks.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+CodeBlocks.swift
@@ -25,7 +25,7 @@ extension WysiwygUITests {
 
         assertTreeEquals(
             """
-            └>pre
+            └>codeblock
               └>p
                 └>"Some text"
             """

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
@@ -30,6 +30,8 @@ extension NSMutableAttributedString {
                 addAttribute(.blockStyle, value: style.codeBlockStyle, range: range)
                 guard let paragraphStyle = NSMutableParagraphStyle.createWithPadding(style.codeBlockStyle.padding) else { return }
                 addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
+                // Remove inline code background color, if it exists.
+                removeAttribute(.backgroundColor, range: range)
             case TempColor.quote:
                 addAttribute(.blockStyle, value: style.quoteBlockStyle, range: range)
                 guard let paragraphStyle = NSMutableParagraphStyle.createWithPadding(style.quoteBlockStyle.padding) else { return }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
@@ -18,11 +18,11 @@
 import XCTest
 
 private enum Constants {
-    static let resultHtml = "<pre>Some code\n\tmore code</pre><p>\(Character.nbsp)</p>"
+    static let resultHtml = "<pre><code>Some code\n\tmore code</code></pre><p>\(Character.nbsp)</p>"
     static let resultTree =
         """
 
-        ├>pre
+        ├>codeblock
         │ ├>p
         │ │ └>"Some code"
         │ └>p

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -343,7 +343,7 @@ describe('computeNodeAndOffset', () => {
             '<ol><li>ordered list</li></ol>',
             '<ul><li>ordered list</li></ul>',
             '<p>paragraph</p>',
-            '<pre>codeblock</pre>',
+            '<pre><code>codeblock</code></pre>',
             '<blockquote>another quote</blockquote>',
         ];
 
@@ -360,42 +360,35 @@ describe('computeNodeAndOffset', () => {
     it('Should find inside quote container node after a quote', () => {
         // When
         const firstNode = '<blockquote>quote</blockquote>';
-        const nextListNodes = [
-            '<ol><li>ordered list</li></ol>',
-            '<ul><li>ordered list</li></ul>',
-        ];
-        const nextOtherNodes = [
-            '<p>paragraph</p>',
-            '<pre>codeblock</pre>',
-            '<blockquote>another quote</blockquote>',
+        const nextNodes = [
+            { node: '<ol><li>ordered list</li></ol>', depth: 2 },
+            { node: '<ul><li>ordered list</li></ul>', depth: 2 },
+            { node: '<pre><code>codeblock</code></pre>', depth: 2 },
+            { node: '<p>paragraph</p>', depth: 1 },
+            { node: '<blockquote>another quote</blockquote>', depth: 1 },
         ];
 
-        nextListNodes.forEach((nextNode) => {
-            setEditorHtml(firstNode + nextNode);
+        nextNodes.forEach((nextNode) => {
+            setEditorHtml(firstNode + nextNode.node);
             const { node, offset } = computeNodeAndOffset(editor, 6);
 
+            let editorNextNode = editor.childNodes[1];
+            for (let i = 0; i < nextNode.depth; i++) {
+                editorNextNode = editorNextNode.childNodes[0];
+            }
             // Then
-            expect(node).toBe(editor.childNodes[1].childNodes[0].childNodes[0]);
-            expect(offset).toBe(0);
-        });
-
-        nextOtherNodes.forEach((nextNode) => {
-            setEditorHtml(firstNode + nextNode);
-            const { node, offset } = computeNodeAndOffset(editor, 6);
-
-            // Then
-            expect(node).toBe(editor.childNodes[1].childNodes[0]);
+            expect(node).toBe(editorNextNode);
             expect(offset).toBe(0);
         });
     });
 
     it('Should count newlines as characters in code blocks', () => {
         // When
-        setEditorHtml('<pre>length\nis 12</pre>');
+        setEditorHtml('<pre><code>length\nis 12</code></pre>');
         const { node } = computeNodeAndOffset(editor, 5);
 
         // Then
-        expect(node).toBe(editor.childNodes[0].childNodes[0]);
+        expect(node).toBe(editor.childNodes[0].childNodes[0].childNodes[0]);
         expect(node?.textContent).toHaveLength(12);
     });
 


### PR DESCRIPTION
## What?

Currently, code blocks are rendered to HTML as a `<pre>` element. After this change, code blocks are rendered using `<code>` wrapped in `<pre>`.

Note that code blocks are still represented internally as a single block node and only converted to this new format during HTML rendering so that the DOM AST is not coupled to the HTML representation.

### Before

```
<pre>
...code content...
</pre>
```

### After
```
<pre>
<code>
...code content...
</code>
</pre>
```

## Why?

The HTML `<pre>` tag represents 'preformatted text' but doesn't imply the text is code. Some clients may choose to format `<pre>` as code but we cannot assume they will. In order to describe the contents of a code block explicitly, we can use the `<code>` tag.

From [mdn web docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code):

> To represent multiple lines of code, wrap the [`<code>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code) element within a [`<pre>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre) element.

[`PSU-1099`](https://element-io.atlassian.net/browse/PSU-1099)