### PR TITLE
[iOS] Remove force tries in binding code and adapt the overall code to throwing functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,10 @@ ios: setup
 	  -headers ${IOS_GENERATION_DIR}/headers \
 	  -library ../../target/ios-simulator/libuniffi_wysiwyg_composer.a \
 	  -headers ${IOS_GENERATION_DIR}/headers \
-	  -output ${IOS_PACKAGE_DIR}/WysiwygComposerFFI.xcframework
+	  -output ${IOS_PACKAGE_DIR}/WysiwygComposerFFI.xcframework && \
+	sed -i "" -e '1h;2,$$H;$$!d;g' -e 's/) -> ComposerUpdate {\n        return try! FfiConverterTypeComposerUpdate.lift(\n            try!/) throws -> ComposerUpdate {\n        return try FfiConverterTypeComposerUpdate.lift(\n            try/g' ${IOS_PACKAGE_DIR}/Sources/WysiwygComposer/WysiwygComposer.swift && \
+	sed -i "" -e '1h;2,$$H;$$!d;g' -e 's/) -> ComposerUpdate/) throws -> ComposerUpdate/g' ${IOS_PACKAGE_DIR}/Sources/WysiwygComposer/WysiwygComposer.swift
+
 web: setup
 	cd bindings/wysiwyg-wasm && \
 	npm install && \

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ ios: setup
 	  -output ${IOS_PACKAGE_DIR}/WysiwygComposerFFI.xcframework && \
 	sed -i "" -e '1h;2,$$H;$$!d;g' -e 's/) -> ComposerUpdate {\n        return try! FfiConverterTypeComposerUpdate.lift(\n            try!/) throws -> ComposerUpdate {\n        return try FfiConverterTypeComposerUpdate.lift(\n            try/g' ${IOS_PACKAGE_DIR}/Sources/WysiwygComposer/WysiwygComposer.swift && \
 	sed -i "" -e '1h;2,$$H;$$!d;g' -e 's/) -> ComposerUpdate/) throws -> ComposerUpdate/g' ${IOS_PACKAGE_DIR}/Sources/WysiwygComposer/WysiwygComposer.swift
+# Note: we use sed to tweak the generated Swift bindings and catch Rust panics, 
+# this should be removed when the Rust code is 100% safe (see `ComposerModelWrapper.swift`).
 
 web: setup
 	cd bindings/wysiwyg-wasm && \

--- a/platforms/ios/example/Shared/View+Accessibility.swift
+++ b/platforms/ios/example/Shared/View+Accessibility.swift
@@ -45,6 +45,7 @@ public enum WysiwygSharedAccessibilityIdentifier: String {
     case linkTextTextField = "WysiwygLinkTextTextField"
     case showTreeButton = "WysiwygShowTreeButton"
     case treeText = "WysiwygTreeText"
+    case forceCrashButton = "WysiwygForceCrashButton"
 }
 
 public extension View {

--- a/platforms/ios/example/Wysiwyg/Views/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/Views/ContentView.swift
@@ -33,6 +33,10 @@ struct ContentView: View {
         Spacer()
             .frame(width: nil, height: 50, alignment: .center)
         Composer(viewModel: viewModel)
+        Button("Force crash") {
+            viewModel.setHtmlContent("</strong>")
+        }
+        .accessibilityIdentifier(.forceCrashButton)
         Button("Min/Max") {
             viewModel.maximised.toggle()
         }

--- a/platforms/ios/example/Wysiwyg/Views/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/Views/ContentView.swift
@@ -34,7 +34,7 @@ struct ContentView: View {
             .frame(width: nil, height: 50, alignment: .center)
         Composer(viewModel: viewModel)
         Button("Force crash") {
-            viewModel.setHtmlContent("</strong>")
+            viewModel.setHtmlContent("<//strong>")
         }
         .accessibilityIdentifier(.forceCrashButton)
         Button("Min/Max") {

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -40,15 +40,23 @@ class WysiwygUITests: XCTestCase {
 
     func testCrashRecovery() throws {
         button(.boldButton).tap()
-        textView.typeTextCharByChar("Some text")
+        textView.typeTextCharByChar("Some ")
+        button(.italicButton).tap()
+        textView.typeTextCharByChar("text")
         assertTreeEquals(
             """
             └>strong
-              └>"Some text"
+              ├>"Some "
+              └>em
+                └>"text"
             """
         )
         button(.forceCrashButton).tap()
-        // TODO: assert plain text tree
+        assertTreeEquals(
+            """
+            └>"Some text"
+            """
+        )
     }
 }
 

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -37,6 +37,19 @@ class WysiwygUITests: XCTestCase {
         sleep(1)
         XCTAssertEqual(textView.frame.height, WysiwygSharedConstants.composerMinHeight)
     }
+
+    func testCrashRecovery() throws {
+        button(.boldButton).tap()
+        textView.typeTextCharByChar("Some text")
+        assertTreeEquals(
+            """
+            └>strong
+              └>"Some text"
+            """
+        )
+        button(.forceCrashButton).tap()
+        // TODO: assert plain text tree
+    }
 }
 
 internal extension WysiwygUITests {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
@@ -1,0 +1,155 @@
+//
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+protocol ComposerModelWrapperProtocol {
+    func setContentFromHtml(html: String) -> ComposerUpdate
+    func setContentFromMarkdown(markdown: String) -> ComposerUpdate
+    func getContentAsHtml() -> String
+    func getContentAsMarkdown() -> String
+    func clear() -> ComposerUpdate
+    func select(startUtf16Codeunit: UInt32, endUtf16Codeunit: UInt32) -> ComposerUpdate
+    func replaceText(newText: String) -> ComposerUpdate
+    func replaceTextIn(newText: String, start: UInt32, end: UInt32) -> ComposerUpdate
+    func backspace() -> ComposerUpdate
+    func enter() -> ComposerUpdate
+    func apply(_ action: WysiwygAction) -> ComposerUpdate
+    func setLink(link: String) -> ComposerUpdate
+    func setLinkWithText(link: String, text: String) -> ComposerUpdate
+    func removeLinks() -> ComposerUpdate
+    func toTree() -> String
+    func getCurrentDomState() -> ComposerState
+    func actionStates() -> [ComposerAction: ActionState]
+    func getLinkAction() -> LinkAction
+}
+
+/// Provides a wrapper around `ComposerModel` that handles failures and reset to
+/// a fallback content if needed.
+final class ComposerModelWrapper: ComposerModelWrapperProtocol {
+    // MARK: - Private
+
+    private var model = newComposerModel()
+    private var fallbackContent: (() -> String)?
+
+    // MARK: - Internal
+
+    init(fallbackContent: (() -> String)? = nil) {
+        self.fallbackContent = fallbackContent
+    }
+
+    func setContentFromHtml(html: String) -> ComposerUpdate {
+        execute { try $0.setContentFromHtml(html: html) }
+    }
+
+    func setContentFromMarkdown(markdown: String) -> ComposerUpdate {
+        execute { try $0.setContentFromMarkdown(markdown: markdown) }
+    }
+
+    func getContentAsHtml() -> String {
+        model.getContentAsHtml()
+    }
+
+    func getContentAsMarkdown() -> String {
+        model.getContentAsMarkdown()
+    }
+
+    func clear() -> ComposerUpdate {
+        execute { try $0.clear() }
+    }
+
+    func select(startUtf16Codeunit: UInt32, endUtf16Codeunit: UInt32) -> ComposerUpdate {
+        execute { try $0.select(startUtf16Codeunit: startUtf16Codeunit, endUtf16Codeunit: endUtf16Codeunit) }
+    }
+
+    func replaceText(newText: String) -> ComposerUpdate {
+        execute { try $0.replaceText(newText: newText) }
+    }
+
+    func replaceTextIn(newText: String, start: UInt32, end: UInt32) -> ComposerUpdate {
+        execute { try $0.replaceTextIn(newText: newText, start: start, end: end) }
+    }
+
+    func backspace() -> ComposerUpdate {
+        execute { try $0.backspace() }
+    }
+
+    func enter() -> ComposerUpdate {
+        execute { try $0.enter() }
+    }
+
+    func apply(_ action: WysiwygAction) -> ComposerUpdate {
+        execute { try $0.apply(action) }
+    }
+
+    func setLink(link: String) -> ComposerUpdate {
+        execute { try $0.setLink(link: link) }
+    }
+
+    func setLinkWithText(link: String, text: String) -> ComposerUpdate {
+        execute { try $0.setLinkWithText(link: link, text: text) }
+    }
+
+    func removeLinks() -> ComposerUpdate {
+        execute { try $0.removeLinks() }
+    }
+
+    func toTree() -> String {
+        model.toTree()
+    }
+
+    func getCurrentDomState() -> ComposerState {
+        model.getCurrentDomState()
+    }
+
+    func actionStates() -> [ComposerAction: ActionState] {
+        model.actionStates()
+    }
+
+    func getLinkAction() -> LinkAction {
+        model.getLinkAction()
+    }
+}
+
+// MARK: - Private
+
+private extension ComposerModelWrapper {
+    /// Execute some failable action on the model and restore provided fallback content if needed.
+    func execute(_ action: @escaping (ComposerModel) throws -> ComposerUpdate) -> ComposerUpdate {
+        do {
+            let update = try action(model)
+            return update
+        } catch {
+            model = newComposerModel()
+            if let fallbackContent {
+                do {
+                    let update = try model.replaceText(newText: fallbackContent())
+                    return update
+                } catch {
+                    // If setting the fallback content fails, just reset to empty.
+                    model = newComposerModel()
+                    // Provide an empty update
+                    // swiftlint:disable:next force_try
+                    return try! model.clear()
+                }
+            } else {
+                // Provide an empty update
+                // swiftlint:disable:next force_try
+                return try! model.clear()
+            }
+        }
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
@@ -44,7 +44,10 @@ protocol ComposerModelWrapperDelegate: AnyObject {
 }
 
 /// Provides a wrapper around `ComposerModel` that handles failures and reset to
-/// a fallback content if needed.
+/// a fallback content if needed. This wrapper exists because we are currently tweaking
+/// the generated bindings to be able to catch Rust panics on the Swift side (see `make ios`).
+/// If the bindings are restored to their standard state, this class can be removed and occurences
+/// of `ComposerModelWrapper()` just needs to be replaced with `newComposerModel()`.
 final class ComposerModelWrapper: ComposerModelWrapperProtocol {
     // MARK: - Private
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerContent.swift
@@ -45,6 +45,8 @@ public struct WysiwygComposerAttributedContent {
     public let text: NSAttributedString
     /// Range of the selected text within the attributed representation.
     public var selection: NSRange
+    /// Plain text variant of the content saved for recovery.
+    public let plainText: String
 
     // MARK: - Internal
 
@@ -53,9 +55,12 @@ public struct WysiwygComposerAttributedContent {
     /// - Parameters:
     ///   - text: Attributed string representation of the displayed text.
     ///   - selection: Range of the selected text within the attributed representation.
+    ///   - plainText: Plain text variant of the content saved for recovery.
     init(text: NSAttributedString = .init(string: ""),
-         selection: NSRange = .zero) {
+         selection: NSRange = .zero,
+         plainText: String = "") {
         self.text = text
         self.selection = selection
+        self.plainText = plainText
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/ComposerModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/ComposerModel.swift
@@ -20,35 +20,35 @@ extension ComposerModel {
     ///
     /// - Parameters:
     ///   - action: Action to apply.
-    func apply(_ action: WysiwygAction) -> ComposerUpdateProtocol? {
+    func apply(_ action: WysiwygAction) throws -> ComposerUpdateProtocol? {
         let update: ComposerUpdateProtocol
         switch action {
         case .bold:
-            update = bold()
+            update = try bold()
         case .italic:
-            update = italic()
+            update = try italic()
         case .strikeThrough:
-            update = strikeThrough()
+            update = try strikeThrough()
         case .underline:
-            update = underline()
+            update = try underline()
         case .inlineCode:
-            update = inlineCode()
+            update = try inlineCode()
         case .undo:
-            update = undo()
+            update = try undo()
         case .redo:
-            update = redo()
+            update = try redo()
         case .orderedList:
-            update = orderedList()
+            update = try orderedList()
         case .unorderedList:
-            update = unorderedList()
+            update = try unorderedList()
         case .indent:
-            update = indent()
+            update = try indent()
         case .unindent:
-            update = unindent()
+            update = try unindent()
         case .codeBlock:
-            update = codeBlock()
+            update = try codeBlock()
         case .quote:
-            update = quote()
+            update = try quote()
         default:
             return nil
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/ComposerModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/ComposerModel.swift
@@ -20,8 +20,8 @@ extension ComposerModel {
     ///
     /// - Parameters:
     ///   - action: Action to apply.
-    func apply(_ action: WysiwygAction) throws -> ComposerUpdateProtocol? {
-        let update: ComposerUpdateProtocol
+    func apply(_ action: WysiwygAction) throws -> ComposerUpdate {
+        let update: ComposerUpdate
         switch action {
         case .bold:
             update = try bold()
@@ -49,8 +49,8 @@ extension ComposerModel {
             update = try codeBlock()
         case .quote:
             update = try quote()
-        default:
-            return nil
+        case .link:
+            fatalError()
         }
 
         return update

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerSnapshotTests/SnapshotTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerSnapshotTests/SnapshotTests.swift
@@ -35,6 +35,7 @@ class SnapshotTests: XCTestCase {
     
     override func tearDownWithError() throws {
         try super.tearDownWithError()
+        viewModel.clearContent()
         hostingController = nil
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerSnapshotTests/SnapshotTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerSnapshotTests/SnapshotTests.swift
@@ -22,12 +22,11 @@ import XCTest
 class SnapshotTests: XCTestCase {
     let isRecord = false
     
-    var viewModel: WysiwygComposerViewModel!
+    var viewModel = WysiwygComposerViewModel()
     var hostingController: UIViewController!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        viewModel = WysiwygComposerViewModel()
         let binding: Binding<Bool> = .init(get: { true }, set: { _ in })
         let composerView = WysiwygComposerView(focused: binding, viewModel: viewModel)
             .placeholder("Placeholder")
@@ -37,6 +36,5 @@ class SnapshotTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         hostingController = nil
-        viewModel = nil
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -150,9 +150,8 @@ final class WysiwygComposerViewModelTests: XCTestCase {
     func testCrashRecoveryUsesLatestPlainText() {
         viewModel.setHtmlContent("<strong>Some <em>text</em></strong>")
         // Force a crash
-        viewModel.setHtmlContent("</strong>")
-        // TODO: replace with plain text when implemented
-        XCTAssertEqual(viewModel.content.html, "")
+        viewModel.setHtmlContent("<//strong>")
+        XCTAssertEqual(viewModel.content.html, "Some text")
     }
 }
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -146,6 +146,14 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         XCTAssertTrue(result)
         XCTAssertEqual(viewModel.content.html, "<a href=\"https://element.io\">teabcst</a>")
     }
+
+    func testCrashRecoveryUsesLatestPlainText() {
+        viewModel.setHtmlContent("<strong>Some <em>text</em></strong>")
+        // Force a crash
+        viewModel.setHtmlContent("</strong>")
+        // TODO: replace with plain text when implemented
+        XCTAssertEqual(viewModel.content.html, "")
+    }
 }
 
 private extension WysiwygComposerViewModelTests {

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/ComposerModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/ComposerModel.swift
@@ -24,8 +24,12 @@ extension ComposerModel {
     ///   - action: composer action to execute
     /// - Returns: self (discardable)
     @discardableResult
-    func action(_ action: @escaping (ComposerModel) -> ComposerUpdate) -> ComposerModel {
-        _ = action(self)
+    func action(_ action: @escaping (ComposerModel) throws -> ComposerUpdate) -> ComposerModel {
+        do {
+            _ = try action(self)
+        } catch {
+            XCTFail("Rust panic: \(error.localizedDescription)")
+        }
         return self
     }
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/ComposerModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Extensions/ComposerModel.swift
@@ -14,22 +14,18 @@
 // limitations under the License.
 //
 
-import WysiwygComposer
+@testable import WysiwygComposer
 import XCTest
 
-extension ComposerModel {
+extension ComposerModelWrapper {
     /// Execute given action that returns a `ComposerUpdate` on self.
     ///
     /// - Parameters:
     ///   - action: composer action to execute
     /// - Returns: self (discardable)
     @discardableResult
-    func action(_ action: @escaping (ComposerModel) throws -> ComposerUpdate) -> ComposerModel {
-        do {
-            _ = try action(self)
-        } catch {
-            XCTFail("Rust panic: \(error.localizedDescription)")
-        }
+    func action(_ action: @escaping (ComposerModelWrapper) -> ComposerUpdate) -> ComposerModelWrapper {
+        _ = action(self)
         return self
     }
 
@@ -39,7 +35,7 @@ extension ComposerModel {
     ///   - block: code to execute
     /// - Returns: self (discardable)
     @discardableResult
-    func execute(_ block: @escaping (ComposerModel) -> Void) -> ComposerModel {
+    func execute(_ block: @escaping (ComposerModelWrapper) -> Void) -> ComposerModelWrapper {
         block(self)
         return self
     }
@@ -50,7 +46,7 @@ extension ComposerModel {
     ///   - html: html string to test
     /// - Returns: self (discardable)
     @discardableResult
-    func assertHtml(_ html: String) -> ComposerModel {
+    func assertHtml(_ html: String) -> ComposerModelWrapper {
         XCTAssertEqual(getContentAsHtml(), html)
         return self
     }
@@ -61,7 +57,7 @@ extension ComposerModel {
     ///   - tree: tree string to test
     /// - Returns: self (discardable)
     @discardableResult
-    func assertTree(_ tree: String) -> ComposerModel {
+    func assertTree(_ tree: String) -> ComposerModelWrapper {
         XCTAssertEqual(toTree(), tree)
         return self
     }
@@ -73,7 +69,7 @@ extension ComposerModel {
     ///   - end: selection end (UTF16 code units)
     /// - Returns: self (discardable)
     @discardableResult
-    func assertSelection(start: UInt32, end: UInt32) -> ComposerModel {
+    func assertSelection(start: UInt32, end: UInt32) -> ComposerModelWrapper {
         let state = getCurrentDomState()
         XCTAssertEqual(state.start, start)
         XCTAssertEqual(state.end, end)
@@ -86,7 +82,7 @@ extension ComposerModel {
     ///   - linkAction: expected link action
     /// - Returns: self (discardable)
     @discardableResult
-    func assertLinkAction(_ linkAction: LinkAction) -> ComposerModel {
+    func assertLinkAction(_ linkAction: LinkAction) -> ComposerModelWrapper {
         XCTAssertEqual(getLinkAction(), linkAction)
         return self
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
@@ -35,36 +35,36 @@ private enum Constants {
 extension WysiwygComposerTests {
     func testCodeBlocksFromEmptyComposer() {
         newComposerModel()
-            .action { $0.codeBlock() }
-            .action { $0.replaceText(newText: "Some code") }
-            .action { $0.enter() }
-            .action { $0.replaceText(newText: "\t") }
-            .action { $0.replaceText(newText: "more code") }
-            .action { $0.enter() }
-            .action { $0.enter() }
+            .action { try $0.codeBlock() }
+            .action { try $0.replaceText(newText: "Some code") }
+            .action { try $0.enter() }
+            .action { try $0.replaceText(newText: "\t") }
+            .action { try $0.replaceText(newText: "more code") }
+            .action { try $0.enter() }
+            .action { try $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }
 
     func testCodeBlocksWithMultilineInput() {
         newComposerModel()
-            .action { $0.codeBlock() }
-            .action { $0.replaceText(newText: "Some code\n\tmore code") }
-            .action { $0.enter() }
-            .action { $0.enter() }
+            .action { try $0.codeBlock() }
+            .action { try $0.replaceText(newText: "Some code\n\tmore code") }
+            .action { try $0.enter() }
+            .action { try $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }
 
     func testCodeBlocksFromContent() {
         newComposerModel()
-            .action { $0.replaceText(newText: "Some code") }
-            .action { $0.codeBlock() }
-            .action { $0.enter() }
-            .action { $0.replaceText(newText: "\t") }
-            .action { $0.replaceText(newText: "more code") }
-            .action { $0.enter() }
-            .action { $0.enter() }
+            .action { try $0.replaceText(newText: "Some code") }
+            .action { try $0.codeBlock() }
+            .action { try $0.enter() }
+            .action { try $0.replaceText(newText: "\t") }
+            .action { try $0.replaceText(newText: "more code") }
+            .action { try $0.enter() }
+            .action { try $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+CodeBlocks.swift
@@ -34,37 +34,37 @@ private enum Constants {
 
 extension WysiwygComposerTests {
     func testCodeBlocksFromEmptyComposer() {
-        newComposerModel()
-            .action { try $0.codeBlock() }
-            .action { try $0.replaceText(newText: "Some code") }
-            .action { try $0.enter() }
-            .action { try $0.replaceText(newText: "\t") }
-            .action { try $0.replaceText(newText: "more code") }
-            .action { try $0.enter() }
-            .action { try $0.enter() }
+        ComposerModelWrapper()
+            .action { $0.apply(.codeBlock) }
+            .action { $0.replaceText(newText: "Some code") }
+            .action { $0.enter() }
+            .action { $0.replaceText(newText: "\t") }
+            .action { $0.replaceText(newText: "more code") }
+            .action { $0.enter() }
+            .action { $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }
 
     func testCodeBlocksWithMultilineInput() {
-        newComposerModel()
-            .action { try $0.codeBlock() }
-            .action { try $0.replaceText(newText: "Some code\n\tmore code") }
-            .action { try $0.enter() }
-            .action { try $0.enter() }
+        ComposerModelWrapper()
+            .action { $0.apply(.codeBlock) }
+            .action { $0.replaceText(newText: "Some code\n\tmore code") }
+            .action { $0.enter() }
+            .action { $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }
 
     func testCodeBlocksFromContent() {
-        newComposerModel()
-            .action { try $0.replaceText(newText: "Some code") }
-            .action { try $0.codeBlock() }
-            .action { try $0.enter() }
-            .action { try $0.replaceText(newText: "\t") }
-            .action { try $0.replaceText(newText: "more code") }
-            .action { try $0.enter() }
-            .action { try $0.enter() }
+        ComposerModelWrapper()
+            .action { $0.replaceText(newText: "Some code") }
+            .action { $0.apply(.codeBlock) }
+            .action { $0.enter() }
+            .action { $0.replaceText(newText: "\t") }
+            .action { $0.replaceText(newText: "more code") }
+            .action { $0.enter() }
+            .action { $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Emoji.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Emoji.swift
@@ -19,8 +19,8 @@ import XCTest
 
 extension WysiwygComposerTests {
     func testSetBaseStringWithEmoji() {
-        newComposerModel()
-            .action { try $0.replaceText(newText: TestConstants.testStringWithEmojis) }
+        ComposerModelWrapper()
+            .action { $0.replaceText(newText: TestConstants.testStringWithEmojis) }
             // Text is preserved, including emojis.
             .assertHtml(TestConstants.testStringWithEmojis)
             // Selection is set at the end of the text.
@@ -28,10 +28,10 @@ extension WysiwygComposerTests {
     }
 
     func testBackspacingEmoji() {
-        newComposerModel()
-            .action { try $0.replaceText(newText: TestConstants.testStringWithEmojis) }
-            .action { try $0.select(startUtf16Codeunit: 7, endUtf16Codeunit: 14) }
-            .action { try $0.backspace() }
+        ComposerModelWrapper()
+            .action { $0.replaceText(newText: TestConstants.testStringWithEmojis) }
+            .action { $0.select(startUtf16Codeunit: 7, endUtf16Codeunit: 14) }
+            .action { $0.backspace() }
             // Text should remove exactly the last emoji.
             .assertHtml(TestConstants.testStringAfterBackspace)
             .assertSelection(start: 7, end: 7)

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Emoji.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Emoji.swift
@@ -20,7 +20,7 @@ import XCTest
 extension WysiwygComposerTests {
     func testSetBaseStringWithEmoji() {
         newComposerModel()
-            .action { $0.replaceText(newText: TestConstants.testStringWithEmojis) }
+            .action { try $0.replaceText(newText: TestConstants.testStringWithEmojis) }
             // Text is preserved, including emojis.
             .assertHtml(TestConstants.testStringWithEmojis)
             // Selection is set at the end of the text.
@@ -29,9 +29,9 @@ extension WysiwygComposerTests {
 
     func testBackspacingEmoji() {
         newComposerModel()
-            .action { $0.replaceText(newText: TestConstants.testStringWithEmojis) }
-            .action { $0.select(startUtf16Codeunit: 7, endUtf16Codeunit: 14) }
-            .action { $0.backspace() }
+            .action { try $0.replaceText(newText: TestConstants.testStringWithEmojis) }
+            .action { try $0.select(startUtf16Codeunit: 7, endUtf16Codeunit: 14) }
+            .action { try $0.backspace() }
             // Text should remove exactly the last emoji.
             .assertHtml(TestConstants.testStringAfterBackspace)
             .assertSelection(start: 7, end: 7)

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Format.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Format.swift
@@ -20,10 +20,10 @@ import XCTest
 
 extension WysiwygComposerTests {
     func testFormatBold() throws {
-        newComposerModel()
-            .action { try $0.replaceText(newText: "This is bold text") }
-            .action { try $0.select(startUtf16Codeunit: 8, endUtf16Codeunit: 12) }
-            .action { try $0.bold() }
+        ComposerModelWrapper()
+            .action { $0.replaceText(newText: "This is bold text") }
+            .action { $0.select(startUtf16Codeunit: 8, endUtf16Codeunit: 12) }
+            .action { $0.apply(.bold) }
             .assertHtml("This is <strong>bold</strong> text")
             // Selection is kept after format.
             .assertSelection(start: 8, end: 12)

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Format.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Format.swift
@@ -21,9 +21,9 @@ import XCTest
 extension WysiwygComposerTests {
     func testFormatBold() throws {
         newComposerModel()
-            .action { $0.replaceText(newText: "This is bold text") }
-            .action { $0.select(startUtf16Codeunit: 8, endUtf16Codeunit: 12) }
-            .action { $0.bold() }
+            .action { try $0.replaceText(newText: "This is bold text") }
+            .action { try $0.select(startUtf16Codeunit: 8, endUtf16Codeunit: 12) }
+            .action { try $0.bold() }
             .assertHtml("This is <strong>bold</strong> text")
             // Selection is kept after format.
             .assertSelection(start: 8, end: 12)

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Indent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Indent.swift
@@ -30,31 +30,31 @@ private enum Constants {
 
 extension WysiwygComposerTests {
     func testIndent() {
-        newComposerModel()
-            .action { try $0.setContentFromHtml(html: Constants.sampleListHtml) }
+        ComposerModelWrapper()
+            .action { $0.setContentFromHtml(html: Constants.sampleListHtml) }
             // Select somewhere on item 2
-            .action { try $0.select(startUtf16Codeunit: 9, endUtf16Codeunit: 9) }
-            .action { try $0.indent() }
+            .action { $0.select(startUtf16Codeunit: 9, endUtf16Codeunit: 9) }
+            .action { $0.apply(.indent) }
             .execute { XCTAssertTrue($0.actionStates()[.indent] == .disabled) }
             // Select somewhere on item 3
-            .action { try $0.select(startUtf16Codeunit: 18, endUtf16Codeunit: 18) }
-            .action { try $0.indent() }
-            .action { try $0.indent() }
+            .action { $0.select(startUtf16Codeunit: 18, endUtf16Codeunit: 18) }
+            .action { $0.apply(.indent) }
+            .action { $0.apply(.indent) }
             .execute { XCTAssertTrue($0.actionStates()[.indent] == .disabled) }
             .assertHtml(Constants.indentedSampleListHtml)
     }
 
     func testUnindent() {
-        newComposerModel()
-            .action { try $0.setContentFromHtml(html: Constants.indentedSampleListHtml) }
+        ComposerModelWrapper()
+            .action { $0.setContentFromHtml(html: Constants.indentedSampleListHtml) }
             // Select somewhere on item 3
-            .action { try $0.select(startUtf16Codeunit: 18, endUtf16Codeunit: 18) }
-            .action { try $0.unindent() }
-            .action { try $0.unindent() }
+            .action { $0.select(startUtf16Codeunit: 18, endUtf16Codeunit: 18) }
+            .action { $0.apply(.unindent) }
+            .action { $0.apply(.unindent) }
             .execute { XCTAssertTrue($0.actionStates()[.unindent] == .disabled) }
             // Select somewhere on item 2
-            .action { try $0.select(startUtf16Codeunit: 9, endUtf16Codeunit: 9) }
-            .action { try $0.unindent() }
+            .action { $0.select(startUtf16Codeunit: 9, endUtf16Codeunit: 9) }
+            .action { $0.apply(.unindent) }
             .execute { XCTAssertTrue($0.actionStates()[.unindent] == .disabled) }
             .assertHtml(Constants.sampleListHtml)
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Indent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Indent.swift
@@ -31,30 +31,30 @@ private enum Constants {
 extension WysiwygComposerTests {
     func testIndent() {
         newComposerModel()
-            .action { $0.setContentFromHtml(html: Constants.sampleListHtml) }
+            .action { try $0.setContentFromHtml(html: Constants.sampleListHtml) }
             // Select somewhere on item 2
-            .action { $0.select(startUtf16Codeunit: 9, endUtf16Codeunit: 9) }
-            .action { $0.indent() }
+            .action { try $0.select(startUtf16Codeunit: 9, endUtf16Codeunit: 9) }
+            .action { try $0.indent() }
             .execute { XCTAssertTrue($0.actionStates()[.indent] == .disabled) }
             // Select somewhere on item 3
-            .action { $0.select(startUtf16Codeunit: 18, endUtf16Codeunit: 18) }
-            .action { $0.indent() }
-            .action { $0.indent() }
+            .action { try $0.select(startUtf16Codeunit: 18, endUtf16Codeunit: 18) }
+            .action { try $0.indent() }
+            .action { try $0.indent() }
             .execute { XCTAssertTrue($0.actionStates()[.indent] == .disabled) }
             .assertHtml(Constants.indentedSampleListHtml)
     }
 
     func testUnindent() {
         newComposerModel()
-            .action { $0.setContentFromHtml(html: Constants.indentedSampleListHtml) }
+            .action { try $0.setContentFromHtml(html: Constants.indentedSampleListHtml) }
             // Select somewhere on item 3
-            .action { $0.select(startUtf16Codeunit: 18, endUtf16Codeunit: 18) }
-            .action { $0.unindent() }
-            .action { $0.unindent() }
+            .action { try $0.select(startUtf16Codeunit: 18, endUtf16Codeunit: 18) }
+            .action { try $0.unindent() }
+            .action { try $0.unindent() }
             .execute { XCTAssertTrue($0.actionStates()[.unindent] == .disabled) }
             // Select somewhere on item 2
-            .action { $0.select(startUtf16Codeunit: 9, endUtf16Codeunit: 9) }
-            .action { $0.unindent() }
+            .action { try $0.select(startUtf16Codeunit: 9, endUtf16Codeunit: 9) }
+            .action { try $0.unindent() }
             .execute { XCTAssertTrue($0.actionStates()[.unindent] == .disabled) }
             .assertHtml(Constants.sampleListHtml)
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+InlineCode.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+InlineCode.swift
@@ -19,9 +19,9 @@ import XCTest
 
 extension WysiwygComposerTests {
     func testInlineCode() {
-        newComposerModel()
-            .action { try $0.inlineCode() }
-            .action { try $0.replaceText(newText: "code") }
+        ComposerModelWrapper()
+            .action { $0.apply(.inlineCode) }
+            .action { $0.replaceText(newText: "code") }
             .assertTree(
                 """
 
@@ -33,13 +33,13 @@ extension WysiwygComposerTests {
     }
 
     func testInlineCodeWithFormatting() {
-        newComposerModel()
-            .action { try $0.bold() }
-            .action { try $0.replaceText(newText: "bold") }
+        ComposerModelWrapper()
+            .action { $0.apply(.bold) }
+            .action { $0.replaceText(newText: "bold") }
             // This should get ignored
-            .action { try $0.italic() }
-            .action { try $0.inlineCode() }
-            .action { try $0.replaceText(newText: "code") }
+            .action { $0.apply(.italic) }
+            .action { $0.apply(.inlineCode) }
+            .action { $0.replaceText(newText: "code") }
             .assertTree(
                 """
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+InlineCode.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+InlineCode.swift
@@ -20,8 +20,8 @@ import XCTest
 extension WysiwygComposerTests {
     func testInlineCode() {
         newComposerModel()
-            .action { $0.inlineCode() }
-            .action { $0.replaceText(newText: "code") }
+            .action { try $0.inlineCode() }
+            .action { try $0.replaceText(newText: "code") }
             .assertTree(
                 """
 
@@ -34,12 +34,12 @@ extension WysiwygComposerTests {
 
     func testInlineCodeWithFormatting() {
         newComposerModel()
-            .action { $0.bold() }
-            .action { $0.replaceText(newText: "bold") }
+            .action { try $0.bold() }
+            .action { try $0.replaceText(newText: "bold") }
             // This should get ignored
-            .action { $0.italic() }
-            .action { $0.inlineCode() }
-            .action { $0.replaceText(newText: "code") }
+            .action { try $0.italic() }
+            .action { try $0.inlineCode() }
+            .action { try $0.replaceText(newText: "code") }
             .assertTree(
                 """
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
@@ -25,21 +25,21 @@ extension WysiwygComposerTests {
 
     func testCreateLinkAction() {
         newComposerModel()
-            .action { $0.replaceText(newText: "test") }
-            .action { $0.select(startUtf16Codeunit: 0, endUtf16Codeunit: 4) }
+            .action { try $0.replaceText(newText: "test") }
+            .action { try $0.select(startUtf16Codeunit: 0, endUtf16Codeunit: 4) }
             .assertLinkAction(.create)
     }
 
     func testEditLinkAction() {
         let link = "test_url"
         newComposerModel()
-            .action { $0.setLinkWithText(link: link, text: "test") }
+            .action { try $0.setLinkWithText(link: link, text: "test") }
             .assertLinkAction(.edit(link: "https://\(link)"))
     }
 
     func testSetLinkWithText() {
         newComposerModel()
-            .action { $0.setLinkWithText(link: "link", text: "text") }
+            .action { try $0.setLinkWithText(link: "link", text: "text") }
             .assertTree(
                 """
 
@@ -52,7 +52,7 @@ extension WysiwygComposerTests {
     
     func testSetLinkWithTextWithIncludedScheme() {
         newComposerModel()
-            .action { $0.setLinkWithText(link: "http://link", text: "text") }
+            .action { try $0.setLinkWithText(link: "http://link", text: "text") }
             .assertTree(
                 """
 
@@ -65,7 +65,7 @@ extension WysiwygComposerTests {
     
     func testSetMailLinkWithText() {
         newComposerModel()
-            .action { $0.setLinkWithText(link: "test@element.io", text: "text") }
+            .action { try $0.setLinkWithText(link: "test@element.io", text: "text") }
             .assertTree(
                 """
 
@@ -78,9 +78,9 @@ extension WysiwygComposerTests {
 
     func testSetLink() {
         newComposerModel()
-            .action { $0.replaceText(newText: "text") }
-            .action { $0.select(startUtf16Codeunit: 0, endUtf16Codeunit: 4) }
-            .action { $0.setLink(link: "link") }
+            .action { try $0.replaceText(newText: "text") }
+            .action { try $0.select(startUtf16Codeunit: 0, endUtf16Codeunit: 4) }
+            .action { try $0.setLink(link: "link") }
             .assertTree(
                 """
 
@@ -93,7 +93,7 @@ extension WysiwygComposerTests {
 
     func testRemoveLinks() {
         newComposerModel()
-            .action { $0.setLinkWithText(link: "link", text: "text") }
+            .action { try $0.setLinkWithText(link: "link", text: "text") }
             .assertTree(
                 """
 
@@ -102,7 +102,7 @@ extension WysiwygComposerTests {
 
                 """
             )
-            .action { $0.removeLinks() }
+            .action { try $0.removeLinks() }
             .assertTree(
                 """
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
@@ -19,27 +19,27 @@ import XCTest
 
 extension WysiwygComposerTests {
     func testCreateWithTextLinkAction() {
-        newComposerModel()
+        ComposerModelWrapper()
             .assertLinkAction(.createWithText)
     }
 
     func testCreateLinkAction() {
-        newComposerModel()
-            .action { try $0.replaceText(newText: "test") }
-            .action { try $0.select(startUtf16Codeunit: 0, endUtf16Codeunit: 4) }
+        ComposerModelWrapper()
+            .action { $0.replaceText(newText: "test") }
+            .action { $0.select(startUtf16Codeunit: 0, endUtf16Codeunit: 4) }
             .assertLinkAction(.create)
     }
 
     func testEditLinkAction() {
         let link = "test_url"
-        newComposerModel()
-            .action { try $0.setLinkWithText(link: link, text: "test") }
+        ComposerModelWrapper()
+            .action { $0.setLinkWithText(link: link, text: "test") }
             .assertLinkAction(.edit(link: "https://\(link)"))
     }
 
     func testSetLinkWithText() {
-        newComposerModel()
-            .action { try $0.setLinkWithText(link: "link", text: "text") }
+        ComposerModelWrapper()
+            .action { $0.setLinkWithText(link: "link", text: "text") }
             .assertTree(
                 """
 
@@ -51,8 +51,8 @@ extension WysiwygComposerTests {
     }
     
     func testSetLinkWithTextWithIncludedScheme() {
-        newComposerModel()
-            .action { try $0.setLinkWithText(link: "http://link", text: "text") }
+        ComposerModelWrapper()
+            .action { $0.setLinkWithText(link: "http://link", text: "text") }
             .assertTree(
                 """
 
@@ -64,8 +64,8 @@ extension WysiwygComposerTests {
     }
     
     func testSetMailLinkWithText() {
-        newComposerModel()
-            .action { try $0.setLinkWithText(link: "test@element.io", text: "text") }
+        ComposerModelWrapper()
+            .action { $0.setLinkWithText(link: "test@element.io", text: "text") }
             .assertTree(
                 """
 
@@ -77,10 +77,10 @@ extension WysiwygComposerTests {
     }
 
     func testSetLink() {
-        newComposerModel()
-            .action { try $0.replaceText(newText: "text") }
-            .action { try $0.select(startUtf16Codeunit: 0, endUtf16Codeunit: 4) }
-            .action { try $0.setLink(link: "link") }
+        ComposerModelWrapper()
+            .action { $0.replaceText(newText: "text") }
+            .action { $0.select(startUtf16Codeunit: 0, endUtf16Codeunit: 4) }
+            .action { $0.setLink(link: "link") }
             .assertTree(
                 """
 
@@ -92,8 +92,8 @@ extension WysiwygComposerTests {
     }
 
     func testRemoveLinks() {
-        newComposerModel()
-            .action { try $0.setLinkWithText(link: "link", text: "text") }
+        ComposerModelWrapper()
+            .action { $0.setLinkWithText(link: "link", text: "text") }
             .assertTree(
                 """
 
@@ -102,7 +102,7 @@ extension WysiwygComposerTests {
 
                 """
             )
-            .action { try $0.removeLinks() }
+            .action { $0.removeLinks() }
             .assertTree(
                 """
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Lists.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Lists.swift
@@ -19,21 +19,21 @@ import XCTest
 
 extension WysiwygComposerTests {
     func testLists() {
-        newComposerModel()
-            .action { try $0.orderedList() }
-            .action { try $0.replaceText(newText: "Item 1") }
-            .action { try $0.enter() }
-            .action { try $0.replaceText(newText: "Item 2") }
+        ComposerModelWrapper()
+            .action { $0.apply(.orderedList) }
+            .action { $0.replaceText(newText: "Item 1") }
+            .action { $0.enter() }
+            .action { $0.replaceText(newText: "Item 2") }
             // Add a third list item
-            .action { try $0.enter() }
+            .action { $0.enter() }
             .assertHtml("<ol><li>Item 1</li><li>Item 2</li><li></li></ol>")
             .assertSelection(start: 14, end: 14)
             // Remove it
-            .action { try $0.enter() }
+            .action { $0.enter() }
             .assertHtml("<ol><li>Item 1</li><li>Item 2</li></ol><p>\(Character.nbsp)</p>")
             .assertSelection(start: 14, end: 14)
             // Insert some text afterwards
-            .action { try $0.replaceText(newText: "Some text") }
+            .action { $0.replaceText(newText: "Some text") }
             .assertHtml("<ol><li>Item 1</li><li>Item 2</li></ol><p>Some text</p>")
             .assertSelection(start: 23, end: 23)
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Lists.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Lists.swift
@@ -20,20 +20,20 @@ import XCTest
 extension WysiwygComposerTests {
     func testLists() {
         newComposerModel()
-            .action { $0.orderedList() }
-            .action { $0.replaceText(newText: "Item 1") }
-            .action { $0.enter() }
-            .action { $0.replaceText(newText: "Item 2") }
+            .action { try $0.orderedList() }
+            .action { try $0.replaceText(newText: "Item 1") }
+            .action { try $0.enter() }
+            .action { try $0.replaceText(newText: "Item 2") }
             // Add a third list item
-            .action { $0.enter() }
+            .action { try $0.enter() }
             .assertHtml("<ol><li>Item 1</li><li>Item 2</li><li></li></ol>")
             .assertSelection(start: 14, end: 14)
             // Remove it
-            .action { $0.enter() }
+            .action { try $0.enter() }
             .assertHtml("<ol><li>Item 1</li><li>Item 2</li></ol><p>\(Character.nbsp)</p>")
             .assertSelection(start: 14, end: 14)
             // Insert some text afterwards
-            .action { $0.replaceText(newText: "Some text") }
+            .action { try $0.replaceText(newText: "Some text") }
             .assertHtml("<ol><li>Item 1</li><li>Item 2</li></ol><p>Some text</p>")
             .assertSelection(start: 23, end: 23)
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Quotes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Quotes.swift
@@ -34,35 +34,35 @@ private enum Constants {
 
 extension WysiwygComposerTests {
     func testQuotesFromEmptyComposer() {
-        newComposerModel()
-            .action { try $0.quote() }
-            .action { try $0.replaceText(newText: "Some quote") }
-            .action { try $0.enter() }
-            .action { try $0.replaceText(newText: "More text") }
-            .action { try $0.enter() }
-            .action { try $0.enter() }
+        ComposerModelWrapper()
+            .action { $0.apply(.quote) }
+            .action { $0.replaceText(newText: "Some quote") }
+            .action { $0.enter() }
+            .action { $0.replaceText(newText: "More text") }
+            .action { $0.enter() }
+            .action { $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }
 
     func testQuotesWithMultilineInput() {
-        newComposerModel()
-            .action { try $0.quote() }
-            .action { try $0.replaceText(newText: "Some quote\nMore text") }
-            .action { try $0.enter() }
-            .action { try $0.enter() }
+        ComposerModelWrapper()
+            .action { $0.apply(.quote) }
+            .action { $0.replaceText(newText: "Some quote\nMore text") }
+            .action { $0.enter() }
+            .action { $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }
 
     func testQuotesFromContent() {
-        newComposerModel()
-            .action { try $0.replaceText(newText: "Some quote") }
-            .action { try $0.quote() }
-            .action { try $0.enter() }
-            .action { try $0.replaceText(newText: "More text") }
-            .action { try $0.enter() }
-            .action { try $0.enter() }
+        ComposerModelWrapper()
+            .action { $0.replaceText(newText: "Some quote") }
+            .action { $0.apply(.quote) }
+            .action { $0.enter() }
+            .action { $0.replaceText(newText: "More text") }
+            .action { $0.enter() }
+            .action { $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Quotes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Quotes.swift
@@ -35,34 +35,34 @@ private enum Constants {
 extension WysiwygComposerTests {
     func testQuotesFromEmptyComposer() {
         newComposerModel()
-            .action { $0.quote() }
-            .action { $0.replaceText(newText: "Some quote") }
-            .action { $0.enter() }
-            .action { $0.replaceText(newText: "More text") }
-            .action { $0.enter() }
-            .action { $0.enter() }
+            .action { try $0.quote() }
+            .action { try $0.replaceText(newText: "Some quote") }
+            .action { try $0.enter() }
+            .action { try $0.replaceText(newText: "More text") }
+            .action { try $0.enter() }
+            .action { try $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }
 
     func testQuotesWithMultilineInput() {
         newComposerModel()
-            .action { $0.quote() }
-            .action { $0.replaceText(newText: "Some quote\nMore text") }
-            .action { $0.enter() }
-            .action { $0.enter() }
+            .action { try $0.quote() }
+            .action { try $0.replaceText(newText: "Some quote\nMore text") }
+            .action { try $0.enter() }
+            .action { try $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }
 
     func testQuotesFromContent() {
         newComposerModel()
-            .action { $0.replaceText(newText: "Some quote") }
-            .action { $0.quote() }
-            .action { $0.enter() }
-            .action { $0.replaceText(newText: "More text") }
-            .action { $0.enter() }
-            .action { $0.enter() }
+            .action { try $0.replaceText(newText: "Some quote") }
+            .action { try $0.quote() }
+            .action { try $0.enter() }
+            .action { try $0.replaceText(newText: "More text") }
+            .action { try $0.enter() }
+            .action { try $0.enter() }
             .assertHtml(Constants.resultHtml)
             .assertTree(Constants.resultTree)
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 final class WysiwygComposerTests: XCTestCase {
     func testComposerEmptyState() {
-        newComposerModel()
+        ComposerModelWrapper()
             .assertHtml("")
             .execute { XCTAssertEqual($0.getContentAsMarkdown(), "") }
             .assertSelection(start: 0, end: 0)

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests.swift
@@ -24,4 +24,15 @@ final class WysiwygComposerTests: XCTestCase {
             .execute { XCTAssertEqual($0.getContentAsMarkdown(), "") }
             .assertSelection(start: 0, end: 0)
     }
+
+    func testComposerCrashRecovery() {
+        let fallbackContent = "Fallback content"
+        ComposerModelWrapper(fallbackContent: {
+            fallbackContent
+        })
+        .action { $0.replaceText(newText: "Some text") }
+        // Force a crash
+        .action { $0.setContentFromHtml(html: "</strong>") }
+        .assertHtml(fallbackContent)
+    }
 }


### PR DESCRIPTION
* Allow to catch Rust panics within the iOS code
* Add tests for it
* Replace content of the composer with the latest plain text in case of failure