### PR TITLE
[Android] Update NDK to r25c

### DIFF
--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -61,7 +61,7 @@ android {
         jacocoVersion = "0.8.8"
     }
 
-    ndkVersion = "25.1.8937393"
+    ndkVersion = "25.2.9519653"
 }
 
 dependencies {


### PR DESCRIPTION
## What?

Update the Android NDK to LTS [r25c](https://developer.android.com/ndk/downloads#lts-downloads).

## Why?

- This is the latest long term support version
- It's now the default installed version on the MacOS 12 Github Actions runner so no need to install it manually