### PR TITLE
[Android] Recover from Rust model crashes

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -252,8 +252,14 @@ impl ComposerModel {
         self.inner.lock().unwrap().get_link_action().into()
     }
 
+    #[cfg(not(debug_assertions))]
+    pub fn debug_panic(self: &Arc<Self>) {
+        // No-op
+    }
+
     /// Force a panic for test purposes
-    pub fn force_panic(self: &Arc<Self>) {
+    #[cfg(debug_assertions)]
+    pub fn debug_panic(self: &Arc<Self>) {
         panic!("This should only happen in tests.");
     }
 }

--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -251,4 +251,9 @@ impl ComposerModel {
     pub fn get_link_action(self: &Arc<Self>) -> LinkAction {
         self.inner.lock().unwrap().get_link_action().into()
     }
+
+    /// Force a panic for test purposes
+    pub fn force_panic(self: &Arc<Self>) {
+        panic!("This should only happen in tests.");
+    }
 }

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -46,7 +46,7 @@ interface ComposerModel {
     ComposerUpdate remove_links();
     ComposerUpdate code_block();
     ComposerUpdate quote();
-    void force_panic();
+    void debug_panic();
     string to_tree();
     string to_example_format();
     ComposerState get_current_dom_state();

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -46,6 +46,7 @@ interface ComposerModel {
     ComposerUpdate remove_links();
     ComposerUpdate code_block();
     ComposerUpdate quote();
+    void force_panic();
     string to_tree();
     string to_example_format();
     ComposerState get_current_dom_state();

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -22,7 +22,7 @@ class InterceptInputConnectionIntegrationTest {
 
     private val app: Application = ApplicationProvider.getApplicationContext()
     private val viewModel = EditorViewModel(
-        composer = newComposerModel(),
+        provideComposer = { newComposerModel() },
         htmlConverter = AndroidHtmlConverter(
             provideHtmlToSpansParser = { html ->
                 HtmlToSpansParser(

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
@@ -8,6 +8,7 @@ import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import io.element.android.wysiwyg.EditorEditText
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
+import io.element.android.wysiwyg.utils.RustErrorCollector
 import org.hamcrest.Matcher
 
 object Editor {
@@ -144,6 +145,22 @@ object Editor {
             )
         }
     }
+
+    class TestCrash(
+        private val errorCollector: RustErrorCollector?
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Test Rust crash"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val editor = view as? EditorEditText ?: return
+            if(errorCollector != null) {
+                editor.rustErrorCollector = errorCollector
+            }
+            editor.testComposerCrashRecovery()
+        }
+    }
 }
 
 object EditorActions {
@@ -157,4 +174,7 @@ object EditorActions {
     fun redo() = Editor.Redo
     fun toggleFormat(format: InlineFormat) = Editor.ToggleFormat(format)
     fun addTextWatcher(watcher : (Editable?) -> Unit) = Editor.AddTextWatcher(watcher)
+    fun testCrash(
+        errorCollector: RustErrorCollector? = null
+    ) = Editor.TestCrash(errorCollector)
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -17,6 +17,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
+import androidx.annotation.VisibleForTesting
 import androidx.core.graphics.withTranslation
 import androidx.lifecycle.*
 import com.google.android.material.textfield.TextInputEditText
@@ -58,8 +59,8 @@ class EditorEditText : TextInputEditText {
                     )
                 },
             )
-            val composer = { if (!isInEditMode) newComposerModel() else null }
-            EditorViewModel(composer, htmlConverter)
+            val provideComposer = { if (!isInEditMode) newComposerModel() else null }
+            EditorViewModel(provideComposer, htmlConverter)
         }
     )
 
@@ -384,6 +385,10 @@ class EditorEditText : TextInputEditText {
         setTextFromComposerUpdate(result)
         setSelectionFromComposerUpdate(result.selection.last)
     }
+
+    @VisibleForTesting
+    internal fun testComposerCrashRecovery() =
+        viewModel.testComposerCrashRecovery()
 
     override fun onDraw(canvas: Canvas) {
         // need to draw bg first so that text can be on top during super.onDraw()

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -58,7 +58,7 @@ class EditorEditText : TextInputEditText {
                     )
                 },
             )
-            val composer = if (!isInEditMode) newComposerModel() else null
+            val composer = { if (!isInEditMode) newComposerModel() else null }
             EditorViewModel(composer, htmlConverter)
         }
     )

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
@@ -172,7 +172,7 @@ internal class EditorViewModel(
         this.crashOnComposerFailure = false
 
         runCatching {
-            composer?.forcePanic()
+            composer?.debugPanic()
         }.onFailure {
             onComposerFailure(it)
         }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
@@ -15,6 +15,7 @@ class MockComposer {
         givenCurrentDomState()
         givenActionStates()
         givenDummyToExampleFormat()
+        givenGetContentAsPlainText()
     }
 
     fun givenCurrentDomState(
@@ -131,6 +132,10 @@ class MockComposer {
     fun givenGetContentAsMarkdown(
         markdown: String = ""
     ) = every { instance.getContentAsMarkdown() } returns markdown
+
+    fun givenGetContentAsPlainText(
+        plainText: String = ""
+    ) = every { instance.getContentAsPlainText() } returns plainText
 
     fun givenDummyToExampleFormat() = every { instance.toExampleFormat() } returns ""
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
@@ -26,7 +26,7 @@ internal class EditorViewModelTest {
     private val composer = MockComposer()
     private val htmlConverter = BasicHtmlConverter()
     private val viewModel = EditorViewModel(
-        composer = composer.instance,
+        provideComposer = { composer.instance },
         htmlConverter = htmlConverter,
     )
     private val actionsStatesCallback = mockk<(


### PR DESCRIPTION
## What?

Recover from Rust panics on Android.

When an error is seen,
- replace the composer model with a new instance
- attempt to revert to the last known good state with all formatting removed

This does not affect the behaviour of debug builds, which should continue to crash.

## Why?

Currently, when the Rust model panics, the editor simply hangs and creates a confusing UX.

[`PSU-1112`](https://element-io.atlassian.net/browse/PSU-1112)

