### PR TITLE
Fix crashes from HTML parsing

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_text_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_text_update.rs
@@ -2,6 +2,12 @@ use widestring::Utf16String;
 
 pub enum TextUpdate {
     Keep,
+    PanicRecovery {
+        previous_html: Vec<u16>,
+        start_utf16_codeunit: u32,
+        end_utf16_codeunit: u32,
+        error_message: String,
+    },
     ReplaceAll {
         replacement_html: Vec<u16>,
         start_utf16_codeunit: u32,
@@ -17,6 +23,18 @@ impl TextUpdate {
     pub fn from(inner: wysiwyg::TextUpdate<Utf16String>) -> Self {
         match inner {
             wysiwyg::TextUpdate::Keep => Self::Keep,
+            wysiwyg::TextUpdate::PanicRecovery(panic_recovery) => {
+                let start_utf16_codeunit: usize = panic_recovery.start.into();
+                let end_utf16_codeunit: usize = panic_recovery.end.into();
+                Self::PanicRecovery {
+                    previous_html: panic_recovery.previous_html.into_vec(),
+                    start_utf16_codeunit: u32::try_from(start_utf16_codeunit)
+                        .unwrap(),
+                    end_utf16_codeunit: u32::try_from(end_utf16_codeunit)
+                        .unwrap(),
+                    error_message: panic_recovery.error_message,
+                }
+            }
             wysiwyg::TextUpdate::ReplaceAll(replace_all) => {
                 let start_utf16_codeunit: usize = replace_all.start.into();
                 let end_utf16_codeunit: usize = replace_all.end.into();

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -66,6 +66,12 @@ dictionary ComposerState {
 [Enum]
 interface TextUpdate {
     Keep();
+    PanicRecovery(
+        sequence<u16> previous_html,
+        u32 start_utf16_codeunit,
+        u32 end_utf16_codeunit,
+        string error_message
+    );
     ReplaceAll(
         sequence<u16> replacement_html,
         u32 start_utf16_codeunit,

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -288,6 +288,7 @@ impl ComposerUpdate {
 #[wasm_bindgen(getter_with_clone)]
 pub struct TextUpdate {
     pub keep: Option<Keep>,
+    pub panic_recovery: Option<PanicRecovery>,
     pub replace_all: Option<ReplaceAll>,
     pub select: Option<Selection>,
 }
@@ -297,14 +298,35 @@ impl TextUpdate {
         match inner {
             wysiwyg::TextUpdate::Keep => Self {
                 keep: Some(Keep),
+                panic_recovery: None,
                 replace_all: None,
                 select: None,
             },
+            wysiwyg::TextUpdate::PanicRecovery(p) => {
+                let start_utf16_codeunit: usize = p.start.into();
+                let end_utf16_codeunit: usize = p.end.into();
+                Self {
+                    keep: None,
+                    panic_recovery: Some(PanicRecovery {
+                        replacement_html: p.previous_html.to_string(),
+                        start_utf16_codeunit: u32::try_from(
+                            start_utf16_codeunit,
+                        )
+                        .unwrap(),
+                        end_utf16_codeunit: u32::try_from(end_utf16_codeunit)
+                            .unwrap(),
+                        error_message: p.error_message,
+                    }),
+                    replace_all: None,
+                    select: None,
+                }
+            }
             wysiwyg::TextUpdate::ReplaceAll(r) => {
                 let start_utf16_codeunit: usize = r.start.into();
                 let end_utf16_codeunit: usize = r.end.into();
                 Self {
                     keep: None,
+                    panic_recovery: None,
                     replace_all: Some(ReplaceAll {
                         replacement_html: r.replacement_html.to_string(),
                         start_utf16_codeunit: u32::try_from(
@@ -322,6 +344,7 @@ impl TextUpdate {
                 let end_utf16_codeunit: usize = s.end.into();
                 Self {
                     keep: None,
+                    panic_recovery: None,
                     replace_all: None,
                     select: Some(Selection {
                         start_utf16_codeunit: u32::try_from(
@@ -340,6 +363,15 @@ impl TextUpdate {
 #[derive(Clone)]
 #[wasm_bindgen]
 pub struct Keep;
+
+#[derive(Clone)]
+#[wasm_bindgen(getter_with_clone)]
+pub struct PanicRecovery {
+    pub replacement_html: String,
+    pub start_utf16_codeunit: u32,
+    pub end_utf16_codeunit: u32,
+    pub error_message: String,
+}
 
 #[derive(Clone)]
 #[wasm_bindgen(getter_with_clone)]

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -105,12 +105,11 @@ where
                 self.state.end = self.state.start;
                 self.create_update_replace_all_with_menu_state()
             }
-            Err(e) => {
-                // We should log here - internal task PSU-741
-                self.state.dom = e.dom;
-                self.previous_states.clear();
-                self.next_states.clear();
-                self.create_update_replace_all_with_menu_state()
+            Err(_) => {
+                // Keep the previous version of the dom and create a recovery update.
+                self.create_update_panic_recovery(String::from(
+                    "An error occured during HTML parsing",
+                ))
             }
         }
     }
@@ -185,6 +184,19 @@ where
             self.state.dom.to_html(),
             self.state.start,
             self.state.end,
+            self.compute_menu_state(MenuStateComputeType::AlwaysUpdate),
+        )
+    }
+
+    pub(crate) fn create_update_panic_recovery(
+        &mut self,
+        error_message: String,
+    ) -> ComposerUpdate<S> {
+        ComposerUpdate::panic_recovery(
+            self.state.dom.to_html(),
+            self.state.start,
+            self.state.end,
+            error_message,
             self.compute_menu_state(MenuStateComputeType::AlwaysUpdate),
         )
     }

--- a/crates/wysiwyg/src/composer_update.rs
+++ b/crates/wysiwyg/src/composer_update.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use crate::dom::UnicodeString;
-use crate::{Location, MenuState, ReplaceAll, Selection, TextUpdate};
+use crate::{
+    Location, MenuState, PanicRecovery, ReplaceAll, Selection, TextUpdate,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComposerUpdate<S>
@@ -64,6 +66,24 @@ where
                 replacement_html,
                 start,
                 end,
+            }),
+            menu_state,
+        }
+    }
+
+    pub fn panic_recovery(
+        previous_html: S,
+        start: Location,
+        end: Location,
+        error_message: String,
+        menu_state: MenuState,
+    ) -> Self {
+        Self {
+            text_update: TextUpdate::PanicRecovery(PanicRecovery {
+                previous_html,
+                start,
+                end,
+                error_message,
             }),
             menu_state,
         }

--- a/crates/wysiwyg/src/dom/parser/padom_node.rs
+++ b/crates/wysiwyg/src/dom/parser/padom_node.rs
@@ -18,12 +18,14 @@ use once_cell::sync::OnceCell;
 use super::{paqual_name, PaNodeContainer, PaNodeText};
 
 static TEXT: OnceCell<QualName> = OnceCell::new();
+static ERROR: OnceCell<QualName> = OnceCell::new();
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum PaDomNode {
     Container(PaNodeContainer),
     Document(PaNodeContainer),
     Text(PaNodeText),
+    Error,
 }
 
 impl PaDomNode {
@@ -32,6 +34,7 @@ impl PaDomNode {
             PaDomNode::Container(n) => &n.name,
             PaDomNode::Document(n) => &n.name,
             PaDomNode::Text(_) => q(&TEXT, ""),
+            PaDomNode::Error => q(&ERROR, ""),
         }
     }
 }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -121,6 +121,7 @@ mod sys {
                             self.current_path.contains(&CodeBlock);
                         convert_text(&text.content, node, is_inside_code_block);
                     }
+                    PaDomNode::Error => {}
                 }
             }
         }

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -47,6 +47,7 @@ pub use crate::list_type::ListType;
 pub use crate::location::Location;
 pub use crate::menu_state::MenuState;
 pub use crate::menu_state::MenuStateUpdate;
+pub use crate::text_update::PanicRecovery;
 pub use crate::text_update::ReplaceAll;
 pub use crate::text_update::Selection;
 pub use crate::text_update::TextUpdate;

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -74,9 +74,8 @@ fn backspacing_a_line_break_deletes_it() {
     let update = model.add_line_break();
 
     let replace_all = match update.text_update {
-        TextUpdate::Keep => panic!("expected ReplaceAll"),
         TextUpdate::ReplaceAll(replace_all) => replace_all,
-        TextUpdate::Select(_) => panic!("expected ReplaceAll"),
+        _ => panic!("expected ReplaceAll"),
     };
 
     assert_eq!(replace_all.start, 4);

--- a/crates/wysiwyg/src/tests/test_set_content.rs
+++ b/crates/wysiwyg/src/tests/test_set_content.rs
@@ -33,6 +33,23 @@ fn set_content_from_markdown() {
 }
 
 #[test]
+fn set_content_from_html_failure() {
+    let mut model = ComposerModel::new();
+    let invalid_htmls = vec!["<//code>", "<strong>", "<em", "</p>test"];
+
+    for html in invalid_htmls {
+        let update = model.set_content_from_html(&Utf16String::from(html));
+        match update.text_update {
+            crate::TextUpdate::PanicRecovery(_) => {}
+            _ => {
+                panic!("Panic recovery did not trigger for HTML: \"{}\"", html)
+            }
+        }
+        assert_eq!(tx(&model), "|");
+    }
+}
+
+#[test]
 fn set_content_from_html_moves_cursor_to_the_end() {
     let mut model = cm("abc|");
     model.set_content_from_html(&"content".into());

--- a/crates/wysiwyg/src/text_update.rs
+++ b/crates/wysiwyg/src/text_update.rs
@@ -20,8 +20,20 @@ where
     S: UnicodeString,
 {
     Keep,
+    PanicRecovery(PanicRecovery<S>),
     ReplaceAll(ReplaceAll<S>),
     Select(Selection),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PanicRecovery<S>
+where
+    S: UnicodeString,
+{
+    pub previous_html: S,
+    pub start: Location,
+    pub end: Location,
+    pub error_message: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/platforms/ios/example/Wysiwyg/Views/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/Views/ContentView.swift
@@ -33,6 +33,9 @@ struct ContentView: View {
         Spacer()
             .frame(width: nil, height: 50, alignment: .center)
         Composer(viewModel: viewModel)
+        Button("Crash") {
+            viewModel.setHtmlContent("<//code>")
+        }
         Button("Min/Max") {
             viewModel.maximised.toggle()
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -343,6 +343,12 @@ private extension WysiwygComposerViewModel {
                 textView.apply(attributedContent)
                 updateCompressedHeightIfNeeded()
             }
+        case let .panicRecovery(previousHtml: codeUnits,
+                                startUtf16Codeunit: start,
+                                endUtf16Codeunit: end,
+                                errorMessage: error):
+            Logger.viewModel.error("\(error)")
+            applyReplaceAll(codeUnits: codeUnits, start: start, end: end)
         case let .select(startUtf16Codeunit: start,
                          endUtf16Codeunit: end):
             applySelect(start: start, end: end)


### PR DESCRIPTION
WIP on avoiding crashes during HTML parsing
Creates a new type of ComposerUpdate that is a `PanicRecovery` which returns the previous state for the client to restore content.