### PR TITLE
Add utility to get content as plain text

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -56,6 +56,14 @@ impl ComposerModel {
             .to_string()
     }
 
+    pub fn get_content_as_plain_text(self: &Arc<Self>) -> String {
+        self.inner
+            .lock()
+            .unwrap()
+            .get_content_as_plain_text()
+            .to_string()
+    }
+
     pub fn clear(self: &Arc<Self>) -> Arc<ComposerUpdate> {
         Arc::new(ComposerUpdate::from(self.inner.lock().unwrap().clear()))
     }

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -21,6 +21,7 @@ interface ComposerModel {
     ComposerUpdate set_content_from_markdown(string markdown);
     string get_content_as_html();
     string get_content_as_markdown();
+    string get_content_as_plain_text();
     ComposerUpdate clear();
     ComposerUpdate select(u32 start_utf16_codeunit, u32 end_utf16_codeunit);
     ComposerUpdate replace_text(string new_text);

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -104,6 +104,10 @@ impl ComposerModel {
         self.inner.get_content_as_markdown().to_string()
     }
 
+    pub fn get_content_as_plain_text(&self) -> String {
+        self.inner.get_content_as_plain_text().to_string()
+    }
+
     pub fn document(&self) -> DomHandle {
         DomHandle {
             inner: self.inner.state.dom.document().handle(),

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -16,6 +16,7 @@ use crate::action_state::ActionState;
 use crate::composer_model::menu_state::MenuStateComputeType;
 use crate::composer_state::ComposerState;
 use crate::dom::parser::parse;
+use crate::dom::to_plain_text::ToPlainText;
 use crate::dom::{Dom, UnicodeString};
 use crate::markdown_html_parser::MarkdownHTMLParser;
 use crate::{
@@ -199,6 +200,10 @@ where
 
     pub fn get_content_as_markdown(&self) -> S {
         self.state.dom.to_markdown().unwrap()
+    }
+
+    pub fn get_content_as_plain_text(&self) -> S {
+        self.state.dom.to_plain_text()
     }
 
     pub fn get_current_state(&self) -> &ComposerState<S> {

--- a/crates/wysiwyg/src/dom.rs
+++ b/crates/wysiwyg/src/dom.rs
@@ -31,6 +31,7 @@ pub mod parser;
 pub mod range;
 pub mod to_html;
 pub mod to_markdown;
+pub mod to_plain_text;
 pub mod to_raw_text;
 pub mod to_tree;
 pub mod unicode_string;

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -24,6 +24,7 @@ use crate::dom::{
 };
 use crate::ToHtml;
 
+use super::to_plain_text::ToPlainText;
 use super::FindResult;
 
 #[derive(Clone, Debug, PartialEq, Default)]
@@ -602,6 +603,15 @@ where
 {
     fn to_raw_text(&self) -> S {
         self.document.to_raw_text()
+    }
+}
+
+impl<S> ToPlainText<S> for Dom<S>
+where
+    S: UnicodeString,
+{
+    fn to_plain_text(&self) -> S {
+        self.document.to_plain_text()
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -19,6 +19,7 @@ use crate::dom::nodes::{
 };
 use crate::dom::to_html::{ToHtml, ToHtmlState};
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
+use crate::dom::to_plain_text::ToPlainText;
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::UnicodeStrExt;
@@ -382,6 +383,19 @@ where
             DomNode::Container(n) => n.to_raw_text(),
             DomNode::LineBreak(n) => n.to_raw_text(),
             DomNode::Text(n) => n.to_raw_text(),
+        }
+    }
+}
+
+impl<S> ToPlainText<S> for DomNode<S>
+where
+    S: UnicodeString,
+{
+    fn to_plain_text(&self) -> S {
+        match self {
+            DomNode::Container(n) => n.to_plain_text(),
+            DomNode::LineBreak(n) => n.to_plain_text(),
+            DomNode::Text(n) => n.to_plain_text(),
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -16,6 +16,7 @@ use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::to_html::{ToHtml, ToHtmlState};
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
+use crate::dom::to_plain_text::ToPlainText;
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
@@ -55,12 +56,12 @@ where
         "br".into()
     }
 
-    pub fn handle(&self) -> DomHandle {
-        self.handle.clone()
-    }
-
     pub fn set_handle(&mut self, handle: DomHandle) {
         self.handle = handle;
+    }
+
+    pub fn handle(&self) -> DomHandle {
+        self.handle.clone()
     }
 
     // A br tag is always treated as 1 character, so this always returns 1
@@ -93,6 +94,15 @@ where
 {
     fn to_raw_text(&self) -> S {
         "\\n".into()
+    }
+}
+
+impl<S> ToPlainText<S> for LineBreakNode<S>
+where
+    S: UnicodeString,
+{
+    fn to_plain_text(&self) -> S {
+        "\n".into()
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -17,6 +17,7 @@ use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::to_html::{ToHtml, ToHtmlState};
 use crate::dom::to_markdown::{MarkdownError, MarkdownOptions, ToMarkdown};
+use crate::dom::to_plain_text::ToPlainText;
 use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::{UnicodeStr, UnicodeStrExt, UnicodeStringExt};
@@ -235,6 +236,15 @@ where
     S: UnicodeString,
 {
     fn to_raw_text(&self) -> S {
+        self.data.clone()
+    }
+}
+
+impl<S> ToPlainText<S> for TextNode<S>
+where
+    S: UnicodeString,
+{
+    fn to_plain_text(&self) -> S {
         self.data.clone()
     }
 }

--- a/crates/wysiwyg/src/dom/to_plain_text.rs
+++ b/crates/wysiwyg/src/dom/to_plain_text.rs
@@ -12,24 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)]
+use super::UnicodeString;
 
-pub mod test_characters;
-pub mod test_deleting;
-pub mod test_formatting;
-pub mod test_get_link_action;
-pub mod test_links;
-pub mod test_lists;
-pub mod test_menu_state;
-pub mod test_paragraphs;
-pub mod test_remove_links;
-pub mod test_selection;
-pub mod test_set_content;
-pub mod test_to_markdown;
-pub mod test_to_plain_text;
-pub mod test_to_raw_text;
-pub mod test_to_tree;
-pub mod test_undo_redo;
-pub mod testutils_composer_model;
-pub mod testutils_conversion;
-pub mod testutils_dom;
+pub trait ToPlainText<S>
+where
+    S: UnicodeString,
+{
+    fn to_plain_text(&self) -> S;
+}

--- a/crates/wysiwyg/src/tests/test_to_plain_text.rs
+++ b/crates/wysiwyg/src/tests/test_to_plain_text.rs
@@ -160,12 +160,17 @@ fn list_unordered() {
             "#
         },
     );
+}
 
+#[test]
+fn list_unordered_indented() {
     assert_to_plain(
-        r#"<ul><li>item1<ul><li>subitem1</li><li>subitem2</li></ul></li><li>item2</li></ul>"#,
+        r#"<ul><li>item1<ul><li>subitem1<ul><li>subitem1a</li><li>subitem1b</li></ul></li><li>subitem2</li></ul></li><li>item2</li></ul>"#,
         indoc! {
             r#"item1
             subitem1
+            subitem1a
+            subitem1b
             subitem2
             item2
             "#
@@ -183,12 +188,17 @@ fn list_ordered() {
             "#
         },
     );
+}
 
+#[test]
+fn list_ordered_indented() {
     assert_to_plain(
-        r#"<ol><li>item1<ol><li>subitem1</li><li>subitem2</li></ol></li><li>item2</li></ol>"#,
+        r#"<ol><li>item1<ol><li>subitem1<ol><li>subitem1a</li><li>subitem1b</li></ol></li><li>subitem2</li></ol></li><li>item2</li></ol>"#,
         indoc! {
             r#"item1
             subitem1
+            subitem1a
+            subitem1b
             subitem2
             item2
             "#

--- a/crates/wysiwyg/src/tests/test_to_plain_text.rs
+++ b/crates/wysiwyg/src/tests/test_to_plain_text.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::{dom::to_plain_text::ToPlainText, ComposerModel};
+use indoc::indoc;
 use widestring::Utf16String;
 
 #[test]
@@ -28,16 +29,20 @@ fn text_with_linebreaks() {
     // One new line.
     assert_to_plain(
         "abc<br />def",
-        r#"abc
-def"#,
+        indoc! {
+            r#"abc
+            def"#
+        },
     );
 
     // Two new lines (isn't transformed into a new block).
     assert_to_plain(
         "abc<br /><br />def",
-        r#"abc
+        indoc! {
+            r#"abc
 
-def"#,
+            def"#
+        },
     );
 }
 
@@ -47,10 +52,12 @@ fn text_with_italic() {
     assert_to_plain("abc <em>def</em> ghi", "abc def ghi");
     assert_to_plain(
         "abc <em>line1<br />line2<br /><br />line3</em> def",
-        r#"abc line1
-line2
+        indoc! {
+            r#"abc line1
+            line2
 
-line3 def"#,
+            line3 def"#
+        },
     );
 
     assert_to_plain("abc<em>def</em>ghi", "abcdefghi");
@@ -64,10 +71,12 @@ fn text_with_bold() {
     assert_to_plain("abc <strong>def</strong> ghi", "abc def ghi");
     assert_to_plain(
         "abc <strong>line1<br />line2<br /><br />line3</strong> def",
-        r#"abc line1
-line2
+        indoc! {
+            r#"abc line1
+            line2
 
-line3 def"#,
+            line3 def"#
+        },
     );
 
     assert_to_plain("abc<strong>def</strong>ghi", "abcdefghi");
@@ -81,8 +90,10 @@ fn text_with_italic_and_bold() {
     assert_to_plain("<em>abc <strong>def</strong></em> ghi", "abc def ghi");
     assert_to_plain(
         "abc <em><strong>line1<br />line2</strong> def</em>",
-        r#"abc line1
-line2 def"#,
+        indoc! {
+            r#"abc line1
+            line2 def"#
+        },
     );
 }
 
@@ -92,10 +103,12 @@ fn text_with_strikethrough() {
     assert_to_plain("abc <del>def</del> ghi", "abc def ghi");
     assert_to_plain(
         "abc <del>line1<br />line2<br /><br />line3</del> def",
-        r#"abc line1
-line2
+        indoc! {
+            r#"abc line1
+            line2
 
-line3 def"#,
+            line3 def"#
+        },
     );
 }
 
@@ -116,10 +129,12 @@ fn text_with_inline_code() {
 
     assert_to_plain(
         "abc <code>line1<br />line2<br /><br />line3</code> def",
-        r#"abc line1
-line2
+        indoc! {
+            r#"abc line1
+            line2
 
-line3 def"#,
+            line3 def"#
+        },
     );
 }
 
@@ -139,18 +154,22 @@ fn link() {
 fn list_unordered() {
     assert_to_plain(
         r#"<ul><li>item1</li><li>item2</li></ul>"#,
-        r#"item1
-item2
-"#,
+        indoc! {
+            r#"item1
+            item2
+            "#
+        },
     );
 
     assert_to_plain(
         r#"<ul><li>item1<ul><li>subitem1</li><li>subitem2</li></ul></li><li>item2</li></ul>"#,
-        r#"item1
-subitem1
-subitem2
-item2
-"#,
+        indoc! {
+            r#"item1
+            subitem1
+            subitem2
+            item2
+            "#
+        },
     );
 }
 
@@ -158,18 +177,22 @@ item2
 fn list_ordered() {
     assert_to_plain(
         r#"<ol><li>item1</li><li>item2</li></ol>"#,
-        r#"item1
-item2
-"#,
+        indoc! {
+            r#"item1
+            item2
+            "#
+        },
     );
 
     assert_to_plain(
         r#"<ol><li>item1<ol><li>subitem1</li><li>subitem2</li></ol></li><li>item2</li></ol>"#,
-        r#"item1
-subitem1
-subitem2
-item2
-"#,
+        indoc! {
+            r#"item1
+            subitem1
+            subitem2
+            item2
+            "#
+        },
     );
 }
 
@@ -177,11 +200,13 @@ item2
 fn list_ordered_and_unordered() {
     assert_to_plain(
         r#"<ol><li>item1<ul><li>subitem1</li><li>subitem2</li></ul></li><li>item2</li></ol>"#,
-        r#"item1
-subitem1
-subitem2
-item2
-"#,
+        indoc! {
+            r#"item1
+            subitem1
+            subitem2
+            item2
+            "#
+        },
     );
 }
 
@@ -189,13 +214,15 @@ item2
 fn blocks() {
     assert_to_plain(
         r#"<p>paragraph 1</p><ul><li>list item 1</li><li>list item 2</li></ul><pre><code>codeblock</code></pre><blockquote>blockquote</blockquote><p>paragraph 2</p>"#,
-        r#"paragraph 1
-list item 1
-list item 2
-codeblock
-blockquote
-paragraph 2
-"#,
+        indoc! {
+            r#"paragraph 1
+            list item 1
+            list item 2
+            codeblock
+            blockquote
+            paragraph 2
+        "#
+        },
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_to_plain_text.rs
+++ b/crates/wysiwyg/src/tests/test_to_plain_text.rs
@@ -1,0 +1,212 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{dom::to_plain_text::ToPlainText, ComposerModel};
+use widestring::Utf16String;
+
+#[test]
+fn text() {
+    assert_to_plain("abc", "abc");
+    assert_to_plain("abc def", "abc def");
+    // Internal spaces are preserved.
+    assert_to_plain("abc   def", "abc   def");
+}
+
+#[test]
+fn text_with_linebreaks() {
+    // One new line.
+    assert_to_plain(
+        "abc<br />def",
+        r#"abc
+def"#,
+    );
+
+    // Two new lines (isn't transformed into a new block).
+    assert_to_plain(
+        "abc<br /><br />def",
+        r#"abc
+
+def"#,
+    );
+}
+
+#[test]
+fn text_with_italic() {
+    assert_to_plain("<em>abc</em>", "abc");
+    assert_to_plain("abc <em>def</em> ghi", "abc def ghi");
+    assert_to_plain(
+        "abc <em>line1<br />line2<br /><br />line3</em> def",
+        r#"abc line1
+line2
+
+line3 def"#,
+    );
+
+    assert_to_plain("abc<em>def</em>ghi", "abcdefghi");
+
+    assert_to_plain("abc<em> def </em>ghi", "abc def ghi");
+}
+
+#[test]
+fn text_with_bold() {
+    assert_to_plain("<strong>abc</strong>", "abc");
+    assert_to_plain("abc <strong>def</strong> ghi", "abc def ghi");
+    assert_to_plain(
+        "abc <strong>line1<br />line2<br /><br />line3</strong> def",
+        r#"abc line1
+line2
+
+line3 def"#,
+    );
+
+    assert_to_plain("abc<strong>def</strong>ghi", "abcdefghi");
+
+    assert_to_plain("abc<strong> def </strong>ghi", "abc def ghi");
+}
+
+#[test]
+fn text_with_italic_and_bold() {
+    assert_to_plain("<em><strong>abc</strong></em>", "abc");
+    assert_to_plain("<em>abc <strong>def</strong></em> ghi", "abc def ghi");
+    assert_to_plain(
+        "abc <em><strong>line1<br />line2</strong> def</em>",
+        r#"abc line1
+line2 def"#,
+    );
+}
+
+#[test]
+fn text_with_strikethrough() {
+    assert_to_plain("<del>abc</del>", "abc");
+    assert_to_plain("abc <del>def</del> ghi", "abc def ghi");
+    assert_to_plain(
+        "abc <del>line1<br />line2<br /><br />line3</del> def",
+        r#"abc line1
+line2
+
+line3 def"#,
+    );
+}
+
+#[test]
+fn text_with_underline() {
+    assert_to_plain("<u>abc</u>", "abc");
+}
+
+#[test]
+fn text_with_inline_code() {
+    assert_to_plain("<code>abc</code>", "abc");
+    // Inline code with a backtick inside.
+    assert_to_plain("<code>abc ` def</code>", "abc ` def");
+    // Inline code with a backtick at the start.
+    assert_to_plain("<code>`abc</code>", "`abc");
+    assert_to_plain("abc <code>def</code> ghi", "abc def ghi");
+    assert_to_plain("abc<code> def </code>ghi", "abc def ghi");
+
+    assert_to_plain(
+        "abc <code>line1<br />line2<br /><br />line3</code> def",
+        r#"abc line1
+line2
+
+line3 def"#,
+    );
+}
+
+#[test]
+fn link() {
+    assert_to_plain(r#"<a href="url">abc</a>"#, "abc");
+    // Empty link.
+    assert_to_plain(r#"<a href="">abc</a>"#, "abc");
+    // Formatting inside link.
+    assert_to_plain(
+        r#"<a href="url">abc <strong>def</strong> ghi</a>"#,
+        "abc def ghi",
+    );
+}
+
+#[test]
+fn list_unordered() {
+    assert_to_plain(
+        r#"<ul><li>item1</li><li>item2</li></ul>"#,
+        r#"item1
+item2
+"#,
+    );
+
+    assert_to_plain(
+        r#"<ul><li>item1<ul><li>subitem1</li><li>subitem2</li></ul></li><li>item2</li></ul>"#,
+        r#"item1
+subitem1
+subitem2
+item2
+"#,
+    );
+}
+
+#[test]
+fn list_ordered() {
+    assert_to_plain(
+        r#"<ol><li>item1</li><li>item2</li></ol>"#,
+        r#"item1
+item2
+"#,
+    );
+
+    assert_to_plain(
+        r#"<ol><li>item1<ol><li>subitem1</li><li>subitem2</li></ol></li><li>item2</li></ol>"#,
+        r#"item1
+subitem1
+subitem2
+item2
+"#,
+    );
+}
+
+#[test]
+fn list_ordered_and_unordered() {
+    assert_to_plain(
+        r#"<ol><li>item1<ul><li>subitem1</li><li>subitem2</li></ul></li><li>item2</li></ol>"#,
+        r#"item1
+subitem1
+subitem2
+item2
+"#,
+    );
+}
+
+#[test]
+fn blocks() {
+    assert_to_plain(
+        r#"<p>paragraph 1</p><ul><li>list item 1</li><li>list item 2</li></ul><pre><code>codeblock</code></pre><blockquote>blockquote</blockquote><p>paragraph 2</p>"#,
+        r#"paragraph 1
+list item 1
+list item 2
+codeblock
+blockquote
+paragraph 2
+"#,
+    );
+}
+
+fn assert_to_plain(html: &str, expected_plain_text: &str) {
+    let plain_text = to_plain_text(html);
+    assert_eq!(plain_text, expected_plain_text);
+}
+
+fn to_plain_text(html: &str) -> Utf16String {
+    ComposerModel::from_html(html, 0, 0)
+        .state
+        .dom
+        .to_plain_text()
+}


### PR DESCRIPTION
## What?

Add a (basic) utility to get content as plain text.

## Why?

If the internal Rust model panics due to a bug, we'd like to be able to reset and continue editing without losing any data. However, recovering to the last known good state is risky because this state is 'nearby' the bad state that caused the panic.

So instead, this method allows the editor to recover the contents of the editor from the Rust model in plain text, stripped of all formatting, and allow the user to continue editing from a safer state.

[`PSU-1117`](https://element-io.atlassian.net/browse/PSU-1117)
