### PR TITLE
Improve selection range computation

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTCoreText/DTHTMLElement.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTCoreText/DTHTMLElement.swift
@@ -25,7 +25,7 @@ extension DTHTMLElement {
            let child = childNodes.first as? DTTextHTMLElement,
            child.text() == .nbsp {
             removeAllChildNodes()
-            let newChild = DiscardableTextHTMLElement(from: child)
+            let newChild = PlaceholderTextHTMLElement(from: child)
             addChildNode(newChild)
             newChild.inheritAttributes(from: self)
             newChild.interpretAttributes()
@@ -69,8 +69,8 @@ extension DTHTMLElement {
         }
     }
 
-    private func createDiscardableElement() -> DiscardableTextHTMLElement {
-        let discardableElement = DiscardableTextHTMLElement()
+    private func createDiscardableElement() -> PlaceholderTextHTMLElement {
+        let discardableElement = PlaceholderTextHTMLElement()
         discardableElement.inheritAttributes(from: self)
         discardableElement.interpretAttributes()
         return discardableElement

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTCoreText/PlaceholderTextHTMLElement.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/DTCoreText/PlaceholderTextHTMLElement.swift
@@ -16,7 +16,9 @@
 
 import DTCoreText
 
-final class DiscardableTextHTMLElement: DTTextHTMLElement {
+/// Defines a placeholder to be inserted during HTML parsing in order to have a valid
+/// position for e.g. an empty paragraph.
+final class PlaceholderTextHTMLElement: DTTextHTMLElement {
     /// Init.
     ///
     /// - Parameters:

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
@@ -70,12 +70,10 @@ extension NSAttributedString {
     ///   - range: the range on which the elements should be detected. Entire range if omitted
     /// - Returns: an array of matching ranges
     func discardableTextRanges(in range: NSRange? = nil) -> [NSRange] {
-        let enumRange = range ?? .init(location: 0, length: length)
         var ranges = [NSRange]()
 
-        enumerateAttribute(.discardableText,
-                           in: enumRange) { (attr: Any?, range: NSRange, _) in
-            if attr != nil {
+        enumerateTypedAttribute(.discardableText, in: range) { (isDiscardable: Bool, range: NSRange, _) in
+            if isDiscardable {
                 ranges.append(range)
             }
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
@@ -62,27 +62,13 @@ extension NSAttributedString {
 
     // MARK: - Internal
 
-    /// Compute an array of all detected occurences of bulleted lists and
-    /// numbered lists prefixes. ("1.", "•", ... with included tabulations and newline
-    /// that are not represented in the HTML raw text).
+    /// Compute an array of all detected occurences of discardable
+    /// text (list prefixes, placeholder characters) within the given range
+    /// of the attributed text.
     ///
     /// - Parameters:
     ///   - range: the range on which the elements should be detected. Entire range if omitted
     /// - Returns: an array of matching ranges
-    func listPrefixesRanges(in range: NSRange? = nil) -> [NSRange] {
-        let enumRange = range ?? .init(location: 0, length: length)
-        var ranges = [NSRange]()
-
-        enumerateAttribute(.DTField,
-                           in: enumRange) { (attr: Any?, range: NSRange, _) in
-            if attr != nil {
-                ranges.append(range)
-            }
-        }
-
-        return ranges
-    }
-
     func discardableTextRanges(in range: NSRange? = nil) -> [NSRange] {
         let enumRange = range ?? .init(location: 0, length: length)
         var ranges = [NSRange]()
@@ -109,25 +95,11 @@ extension NSAttributedString {
                 .outOfBoundsAttributedIndex(index: attributedIndex)
         }
 
-        let discardableTextRanges = discardableTextRanges()
-        var actualIndex = attributedIndex
-
-        for discardableTextRange in discardableTextRanges where discardableTextRange.upperBound <= attributedIndex {
-            actualIndex -= discardableTextRange.length
-        }
-
-        let prefixes = listPrefixesRanges()
-
-        for listPrefix in prefixes {
-            if listPrefix.upperBound <= attributedIndex {
-                actualIndex -= listPrefix.length
-            } else if listPrefix.contains(attributedIndex),
-                      character(at: attributedIndex)?.isNewline == false {
-                actualIndex -= (attributedIndex - listPrefix.location)
-            }
-        }
-
-        return actualIndex
+        return discardableTextRanges(in: .init(location: 0, length: attributedIndex))
+            // All ranges length should be counted out, unless the last one end strictly after the
+            // attributed index, in that case we only count out the difference (i.e. chars before the index)
+            .map { $0.upperBound <= attributedIndex ? $0.length : attributedIndex - $0.location }
+            .reduce(attributedIndex) { $0 - $1 }
     }
 
     /// Computes index inside the attributed representation from the index
@@ -137,34 +109,16 @@ extension NSAttributedString {
     ///   - htmlIndex: the index inside the HTML raw text
     /// - Returns: the index inside the attributed representation
     func attributedPosition(at htmlIndex: Int) throws -> Int {
-        let discardableTextRanges = discardableTextRanges()
-        var actualIndex = htmlIndex
+        let attributedIndex = try discardableTextRanges()
+            // All ranges that have a HTML position before the provided index should be entirely counted.
+            .filter { try htmlPosition(at: $0.location) <= htmlIndex }
+            .reduce(htmlIndex) { $0 + $1.length }
 
-        for discardableTextRange in discardableTextRanges where try htmlPosition(at: discardableTextRange.location) <= htmlIndex {
-            actualIndex += discardableTextRange.length
-        }
-
-        let prefixes = listPrefixesRanges()
-
-        for listPrefix in prefixes {
-            let prefixLocation = try htmlPosition(at: listPrefix.location)
-            if prefixLocation < htmlIndex {
-                actualIndex += listPrefix.length
-            } else if prefixLocation == htmlIndex {
-                // Should only count the listPrefix in if we are
-                // not on an inserted newline from end of <li>
-                if !(attributedSubstring(from: .init(location: actualIndex, length: 1))
-                    .string == "\n") {
-                    actualIndex += listPrefix.length
-                }
-            }
-        }
-
-        guard actualIndex <= length else {
+        guard attributedIndex <= length else {
             throw AttributedRangeError
                 .outOfBoundsHtmlIndex(index: htmlIndex)
         }
 
-        return actualIndex
+        return attributedIndex
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString.Key.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString.Key.swift
@@ -18,9 +18,17 @@ import DTCoreText
 import Foundation
 
 extension NSAttributedString.Key {
+    // MARK: - DTCoreText Internal Keys
+
     static let DTTextBlocks: NSAttributedString.Key = .init(rawValue: DTTextBlocksAttribute)
-    static let blockStyle: NSAttributedString.Key = .init(rawValue: "BlockStyleAttributeKey")
     static let DTField: NSAttributedString.Key = .init(rawValue: DTFieldAttribute)
     static let DTTextLists: NSAttributedString.Key = .init(rawValue: DTTextListsAttribute)
+
+    // MARK: - Custom Keys
+
+    /// Attribute for parts of the string that require some custom drawing (e.g. code blocks, quotes).
+    static let blockStyle: NSAttributedString.Key = .init(rawValue: "BlockStyleAttributeKey")
+    /// Attribute for parts of the string that should be removed for HTML selection computation.
+    /// Should include both placeholder characters such as NBSP and ZWSP, as well as list prefixes.
     static let discardableText: NSAttributedString.Key = .init(rawValue: "DiscardableAttributeKey")
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
@@ -18,6 +18,46 @@ import DTCoreText
 import UIKit
 
 extension NSMutableAttributedString {
+    /// Apply all custom attributes expected by the composer's `UITextView` on self.
+    ///
+    /// - Parameters:
+    ///   - style: Style for HTML parsing.
+    func applyPostParsingCustomAttributes(style: HTMLParserStyle) {
+        addAttributes(
+            [.foregroundColor: style.textColor], range: NSRange(location: 0, length: length)
+        )
+
+        // This fixes an iOS bug where if some text is typed after a link, and then a whitespace is added the link color is overridden.
+        enumerateAttribute(
+            .link,
+            in: NSRange(location: 0, length: length)
+        ) { value, range, _ in
+            if value != nil {
+                removeAttribute(.underlineStyle, range: range)
+                removeAttribute(.underlineColor, range: range)
+                addAttributes([.foregroundColor: style.linkColor], range: range)
+            }
+        }
+
+        removeParagraphVerticalSpacing()
+        applyBackgroundStyles(style: style)
+        applyInlineCodeBackgroundStyle(codeBackgroundColor: style.codeBlockStyle.backgroundColor)
+        replacePlaceholderTexts()
+        applyDiscardableToListPrefixes()
+    }
+}
+
+private extension NSMutableAttributedString {
+    /// Remove the vertical spacing for paragraphs in the entire attributed string.
+    func removeParagraphVerticalSpacing() {
+        enumerateTypedAttribute(.paragraphStyle) { (style: NSParagraphStyle, range: NSRange, _) in
+            let mutableStyle = style.mut()
+            mutableStyle.paragraphSpacing = 0
+            mutableStyle.paragraphSpacingBefore = 0
+            addAttribute(.paragraphStyle, value: mutableStyle as Any, range: range)
+        }
+    }
+
     /// Sets the background style for detected quote & code blocks within the attributed string.
     ///
     /// - Parameters:
@@ -54,23 +94,21 @@ extension NSMutableAttributedString {
         }
     }
 
-    /// Finds any text that has been marked as discardable
-    /// and either replaces it with ZWSP if contained overlaps with text marked with a background style
-    /// or removes it otherwise
-    func replaceOrDeleteDiscardableText() {
+    /// Finds any text that has been marked as discardable and replaces it with ZWSP
+    func replacePlaceholderTexts() {
         enumerateTypedAttribute(.discardableText) { (discardable: Bool, range: NSRange, _) in
             guard discardable == true else { return }
             self.replaceCharacters(in: range, with: String.zwsp)
         }
     }
 
-    /// Remove the vertical spacing for paragraphs in the entire attributed string.
-    func removeParagraphVerticalSpacing() {
-        enumerateTypedAttribute(.paragraphStyle) { (style: NSParagraphStyle, range: NSRange, _) in
-            let mutableStyle = style.mut()
-            mutableStyle.paragraphSpacing = 0
-            mutableStyle.paragraphSpacingBefore = 0
-            addAttribute(.paragraphStyle, value: mutableStyle as Any, range: range)
+    /// Finds any list prefix field inside the string and mark them as discardable text.
+    func applyDiscardableToListPrefixes() {
+        enumerateAttribute(.DTField,
+                           in: .init(location: 0, length: length)) { (attr: Any?, range: NSRange, _) in
+            if attr != nil {
+                addAttribute(.discardableText, value: true, range: range)
+            }
         }
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
@@ -28,15 +28,10 @@ extension NSMutableAttributedString {
         )
 
         // This fixes an iOS bug where if some text is typed after a link, and then a whitespace is added the link color is overridden.
-        enumerateAttribute(
-            .link,
-            in: NSRange(location: 0, length: length)
-        ) { value, range, _ in
-            if value != nil {
-                removeAttribute(.underlineStyle, range: range)
-                removeAttribute(.underlineColor, range: range)
-                addAttributes([.foregroundColor: style.linkColor], range: range)
-            }
+        enumerateTypedAttribute(.link) { (_: URL, range: NSRange, _) in
+            removeAttribute(.underlineStyle, range: range)
+            removeAttribute(.underlineColor, range: range)
+            addAttributes([.foregroundColor: style.linkColor], range: range)
         }
 
         removeParagraphVerticalSpacing()
@@ -104,11 +99,8 @@ private extension NSMutableAttributedString {
 
     /// Finds any list prefix field inside the string and mark them as discardable text.
     func applyDiscardableToListPrefixes() {
-        enumerateAttribute(.DTField,
-                           in: .init(location: 0, length: length)) { (attr: Any?, range: NSRange, _) in
-            if attr != nil {
-                addAttribute(.discardableText, value: true, range: range)
-            }
+        enumerateTypedAttribute(.DTField) { (_: String, range: NSRange, _) in
+            addAttribute(.discardableText, value: true, range: range)
         }
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
@@ -96,28 +96,7 @@ public final class HTMLParser {
         }
         
         let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
-        
-        mutableAttributedString.addAttributes(
-            [.foregroundColor: style.textColor], range: NSRange(location: 0, length: mutableAttributedString.length)
-        )
-        
-        // This fixes an iOS bug where if some text is typed after a link, and then a whitespace is added the link color is overridden.
-        mutableAttributedString.enumerateAttribute(
-            .link,
-            in: NSRange(location: 0, length: mutableAttributedString.length)
-        ) { value, range, _ in
-            if value != nil {
-                mutableAttributedString.removeAttribute(.underlineStyle, range: range)
-                mutableAttributedString.removeAttribute(.underlineColor, range: range)
-                mutableAttributedString.addAttributes([.foregroundColor: style.linkColor], range: range)
-            }
-        }
-
-        mutableAttributedString.removeParagraphVerticalSpacing()
-        mutableAttributedString.applyBackgroundStyles(style: style)
-        mutableAttributedString.applyInlineCodeBackgroundStyle(codeBackgroundColor: style.codeBlockStyle.backgroundColor)
-        mutableAttributedString.replaceOrDeleteDiscardableText()
-
+        mutableAttributedString.applyPostParsingCustomAttributes(style: style)
         removeTrailingNewlineIfNeeded(from: mutableAttributedString, given: html)
         return mutableAttributedString
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -245,9 +245,9 @@ public extension WysiwygComposerViewModel {
             // NSAttributedString upon next character input if we
             // are in a structure that might add non-formatted
             // representation chars to it (e.g. NBSP/ZWSP, list prefixes)
-            if !model.reversedActions
-                .intersection([.codeBlock, .quote, .orderedList, .unorderedList])
-                .isEmpty {
+            if !model
+                .reversedActions
+                .isDisjoint(with: [.codeBlock, .quote, .orderedList, .unorderedList]) {
                 hasPendingFormats = true
             }
             shouldAcceptChange = false

--- a/platforms/ios/lib/WysiwygComposer/Tests/HTMLParserTests/Extensions/NSAttributedStringRangeTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/HTMLParserTests/Extensions/NSAttributedStringRangeTests.swift
@@ -27,7 +27,7 @@ final class NSAttributedStringRangeTests: XCTestCase {
                        "\t1.\tItem 1\n\t2.\tItem 2\nSome Text")
 
         // Ranges that are not part of the raw HTML text (excluding tags) are detected
-        XCTAssertEqual(attributed.listPrefixesRanges(),
+        XCTAssertEqual(attributed.discardableTextRanges(),
                        [NSRange(location: 0, length: 4),
                         NSRange(location: 11, length: 4)])
 
@@ -72,7 +72,7 @@ final class NSAttributedStringRangeTests: XCTestCase {
         let attributed = try HTMLParser.parse(html: html)
         XCTAssertEqual(attributed.string,
                        "\t•\tItem 1\n\t•\tItem 2\nSome Text")
-        XCTAssertEqual(attributed.listPrefixesRanges(),
+        XCTAssertEqual(attributed.discardableTextRanges(),
                        [NSRange(location: 0, length: 3),
                         NSRange(location: 10, length: 3)])
         XCTAssertEqual(try attributed.attributedPosition(at: 1), 4)
@@ -86,7 +86,7 @@ final class NSAttributedStringRangeTests: XCTestCase {
         let attributed = try HTMLParser.parse(html: html)
         XCTAssertEqual(attributed.string,
                        "\t1.\tItem 1\n\t2.\tItem 2\n\t•\tItem 1\n\t•\tItem 2")
-        XCTAssertEqual(attributed.listPrefixesRanges(),
+        XCTAssertEqual(attributed.discardableTextRanges(),
                        [NSRange(location: 0, length: 4),
                         NSRange(location: 11, length: 4),
                         NSRange(location: 22, length: 3),
@@ -113,7 +113,7 @@ final class NSAttributedStringRangeTests: XCTestCase {
         }
         html.append(contentsOf: "</ol>")
         let attributed = try HTMLParser.parse(html: html)
-        XCTAssertEqual(attributed.listPrefixesRanges().count,
+        XCTAssertEqual(attributed.discardableTextRanges().count,
                        19)
     }
 


### PR DESCRIPTION
* Merge all text that are not part of the HTML under a single attribute (discardable text)
* Improve selection range computation
* Use typed variant of enumerateAttribute when possible
* Fix a Swiftlint issue
