### PR TITLE
Fix leading whitespace getting ignored by parsers

### DIFF
--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -411,7 +411,7 @@ mod test {
         model.code_block();
         assert_eq!(
             tx(&model),
-            "<p>Text</p><p><b>code|</b><i> and italic</i></p>"
+            "<p>Text</p><p><b>code|</b><i>&nbsp;and italic</i></p>"
         );
     }
 

--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -343,7 +343,7 @@ mod test {
     fn test_new_line_in_plain_text() {
         let mut model = cm("Test| lines");
         model.enter();
-        assert_eq!(tx(&model), "<p>Test</p><p>| lines</p>");
+        assert_eq!(tx(&model), "<p>Test</p><p>|&nbsp;lines</p>");
     }
 
     #[test]
@@ -364,14 +364,14 @@ mod test {
     fn test_new_line_in_formatted_text() {
         let mut model = cm("<b>Test| lines</b>");
         model.enter();
-        assert_eq!(tx(&model), "<p><b>Test</b></p><p><b>| lines</b></p>");
+        assert_eq!(tx(&model), "<p><b>Test</b></p><p><b>|&nbsp;lines</b></p>");
     }
 
     #[test]
     fn test_new_line_in_paragraph() {
         let mut model = cm("<p>Test| lines</p>");
         model.enter();
-        assert_eq!(tx(&model), "<p>Test</p><p>| lines</p>");
+        assert_eq!(tx(&model), "<p>Test</p><p>|&nbsp;lines</p>");
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -222,6 +222,14 @@ where
                 // space with a non-breaking one.
                 escaped.replace_range(escaped.len() - 1.., "\u{A0}");
             }
+
+            if state.is_first_node_in_parent
+                && escaped.chars().next().map_or(false, |c| c == ' ')
+            {
+                // If this is the first node and it starts with a space, replace that
+                // space with a non-breaking one.
+                escaped.replace_range(..1, "\u{A0}");
+            }
         }
         buf.push(escaped.as_str());
 

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -316,21 +316,39 @@ fn insert_text_between_line_breaks_in_format_node() {
 }
 
 #[test]
-fn leading_whitespace_is_replace_with_nbsp() {
+fn leading_whitespace_is_replaced_with_nbsp() {
     let model = cm("<p> text|</p>");
     assert_eq!(tx(&model), "<p>&nbsp;text|</p>")
 }
 
 #[test]
-fn trailing_whitespace_is_replace_with_nbsp() {
+fn multiple_leading_whitespaces_are_replaced_with_nbsp() {
+    let model = cm("<p>  text|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;&nbsp;text|</p>")
+}
+
+#[test]
+fn trailing_whitespace_is_replaced_with_nbsp() {
     let model = cm("<p>text |</p>");
     assert_eq!(tx(&model), "<p>text&nbsp;|</p>")
+}
+
+#[test]
+fn multiple_trailing_whitespaces_are_replaced_with_nbsp() {
+    let model = cm("<p>text  |</p>");
+    assert_eq!(tx(&model), "<p>text&nbsp;&nbsp;|</p>")
 }
 
 #[test]
 fn leading_and_trailing_whitespace_are_both_replaced_with_nbsp() {
     let model = cm("<p> text |</p>");
     assert_eq!(tx(&model), "<p>&nbsp;text&nbsp;|</p>");
+}
+
+#[test]
+fn multiple_leading_and_trailing_whitespace_are_all_replaced_with_nbsp() {
+    let model = cm("<p>  text  |</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;&nbsp;text&nbsp;&nbsp;|</p>");
 }
 
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -315,6 +315,24 @@ fn insert_text_between_line_breaks_in_format_node() {
     assert_eq!(tx(&model), "A<br /><b>C|<br />B</b>");
 }
 
+#[test]
+fn leading_whitespace_is_replace_with_nbsp() {
+    let model = cm("<p> text|</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;text|</p>")
+}
+
+#[test]
+fn trailing_whitespace_is_replace_with_nbsp() {
+    let model = cm("<p>text |</p>");
+    assert_eq!(tx(&model), "<p>text&nbsp;|</p>")
+}
+
+#[test]
+fn leading_and_trailing_whitespace_are_both_replaced_with_nbsp() {
+    let model = cm("<p> text |</p>");
+    assert_eq!(tx(&model), "<p>&nbsp;text&nbsp;|</p>");
+}
+
 fn replace_text(model: &mut ComposerModel<Utf16String>, new_text: &str) {
     model.replace_text(utf16(new_text));
 }

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -358,7 +358,7 @@ fn deleting_selection_in_multiple_containers() {
 fn deleting_selection_of_a_container_in_multiple_containers() {
     let mut model = cm("<i><b>{test}|</b> test</i>");
     model.backspace();
-    assert_eq!(tx(&model), "<i>| test</i>");
+    assert_eq!(tx(&model), "<i>|&nbsp;test</i>");
     model.state.dom.explicitly_assert_invariants();
 }
 

--- a/crates/wysiwyg/src/tests/test_formatting.rs
+++ b/crates/wysiwyg/src/tests/test_formatting.rs
@@ -52,7 +52,7 @@ fn format_several_nodes_with_empty_text_nodes() {
     model.italic();
     model.select(Location::from(2), Location::from(17));
     model.strike_through();
-    assert_eq!(tx(&model), "<strong>so<del>{me</del></strong><del>&nbsp;</del><em><del>different</del></em><del> no}|</del>des")
+    assert_eq!(tx(&model), "<strong>so<del>{me</del></strong><del>&nbsp;</del><em><del>different</del></em><del>&nbsp;no}|</del>des")
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -658,7 +658,7 @@ fn set_link_accross_quote() {
             test_<a href=\"https://element.io\">{block_quote</a>\
         </blockquote>\
         <p>\
-            <a href=\"https://element.io\"> test}|</a>\
+            <a href=\"https://element.io\">&nbsp;test}|</a>\
         </p>"
     );
 }


### PR DESCRIPTION
* Fix issue where parser would ignore leading whitespace that are actually inserted by the user.
* Replace them in the same fashion as trailing whitespaces (nbsp)
* Add tests for both whitespace replacements
* Update some impacted Rust tests