### PR TITLE
Hide indent/unindent buttons outside of lists

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_action_state.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_action_state.rs
@@ -3,6 +3,7 @@ pub enum ActionState {
     Enabled,
     Reversed,
     Disabled,
+    Hidden,
 }
 
 impl From<&wysiwyg::ActionState> for ActionState {
@@ -11,6 +12,7 @@ impl From<&wysiwyg::ActionState> for ActionState {
             wysiwyg::ActionState::Enabled => Self::Enabled,
             wysiwyg::ActionState::Reversed => Self::Reversed,
             wysiwyg::ActionState::Disabled => Self::Disabled,
+            wysiwyg::ActionState::Hidden => Self::Hidden,
         }
     }
 }

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -89,14 +89,14 @@ mod test {
     fn redo_indent_unindent_disabled() -> HashMap<ComposerAction, ActionState> {
         HashMap::from([
             (ComposerAction::Bold, ActionState::Enabled),
-            (ComposerAction::Indent, ActionState::Disabled),
+            (ComposerAction::Indent, ActionState::Hidden),
             (ComposerAction::InlineCode, ActionState::Enabled),
             (ComposerAction::Italic, ActionState::Enabled),
             (ComposerAction::Link, ActionState::Enabled),
             (ComposerAction::OrderedList, ActionState::Enabled),
             (ComposerAction::Redo, ActionState::Disabled),
             (ComposerAction::StrikeThrough, ActionState::Enabled),
-            (ComposerAction::Unindent, ActionState::Disabled),
+            (ComposerAction::Unindent, ActionState::Hidden),
             (ComposerAction::Underline, ActionState::Enabled),
             (ComposerAction::Undo, ActionState::Enabled),
             (ComposerAction::UnorderedList, ActionState::Enabled),
@@ -109,14 +109,14 @@ mod test {
     ) -> HashMap<ComposerAction, ActionState> {
         HashMap::from([
             (ComposerAction::Bold, ActionState::Enabled),
-            (ComposerAction::Indent, ActionState::Disabled),
+            (ComposerAction::Indent, ActionState::Hidden),
             (ComposerAction::InlineCode, ActionState::Enabled),
             (ComposerAction::Italic, ActionState::Enabled),
             (ComposerAction::Link, ActionState::Enabled),
             (ComposerAction::OrderedList, ActionState::Enabled),
             (ComposerAction::Redo, ActionState::Disabled),
             (ComposerAction::StrikeThrough, ActionState::Enabled),
-            (ComposerAction::Unindent, ActionState::Disabled),
+            (ComposerAction::Unindent, ActionState::Hidden),
             (ComposerAction::Underline, ActionState::Enabled),
             (ComposerAction::Undo, ActionState::Disabled),
             (ComposerAction::UnorderedList, ActionState::Enabled),

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -98,6 +98,7 @@ enum ActionState {
     "Enabled",
     "Reversed",
     "Disabled",
+    "Hidden",
 };
 
 [Enum]

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -56,6 +56,9 @@ pub enum ActionState {
 
     /// The button cannot be clicked
     Disabled,
+
+    /// The button is hidden
+    Hidden,
 }
 
 trait IntoFfi {

--- a/crates/wysiwyg/src/action_state.rs
+++ b/crates/wysiwyg/src/action_state.rs
@@ -19,4 +19,5 @@ pub enum ActionState {
     Enabled,
     Reversed,
     Disabled,
+    Hidden,
 }

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -147,6 +147,11 @@ where
         self.action_states.get(&action) == Some(&ActionState::Disabled)
     }
 
+    #[cfg(test)]
+    pub(crate) fn action_is_hidden(&self, action: ComposerAction) -> bool {
+        self.action_states.get(&action) == Some(&ActionState::Hidden)
+    }
+
     pub(crate) fn create_update_update_selection(
         &mut self,
     ) -> ComposerUpdate<S> {

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -247,20 +247,21 @@ mod test {
                 Location::from(1),
                 Location::from(1),
                 MenuState::Update(MenuStateUpdate {
-                    action_states: indent_unindent_redo_disabled()
+                    action_states: indent_unindent_hidden_redo_disabled()
                 }),
             )
         );
     }
 
-    fn indent_unindent_redo_disabled() -> HashMap<ComposerAction, ActionState> {
+    fn indent_unindent_hidden_redo_disabled(
+    ) -> HashMap<ComposerAction, ActionState> {
         let actions = ComposerAction::iter().map(|action| {
             if matches!(
                 action,
-                ComposerAction::Redo
-                    | ComposerAction::Indent
-                    | ComposerAction::Unindent
+                ComposerAction::Indent | ComposerAction::Unindent
             ) {
+                (action, ActionState::Hidden)
+            } else if action == ComposerAction::Redo {
                 (action, ActionState::Disabled)
             } else {
                 (action, ActionState::Enabled)

--- a/crates/wysiwyg/src/tests/test_menu_state.rs
+++ b/crates/wysiwyg/src/tests/test_menu_state.rs
@@ -86,15 +86,15 @@ fn updating_model_updates_disabled_actions() {
     assert!(model.action_is_enabled(ComposerAction::UnorderedList));
     assert!(model.action_is_disabled(ComposerAction::Undo));
     assert!(model.action_is_disabled(ComposerAction::Redo));
-    assert!(model.action_is_disabled(ComposerAction::Indent));
-    assert!(model.action_is_disabled(ComposerAction::Unindent));
+    assert!(model.action_is_hidden(ComposerAction::Indent));
+    assert!(model.action_is_hidden(ComposerAction::Unindent));
 
     replace_text(&mut model, "a");
     model.select(Location::from(0), Location::from(1));
     model.bold();
     assert!(model.action_is_disabled(ComposerAction::Redo));
-    assert!(model.action_is_disabled(ComposerAction::Indent));
-    assert!(model.action_is_disabled(ComposerAction::Unindent));
+    assert!(model.action_is_hidden(ComposerAction::Indent));
+    assert!(model.action_is_hidden(ComposerAction::Unindent));
     assert!(model.action_is_enabled(ComposerAction::StrikeThrough));
 
     model.undo();
@@ -287,6 +287,19 @@ fn empty_paragraph_with_formatting_computes_expected_menu_state() {
 fn empty_list_item_with_formatting_computes_expected_menu_state() {
     let model = cm("<ol><li><em>abc</em></li><li><em>|</em></li></ol>");
     assert!(model.action_is_reversed(ComposerAction::Italic));
+}
+
+#[test]
+fn indent_unindent_is_hidden_outside_of_list() {
+    let mut model = cm("abc|");
+    assert!(model.action_is_hidden(ComposerAction::Indent));
+    assert!(model.action_is_hidden(ComposerAction::Unindent));
+    model.ordered_list();
+    assert!(model.action_is_disabled(ComposerAction::Indent));
+    assert!(model.action_is_disabled(ComposerAction::Unindent));
+    model.enter();
+    assert!(model.action_is_enabled(ComposerAction::Indent));
+    assert!(model.action_is_disabled(ComposerAction::Unindent));
 }
 
 fn assert_formatting_actions_and_links_are_disabled(

--- a/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
+++ b/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
@@ -132,6 +132,7 @@ class RichTextEditor : LinearLayout {
         actionStates: Map<ComposerAction, ActionState>
     ) {
         val state = actionStates[action]
+        button.isVisible = state != ActionState.HIDDEN
         button.isEnabled = state != ActionState.DISABLED
         button.isActivated = state == ActionState.REVERSED
     }

--- a/platforms/ios/example/Wysiwyg/Extensions/WysiwygAction+Utils.swift
+++ b/platforms/ios/example/Wysiwyg/Extensions/WysiwygAction+Utils.swift
@@ -50,6 +50,14 @@ extension WysiwygAction: CaseIterable, Identifiable {
         viewModel.actionStates[composerAction] == ActionState.disabled
     }
 
+    /// Compute hidden status for action.
+    ///
+    /// - Parameter viewModel: Composer's view model.
+    /// - Returns: True if the action is hidden, false otherwise.
+    public func isHidden(_ viewModel: WysiwygComposerViewModel) -> Bool {
+        viewModel.actionStates[composerAction] == ActionState.hidden
+    }
+
     var accessibilityIdentifier: WysiwygSharedAccessibilityIdentifier {
         switch self {
         case .bold:

--- a/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
+++ b/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
@@ -26,7 +26,7 @@ struct WysiwygActionToolbar: View {
     
     var body: some View {
         HStack {
-            ForEach(WysiwygAction.allCases) { action in
+            ForEach(WysiwygAction.allCases.filter { !$0.isHidden(viewModel) }) { action in
                 Button {
                     if action == .link {
                         linkAttributedRange = viewModel.attributedContent.selection


### PR DESCRIPTION
* Adds a new `ActionState` to specify some action that should be hidden rather than just disabled.
* Indent/Unindent are now hidden outside of lists
* When lists are selected or partially selected, the buttons are visible but still rely on `can_indent` / `can_unindent` to be enabled