### PR TITLE
Fix creating list with selection containing quote / code blocks

### DIFF
--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -248,8 +248,16 @@ where
         list_type: ListType,
         range: Range,
     ) -> ComposerUpdate<S> {
-        let handles: Vec<&DomHandle> = range
-            .top_level_locations()
+        let nodes_iterator =
+            if range.has_single_top_level_node(Some(DomNodeKind::Quote)) {
+                // Single top level quote means we're trying to create a list inside
+                // the quote, we should wrap the nodes from one depth further into it.
+                range.locations_at_depth(range.top_level_depth() + 1)
+            } else {
+                range.locations_at_depth(range.top_level_depth())
+            };
+
+        let handles = nodes_iterator
             // FIXME: filtering positions that are before start, these shouldn't be returned from a > 0 range
             .filter(|l| !(l.relative_position() == DomLocationPosition::Before))
             .map(|l| &l.node_handle)

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -257,11 +257,7 @@ where
                 range.locations_at_depth(range.top_level_depth())
             };
 
-        let handles = nodes_iterator
-            // FIXME: filtering positions that are before start, these shouldn't be returned from a > 0 range
-            .filter(|l| !(l.relative_position() == DomLocationPosition::Before))
-            .map(|l| &l.node_handle)
-            .collect();
+        let handles = nodes_iterator.map(|l| &l.node_handle).collect();
         self.state.dom.wrap_nodes_in_list(list_type, handles);
         self.create_update_replace_all()
     }

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -290,6 +290,8 @@ impl Range {
         self.locations
             .iter()
             .filter(move |l| l.node_handle.depth() == depth)
+            // FIXME: filtering positions that are before start, these shouldn't be returned.
+            .filter(|l| !(l.relative_position() == DomLocationPosition::Before))
     }
 
     pub fn locations_from_depth(
@@ -308,12 +310,7 @@ impl Range {
     /// Return true if the current range contains a single top
     /// level node of optional given kind.
     pub fn has_single_top_level_node(&self, kind: Option<DomNodeKind>) -> bool {
-        let mut top_level_locations = self
-            .top_level_locations()
-            // FIXME: filtering positions that are before start, these shouldn't be returned from a > 0 range
-            .filter(|l| {
-                !(l.relative_position() == DomLocationPosition::Before)
-            });
+        let mut top_level_locations = self.top_level_locations();
 
         if let Some(first_loc) = top_level_locations.next() {
             let is_expected_kind = if let Some(kind) = kind {

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -305,6 +305,29 @@ impl Range {
         self.locations_at_depth(self.top_level_depth())
     }
 
+    /// Return true if the current range contains a single top
+    /// level node of optional given kind.
+    pub fn has_single_top_level_node(&self, kind: Option<DomNodeKind>) -> bool {
+        let mut top_level_locations = self
+            .top_level_locations()
+            // FIXME: filtering positions that are before start, these shouldn't be returned from a > 0 range
+            .filter(|l| {
+                !(l.relative_position() == DomLocationPosition::Before)
+            });
+
+        if let Some(first_loc) = top_level_locations.next() {
+            let is_expected_kind = if let Some(kind) = kind {
+                first_loc.kind == kind
+            } else {
+                // No specific `DomNodeKind` provided.
+                true
+            };
+            is_expected_kind && top_level_locations.next().is_none()
+        } else {
+            false
+        }
+    }
+
     pub fn node_handles(&self) -> impl DoubleEndedIterator<Item = &DomHandle> {
         self.locations.iter().map(|l| &l.node_handle)
     }
@@ -689,6 +712,24 @@ mod test {
         let location = range.find_location(&handle);
 
         assert!(location.is_none());
+    }
+
+    #[test]
+    fn range_top_level_single_node() {
+        let range = range_of(
+            "<blockquote><p><em>{ab</em>c</p><p>de}|f</p></blockquote>",
+        );
+        assert!(range.has_single_top_level_node(None));
+        assert!(range.has_single_top_level_node(Some(DomNodeKind::Quote)));
+        assert!(!range.has_single_top_level_node(Some(DomNodeKind::Paragraph)));
+    }
+
+    #[test]
+    fn range_top_level_single_node_with_multiple_nodes() {
+        let range = range_of("<p>a{bc</p><pre><code>de}|f</code></pre>");
+        assert!(!range.has_single_top_level_node(None));
+        assert!(!range.has_single_top_level_node(Some(DomNodeKind::Paragraph)));
+        assert!(!range.has_single_top_level_node(Some(DomNodeKind::CodeBlock)));
     }
 
     fn range_of(model: &str) -> Range {

--- a/crates/wysiwyg/src/tests.rs
+++ b/crates/wysiwyg/src/tests.rs
@@ -20,6 +20,7 @@ pub mod test_formatting;
 pub mod test_get_link_action;
 pub mod test_links;
 pub mod test_lists;
+pub mod test_lists_with_blocks;
 pub mod test_menu_state;
 pub mod test_paragraphs;
 pub mod test_remove_links;

--- a/crates/wysiwyg/src/tests/test_lists_with_blocks.rs
+++ b/crates/wysiwyg/src/tests/test_lists_with_blocks.rs
@@ -1,0 +1,85 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tests::testutils_composer_model::{cm, tx};
+
+// This file defines specific tests on how lists behave in combination to
+// some other block nodes such as quote and code blocks. At some point, some
+// of these behaviours might change with updates such as e.g. quotes
+// available inside list items.
+
+#[test]
+fn create_list_inside_quote() {
+    let mut model = cm("<blockquote><p>a|</p></blockquote>");
+    model.ordered_list();
+    assert_eq!(tx(&model), "<blockquote><ol><li>a|</li></ol></blockquote>")
+}
+
+#[test]
+fn create_list_inside_quote_with_multiple_paragraphs() {
+    let mut model =
+        cm("<blockquote><p>{a</p><p>b</p><p>c}|</p><p>d</p></blockquote>");
+    model.ordered_list();
+    assert_eq!(
+        tx(&model),
+        "<blockquote><ol><li>{a</li><li>b</li><li>c}|</li></ol><p>d</p></blockquote>"
+    )
+}
+
+#[test]
+fn create_list_with_selected_paragraph_and_quote() {
+    let mut model = cm("<p>{text</p><blockquote><p>quote}|</p></blockquote>");
+    model.unordered_list();
+    assert_eq!(tx(&model), "<ul><li>{text</li><li>quote}|</li></ul>")
+}
+
+#[test]
+fn create_list_with_selected_paragraph_and_quote_with_multiple_nested_paragraphs(
+) {
+    let mut model = cm(
+        "<p>{text</p><blockquote><p>quote</p><p>more quote}|</p></blockquote>",
+    );
+    model.unordered_list();
+    assert_eq!(
+        tx(&model),
+        "<ul><li>{text</li><li>quote</li><li>more quote}|</li></ul>"
+    )
+}
+
+#[test]
+fn create_list_with_selected_paragraph_and_codeblock() {
+    let mut model = cm("<p>{text</p><pre><code>some code}|</code></pre>");
+    model.unordered_list();
+    assert_eq!(tx(&model), "<ul><li>{text</li><li>some code}|</li></ul>")
+}
+
+#[test]
+fn create_list_with_selected_paragraph_and_codeblock_with_multiple_lines() {
+    let mut model = cm("<p>{text</p><pre><code>code\nmore code}|</code></pre>");
+    model.unordered_list();
+    assert_eq!(
+        tx(&model),
+        "<ul><li>{text</li><li>code</li><li>more code}|</li></ul>"
+    )
+}
+
+#[test]
+fn create_list_with_selected_paragraph_quote_and_code_block() {
+    let mut model = cm("<blockquote><p>{quote</p><p>more quote</p></blockquote><p>text</p><pre><code>code\nmore code}|</code></pre>");
+    model.ordered_list();
+    assert_eq!(
+        tx(&model),
+        "<ol><li>{quote</li><li>more quote</li><li>text</li><li>code</li><li>more code}|</li></ol>"
+    )
+}


### PR DESCRIPTION
* Fixes issue with list created inside a quote
* Fixes creating a list from a complex selection such as a paragraph + a quote
  * For now quote/code blocks are removed and their content is reused to create a valid list item
  * This behaviour might change in the future if we handle quote/code blocks inside lists ^
* Add Rust tests for this change