### PR TITLE
Test coverage improvements

### DIFF
--- a/platforms/web/lib/testUtils/Editor.tsx
+++ b/platforms/web/lib/testUtils/Editor.tsx
@@ -41,13 +41,25 @@ export const Editor = forwardRef<HTMLDivElement, EditorProps>(function Editor(
             key !== 'insertText' &&
             key !== 'link' &&
             key !== 'removeLinks' &&
-            key !== 'getLink',
+            key !== 'getLink' &&
+            key !== 'indent' &&
+            key !== 'unindent',
     ) as Array<
         Exclude<
             keyof typeof wysiwyg,
-            'insertText' | 'link' | 'removeLinks' | 'getLink'
+            | 'insertText'
+            | 'link'
+            | 'removeLinks'
+            | 'getLink'
+            | 'indent'
+            | 'unindent'
         >
     >;
+
+    const isInList =
+        actionStates.unorderedList === 'reversed' ||
+        actionStates.orderedList === 'reversed';
+
     return (
         <>
             {keys.map((key) => (
@@ -60,6 +72,24 @@ export const Editor = forwardRef<HTMLDivElement, EditorProps>(function Editor(
                     {key}
                 </button>
             ))}
+            {isInList && (
+                <button
+                    onClick={wysiwyg.indent}
+                    type="button"
+                    data-state={actionStates.indent}
+                >
+                    indent
+                </button>
+            )}
+            {isInList && (
+                <button
+                    onClick={wysiwyg.unindent}
+                    type="button"
+                    data-state={actionStates.unindent}
+                >
+                    unindent
+                </button>
+            )}
             <button
                 type="button"
                 onClick={() => wysiwyg.insertText('add new words')}

--- a/platforms/web/lib/useWysiwyg.formatting.test.tsx
+++ b/platforms/web/lib/useWysiwyg.formatting.test.tsx
@@ -14,13 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {
-    act,
-    fireEvent,
-    render,
-    screen,
-    waitFor,
-} from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, MutableRefObject } from 'react';
 
@@ -66,6 +60,51 @@ describe.each([
         '<p><del>fo</del>o</p><p>b<del>ar</del></p>',
         '<del>fo</del>o <del>bar</del>',
     ],
+    [
+        'orderedList',
+        'enabled',
+        'reversed',
+        '<ol><li>foo</li></ol>',
+        '<ol><li>foo bar</li></ol>',
+        '<ol><li><del>foo</del></li><li><del>bar</del></li></ol>',
+        'foo bar',
+    ],
+    [
+        'unorderedList',
+        'enabled',
+        'reversed',
+        '<ul><li>foo</li></ul>',
+        '<ul><li>foo bar</li></ul>',
+        '<ul><li><del>foo</del></li><li><del>bar</del></li></ul>',
+        'foo bar',
+    ],
+    [
+        'inlineCode',
+        'enabled',
+        'reversed',
+        '<code>foo</code>',
+        'fo<code>o&nbsp;</code>bar',
+        '<p><del>fo</del><code>o</code></p><p><code>b</code><del>ar</del></p>',
+        '<code>fo</code>o <code>bar</code>',
+    ],
+    [
+        'codeBlock',
+        'enabled',
+        'reversed',
+        '<pre><code>foo</code></pre>',
+        '<pre><code>foo bar</code></pre>',
+        '<pre><code><del>foo</del>\n<del>bar</del></code></pre>',
+        'foo bar',
+    ],
+    [
+        'quote',
+        'enabled',
+        'reversed',
+        '<blockquote><p>foo</p></blockquote>',
+        '<blockquote><p>foo bar</p></blockquote>',
+        '<blockquote><p><del>foo</del></p><p><del>bar</del></p></blockquote>',
+        'foo bar',
+    ],
 ])(
     'Formatting %s',
     (
@@ -94,25 +133,21 @@ describe.each([
             expect(button).toHaveAttribute('data-state', defaultState);
         });
 
-        it(
-            `Should be ${expectedActivationState} ` + `after single activation`,
-            async () => {
-                // When
-                await act(() => userEvent.click(button));
+        // eslint-disable-next-line max-len
+        it(`Should be ${expectedActivationState} after single activation`, async () => {
+            // When
+            await userEvent.click(button);
 
-                // Then
-                await waitFor(() =>
-                    expect(button).toHaveAttribute(
-                        'data-state',
-                        expectedActivationState,
-                    ),
-                );
-            },
-        );
+            // Then
+            expect(button).toHaveAttribute(
+                'data-state',
+                expectedActivationState,
+            );
+        });
 
         it('Should be formatted after typing', async () => {
             // When
-            await act(() => userEvent.click(button));
+            await userEvent.click(button);
             // Do not use userEvent.type
             // The generated inputEvent has missing attributes
             fireEvent.input(textbox, {
@@ -121,9 +156,7 @@ describe.each([
             });
 
             // Then
-            await waitFor(() =>
-                expect(textbox).toContainHTML(expectedSimpleFormatting),
-            );
+            expect(textbox).toContainHTML(expectedSimpleFormatting);
         });
 
         it('Should format the selection', async () => {
@@ -133,55 +166,47 @@ describe.each([
                 inputType: 'insertText',
             });
             select(textbox, 2, 4);
-            await act(() => userEvent.click(button));
+            await userEvent.click(button);
 
             // Then
-            await waitFor(() =>
-                expect(textbox).toContainHTML(expectedAdvancedFormatting),
-            );
+            expect(textbox).toContainHTML(expectedAdvancedFormatting);
         });
 
         it('Should format the selection on multiple lines', async () => {
             // When
-            await act(() =>
-                userEvent.click(
-                    screen.getByRole('button', { name: 'strikeThrough' }),
-                ),
+            await userEvent.click(
+                screen.getByRole('button', { name: 'strikeThrough' }),
             );
             fireEvent.input(textbox, {
                 data: 'foo',
                 inputType: 'insertText',
             });
-            await act(() => userEvent.type(textbox, '{enter}'));
+            await userEvent.type(textbox, '{enter}');
             fireEvent.input(textbox, {
                 data: 'bar',
                 inputType: 'insertText',
             });
 
             select(textbox, 2, 5);
-            await act(() => userEvent.click(button));
+            await userEvent.click(button);
 
             // Then
-            await waitFor(() =>
-                expect(textbox).toContainHTML(expectedMultipleLineFormatting),
-            );
+            expect(textbox).toContainHTML(expectedMultipleLineFormatting);
         });
 
         it('Should unformat the selection', async () => {
             // When
-            await act(() => userEvent.click(button));
+            await userEvent.click(button);
             fireEvent.input(textbox, {
                 data: 'foo bar',
                 inputType: 'insertText',
             });
             select(textbox, 2, 4);
-            await act(() => userEvent.click(button));
+            await userEvent.click(button);
 
             // Then
-            await waitFor(() => {
-                expect(button).toHaveAttribute('data-state', defaultState);
-                expect(textbox).toContainHTML(expectedUnformatting);
-            });
+            expect(button).toHaveAttribute('data-state', defaultState);
+            expect(textbox).toContainHTML(expectedUnformatting);
         });
     },
 );
@@ -201,10 +226,10 @@ describe('insertText', () => {
 
     it('Should insert the text when empty', async () => {
         // When
-        await act(() => userEvent.click(button));
+        await userEvent.click(button);
 
         // Then
-        await waitFor(() => expect(textbox).toContainHTML('add new words'));
+        expect(textbox).toContainHTML('add new words');
     });
 
     it('Should insert the text when ', async () => {
@@ -213,12 +238,10 @@ describe('insertText', () => {
             data: 'foo bar',
             inputType: 'insertText',
         });
-        await act(() => userEvent.click(button));
+        await userEvent.click(button);
 
         // Then
-        await waitFor(() =>
-            expect(textbox).toContainHTML('foo baradd new words'),
-        );
+        expect(textbox).toContainHTML('foo baradd new words');
     });
 });
 
@@ -245,10 +268,8 @@ describe('link', () => {
         );
 
         // Then
-        await waitFor(() =>
-            expect(textbox).toContainHTML(
-                '<a href="https://mylink.com">my text</a>',
-            ),
+        expect(textbox).toContainHTML(
+            '<a href="https://mylink.com">my text</a>',
         );
     });
 
@@ -259,10 +280,8 @@ describe('link', () => {
         await userEvent.click(screen.getByRole('button', { name: 'link' }));
 
         // Then
-        await waitFor(() =>
-            expect(textbox).toContainHTML(
-                '<a href="https://mylink.com">foobar</a>',
-            ),
+        expect(textbox).toContainHTML(
+            '<a href="https://mylink.com">foobar</a>',
         );
     });
 
@@ -277,7 +296,7 @@ describe('link', () => {
         );
 
         // Then
-        await waitFor(() => expect(textbox).toContainHTML('foobar'));
+        expect(textbox).toContainHTML('foobar');
     });
 
     it('Should get the link', async () => {
@@ -290,8 +309,6 @@ describe('link', () => {
         select(textbox, 0, 6);
 
         // Then
-        await waitFor(() =>
-            expect(actionsRef.current?.getLink()).toBe('https://mylink.com'),
-        );
+        expect(actionsRef.current?.getLink()).toBe('https://mylink.com');
     });
 });

--- a/platforms/web/lib/useWysiwyg.inputEventProcessor.test.tsx
+++ b/platforms/web/lib/useWysiwyg.inputEventProcessor.test.tsx
@@ -48,41 +48,25 @@ describe('inputEventProcessor', () => {
         });
     });
 
-    /**
-     *
-     * This fails in a flaky way. I (AndyB) spent quite a bit of time today
-     * trying to figure out why it's failing, and look for a workaround. The
-     * situation improves if you add other interactions e.g. send a `type` user
-     * event, but it still fails from time to time.
-     *
-     * There must be something we should be waiting for or similar but I really
-     * can't figure it out. I also can't see why this test is problematic and
-     * others are not.
-     *
-     * If the test is run on its own, it tends to pass, but if others are
-     * running, it is less reliable. This leads me to suspect there is a timing
-     * issue.
-     */
-    it.skip('Should call inputEventProcessor', async () => {
+    it('Should call inputEventProcessor', async () => {
         // When
-        inputEventProcessor.mockReturnValue(null);
-        fireEvent.input(textbox, {
+        const inputEvent = new InputEvent('input', {
             data: 'foo',
             inputType: 'insertText',
         });
+        inputEventProcessor.mockReturnValue(null);
+        fireEvent(textbox, inputEvent);
 
         // Then
-        await waitFor(() => {
-            expect(textbox).toHaveTextContent(/^$/);
-            expect(textbox).toHaveAttribute('data-content', '');
-            expect(inputEventProcessor).toBeCalledTimes(1);
-            expect(inputEventProcessor).toBeCalledWith(
-                new InputEvent('input', {
-                    data: 'foo',
-                    inputType: 'insertText',
-                }),
-                expect.anything(),
-            );
-        });
+        // As we're returning null from the inputEventProcessor, do not expect
+        // anything to be displayed
+        expect(textbox).toHaveTextContent('');
+        expect(textbox).toHaveAttribute('data-content', '');
+        expect(inputEventProcessor).toBeCalledTimes(1);
+        expect(inputEventProcessor).toBeCalledWith(
+            inputEvent,
+            expect.anything(),
+            expect.anything(),
+        );
     });
 });

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,16 +1,14 @@
 sonar.projectKey=matrix-rich-text-editor
 sonar.organization=matrix-org
 
-# set the sources to be everything in /web/src/ and /web/lib/ folders
+# set the source code to be everything in /web/src/ and /web/lib/ folders
 sonar.sources=platforms/web/src,platforms/web/lib
+# then do not consider any /testUtils files or any .test. files as source code
+sonar.exclusions=platforms/web/lib/testUtils/**/*,platforms/web/lib/**/*.test.*
 
 # set the tests to be everything in /web/lib/ folder
 sonar.tests=platforms/web/lib
-
-# exclude /testUtils all .test. files from the source code
-sonar.exclusions=platforms/web/lib/testUtils/**/*,platforms/web/lib/**/*.test.*
-
-# only include the the .test. files in the test code
+# then only consider .test. files as test code
 sonar.test.inclusions=platforms/web/lib/**/*.test.*
 
 sonar.typescript.tsconfigPath=platforms/web/tsconfig.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,8 +7,8 @@ sonar.sources=platforms/web/src,platforms/web/lib
 # set the tests to be everything in /web/lib/ folder
 sonar.tests=platforms/web/lib
 
-# exclude all the .test. files from the source code
-sonar.exclusions=platforms/web/lib/**/*.test.*
+# exclude all the /testUtils folder and all .test. files from the source code
+sonar.exclusions=platforms/web/lib/testUtils,platforms/web/lib/**/*.test.*
 
 # include all the .test. files in the test code
 sonar.test.inclusions=platforms/web/lib/**/*.test.*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,11 +7,11 @@ sonar.sources=platforms/web/src,platforms/web/lib
 # set the tests to be everything in /web/lib/ folder
 sonar.tests=platforms/web/lib
 
-# exclude all the /testUtils folder and all .test. files from the source code
+# exclude the /testUtils folder and all .test. files from the source code
 sonar.exclusions=platforms/web/lib/testUtils,platforms/web/lib/**/*.test.*
 
-# include all the .test. files in the test code
-sonar.test.inclusions=platforms/web/lib/**/*.test.*
+# include the /testUtils folder and all .test. files in the test code
+sonar.test.inclusions=platforms/web/lib/testUtils,platforms/web/lib/**/*.test.*
 
 sonar.typescript.tsconfigPath=platforms/web/tsconfig.json
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,8 +10,8 @@ sonar.tests=platforms/web/lib
 # exclude the /testUtils folder and all .test. files from the source code
 sonar.exclusions=platforms/web/lib/testUtils,platforms/web/lib/**/*.test.*
 
-# include the /testUtils folder and all .test. files in the test code
-sonar.test.inclusions=platforms/web/lib/testUtils,platforms/web/lib/**/*.test.*
+# only include the the .test. files in the test code
+sonar.test.inclusions=platforms/web/lib/**/*.test.*
 
 sonar.typescript.tsconfigPath=platforms/web/tsconfig.json
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,17 @@
 sonar.projectKey=matrix-rich-text-editor
 sonar.organization=matrix-org
 
+# set the sources to be everything in /web/src/ and /web/lib/ folders
 sonar.sources=platforms/web/src,platforms/web/lib
-sonar.test=platforms/web/lib
+
+# set the tests to be everything in /web/lib/ folder
+sonar.tests=platforms/web/lib
+
+# exclude all the .test. files from the source code
+sonar.exclusions=platforms/web/lib/**/*.test.*
+
+# include all the .test. files in the test code
+sonar.test.inclusions=platforms/web/lib/**/*.test.*
 
 sonar.typescript.tsconfigPath=platforms/web/tsconfig.json
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,8 +7,8 @@ sonar.sources=platforms/web/src,platforms/web/lib
 # set the tests to be everything in /web/lib/ folder
 sonar.tests=platforms/web/lib
 
-# exclude all .test. files from the source code
-sonar.exclusions=platforms/web/lib/**/*.test.*
+# exclude /testUtils all .test. files from the source code
+sonar.exclusions=platforms/web/lib/testUtils/**/*,platforms/web/lib/**/*.test.*
 
 # only include the the .test. files in the test code
 sonar.test.inclusions=platforms/web/lib/**/*.test.*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,8 +7,8 @@ sonar.sources=platforms/web/src,platforms/web/lib
 # set the tests to be everything in /web/lib/ folder
 sonar.tests=platforms/web/lib
 
-# exclude the /testUtils folder and all .test. files from the source code
-sonar.exclusions=platforms/web/lib/testUtils/*,platforms/web/lib/**/*.test.*
+# exclude all .test. files from the source code
+sonar.exclusions=platforms/web/lib/**/*.test.*
 
 # only include the the .test. files in the test code
 sonar.test.inclusions=platforms/web/lib/**/*.test.*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.sources=platforms/web/src,platforms/web/lib
 sonar.tests=platforms/web/lib
 
 # exclude the /testUtils folder and all .test. files from the source code
-sonar.exclusions=platforms/web/lib/testUtils,platforms/web/lib/**/*.test.*
+sonar.exclusions=platforms/web/lib/testUtils/*,platforms/web/lib/**/*.test.*
 
 # only include the the .test. files in the test code
 sonar.test.inclusions=platforms/web/lib/**/*.test.*


### PR DESCRIPTION
Following reactivation of the coverage reports, it showed that some of the recent work was lacking in coverage. This work:

- rectifies some of the bits that were missed by testing in recent work
- makes sonarcloud look at the correct files for source and test files to avoid spurious warnings (implemented due to warnings being raised for duplication in test files)