### PR TITLE
Add an invariant assert for `li` never contains a single `p`

### DIFF
--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -430,6 +430,10 @@ where
             list_items_after_removed_ones.insert(0, child);
         }
 
+        // FIXME: extract transaction to a dom method if possible
+        #[cfg(any(test, feature = "assert-invariants"))]
+        self.state.dom.start_transaction();
+
         let list_became_empty =
             get_container(&self.state.dom, &parent_handle).is_empty();
         if list_became_empty {
@@ -491,6 +495,9 @@ where
             .insert(&insert_into_handle, removed_list_items);
 
         self.state.dom.join_nodes_in_container(&insert_into_handle);
+
+        #[cfg(any(test, feature = "assert-invariants"))]
+        self.state.dom.end_transaction();
     }
 }
 

--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -137,6 +137,10 @@ where
                         .unwrap()
                         .is_empty()
                     {
+                        // FIXME: extract transaction to a dom method if possible
+                        #[cfg(any(test, feature = "assert-invariants"))]
+                        self.state.dom.start_transaction();
+
                         self.state.dom.remove(&list_handle);
 
                         // Then remove extra paragraphs from siblings if needed
@@ -155,6 +159,9 @@ where
                                 &list_handle.prev_sibling(),
                             );
                         }
+
+                        #[cfg(any(test, feature = "assert-invariants"))]
+                        self.state.dom.end_transaction();
                     }
                 } else if block_location.start_offset == 0 {
                     self.state.dom.insert_at(

--- a/crates/wysiwyg/src/dom/dom_invariants.rs
+++ b/crates/wysiwyg/src/dom/dom_invariants.rs
@@ -62,6 +62,7 @@ where
         self.assert_no_adjacent_text_nodes();
         self.assert_exactly_one_generic_container();
         self.assert_all_nodes_in_containers_are_block_or_inline();
+        self.assert_list_item_never_contains_single_paragraph();
 
         // We probably want some more asserts like these:
         // self.assert_document_node_is_a_container();
@@ -138,6 +139,17 @@ where
                 panic!("All child nodes of handle {:?} must be either inline nodes or block nodes:\n{}", container.handle(), container.to_tree());
             }
         }
+    }
+
+    #[cfg(any(test, feature = "assert-invariants"))]
+    fn assert_list_item_never_contains_single_paragraph(&self) {
+        use super::nodes::dom_node::DomNodeKind;
+
+        self.iter_containers().filter(|c| c.is_list_item()).for_each(|c| {
+            if c.children().len() == 1 && c.children()[0].kind() == DomNodeKind::Paragraph {
+                panic!("List item at handle {:?} contains a single paragraph: \n{}", c.handle(), c.to_tree());
+            }
+        })
     }
 }
 

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -63,7 +63,7 @@ where
 
     pub fn replace_text_in(&mut self, new_text: S, start: usize, end: usize) {
         #[cfg(any(test, feature = "assert-invariants"))]
-        self.assert_invariants();
+        self.start_transaction();
 
         let extra_len = new_text.len() + 1;
         let range = self.find_range(start, end);
@@ -144,7 +144,7 @@ where
         }
 
         #[cfg(any(test, feature = "assert-invariants"))]
-        self.assert_invariants();
+        self.end_transaction();
     }
 
     /// Removes paragraph from the closest list item ancestor, if


### PR DESCRIPTION
Add an invariant assert for list items to never contain a single paragraph. 

Note: added temporary FIXMEs we can try to make work since it might be better that transactions are performed on dedicated dom methods if possible.