### PR TITLE
Add commands for web

### DIFF
--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -80,6 +80,18 @@ export function processInput(
             }
             break;
         }
+        case 'insertCommand': {
+            if (suggestion && event.data) {
+                return action(
+                    composerModel.replace_text_suggestion(
+                        event.data,
+                        suggestion,
+                    ),
+                    'replace_text_suggestion',
+                );
+            }
+            break;
+        }
         case 'clear':
             return action(composerModel.clear(), 'clear');
         case 'deleteContentBackward':

--- a/platforms/web/lib/constants.ts
+++ b/platforms/web/lib/constants.ts
@@ -31,3 +31,5 @@ export const ACTION_TYPES = [
     'indent',
     'unindent',
 ] as const;
+
+export const SUGGESTIONS = ['@', '#', '/'] as const;

--- a/platforms/web/lib/suggestion.test.tsx
+++ b/platforms/web/lib/suggestion.test.tsx
@@ -1,0 +1,82 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { SuggestionPattern } from '../generated/wysiwyg';
+import { SUGGESTIONS } from './constants';
+import {
+    getSuggestionChar,
+    getSuggestionType,
+    mapSuggestion,
+} from './suggestion';
+
+describe('getSuggestionChar', () => {
+    it('returns the expected character', () => {
+        SUGGESTIONS.forEach((suggestionCharacter, index) => {
+            const suggestion = { key: index } as unknown as SuggestionPattern;
+            expect(getSuggestionChar(suggestion)).toBe(suggestionCharacter);
+        });
+    });
+
+    it('returns empty string if given index is too high', () => {
+        const suggestion = { key: 200 } as unknown as SuggestionPattern;
+        expect(getSuggestionChar(suggestion)).toBe('');
+    });
+});
+
+describe('getSuggestionType', () => {
+    it('returns the expected type for a user or room mention', () => {
+        const userSuggestion = { key: 0 } as unknown as SuggestionPattern;
+        const roomSuggestion = { key: 1 } as unknown as SuggestionPattern;
+
+        expect(getSuggestionType(userSuggestion)).toBe('mention');
+        expect(getSuggestionType(roomSuggestion)).toBe('mention');
+    });
+
+    it('returns the expected type for a slash command', () => {
+        const slashSuggestion = { key: 2 } as unknown as SuggestionPattern;
+
+        expect(getSuggestionType(slashSuggestion)).toBe('command');
+    });
+
+    it('returns unknown for any other implementations', () => {
+        const slashSuggestion = { key: 200 } as unknown as SuggestionPattern;
+
+        expect(getSuggestionType(slashSuggestion)).toBe('unknown');
+    });
+});
+
+describe('mapSuggestion', () => {
+    it('returns null when passed null', () => {
+        expect(mapSuggestion(null)).toBe(null);
+    });
+
+    it('returns the input with additional keys keyChar and type', () => {
+        const suggestion: SuggestionPattern = {
+            free: () => {},
+            start: 1,
+            end: 2,
+            key: 0,
+            text: 'some text',
+        };
+
+        const mappedSuggestion = mapSuggestion(suggestion);
+        expect(mappedSuggestion).toMatchObject(suggestion);
+        expect(mappedSuggestion).toMatchObject({
+            keyChar: '@',
+            type: 'mention',
+        });
+    });
+});

--- a/platforms/web/lib/suggestion.ts
+++ b/platforms/web/lib/suggestion.ts
@@ -1,0 +1,46 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { SuggestionPattern } from '../generated/wysiwyg';
+import { SUGGESTIONS } from './constants';
+import { MappedSuggestion, SuggestionChar, SuggestionType } from './types';
+
+function getSuggestionChar(suggestion: SuggestionPattern): SuggestionChar {
+    return SUGGESTIONS[suggestion.key];
+}
+
+function getSuggestionType(suggestion: SuggestionPattern): SuggestionType {
+    switch (suggestion.key) {
+        case 0:
+        case 1:
+            return 'mention';
+        case 2:
+            return 'command';
+        default:
+            return 'unknown';
+    }
+}
+
+export function mapSuggestion(
+    suggestion: SuggestionPattern | null,
+): MappedSuggestion | null {
+    if (suggestion === null) return suggestion;
+    return {
+        ...suggestion,
+        keyChar: getSuggestionChar(suggestion),
+        type: getSuggestionType(suggestion),
+    };
+}

--- a/platforms/web/lib/suggestion.ts
+++ b/platforms/web/lib/suggestion.ts
@@ -18,11 +18,15 @@ import { SuggestionPattern } from '../generated/wysiwyg';
 import { SUGGESTIONS } from './constants';
 import { MappedSuggestion, SuggestionChar, SuggestionType } from './types';
 
-function getSuggestionChar(suggestion: SuggestionPattern): SuggestionChar {
-    return SUGGESTIONS[suggestion.key];
+export function getSuggestionChar(
+    suggestion: SuggestionPattern,
+): SuggestionChar {
+    return SUGGESTIONS[suggestion.key] || '';
 }
 
-function getSuggestionType(suggestion: SuggestionPattern): SuggestionType {
+export function getSuggestionType(
+    suggestion: SuggestionPattern,
+): SuggestionType {
     switch (suggestion.key) {
         case 0:
         case 1:

--- a/platforms/web/lib/testUtils/Editor.tsx
+++ b/platforms/web/lib/testUtils/Editor.tsx
@@ -43,6 +43,7 @@ export const Editor = forwardRef<HTMLDivElement, EditorProps>(function Editor(
             key !== 'removeLinks' &&
             key !== 'getLink' &&
             key !== 'mention' &&
+            key !== 'command' &&
             key !== 'indent' &&
             key !== 'unindent',
     ) as Array<
@@ -53,6 +54,7 @@ export const Editor = forwardRef<HTMLDivElement, EditorProps>(function Editor(
             | 'removeLinks'
             | 'getLink'
             | 'mention'
+            | 'command'
             | 'indent'
             | 'unindent'
         >
@@ -123,6 +125,14 @@ export const Editor = forwardRef<HTMLDivElement, EditorProps>(function Editor(
                 }}
             >
                 add @mention
+            </button>
+            <button
+                type="button"
+                onClick={() => {
+                    wysiwyg.command('/test_command');
+                }}
+            >
+                add command
             </button>
             <div
                 ref={(node) => {

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -42,6 +42,7 @@ export type FormattingFunctions = Record<
     insertText: (text: string) => void;
     link: (link: string, text?: string) => void;
     mention: (link: string, text: string) => void;
+    command: (text: string) => void;
     removeLinks: () => void;
     getLink: () => string;
 };

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ACTION_TYPES } from './constants';
+import { SuggestionPattern } from '../generated/wysiwyg';
+import { ACTION_TYPES, SUGGESTIONS } from './constants';
 import { LinkEvent } from './useListeners/types';
 
 export type BlockType = InputEvent['inputType'] | 'formatInlineCode' | 'clear';
@@ -57,3 +58,10 @@ export type InputEventProcessor = (
     wysiwyg: Wysiwyg,
     editor: HTMLElement,
 ) => WysiwygEvent | null;
+
+export type SuggestionChar = typeof SUGGESTIONS[number];
+export type SuggestionType = 'mention' | 'command' | 'unknown';
+export type MappedSuggestion = Omit<SuggestionPattern, 'free'> & {
+    type: SuggestionType;
+    keyChar: SuggestionChar;
+};

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -59,7 +59,7 @@ export type InputEventProcessor = (
     editor: HTMLElement,
 ) => WysiwygEvent | null;
 
-export type SuggestionChar = typeof SUGGESTIONS[number];
+export type SuggestionChar = typeof SUGGESTIONS[number] | '';
 export type SuggestionType = 'mention' | 'command' | 'unknown';
 export type MappedSuggestion = Omit<SuggestionPattern, 'free'> & {
     type: SuggestionType;

--- a/platforms/web/lib/useFormattingFunctions.ts
+++ b/platforms/web/lib/useFormattingFunctions.ts
@@ -65,6 +65,7 @@ export function useFormattingFunctions(
             unindent: () => sendEvent('formatOutdent'),
             mention: (link: string, text: string) =>
                 sendEvent('insertSuggestion', { link, text }),
+            command: (text: string) => sendEvent('insertCommand', text),
         };
     }, [editorRef, composerModel]);
 

--- a/platforms/web/lib/useWysiwyg.formatting.test.tsx
+++ b/platforms/web/lib/useWysiwyg.formatting.test.tsx
@@ -433,9 +433,7 @@ describe('mentions', () => {
         await expect(textbox).toContainHTML(noPrefixInput);
     });
 
-    const prefixedInputs = ['@at', '#hash', '/slash'];
-
-    it.each(prefixedInputs)(
+    it.each(['@at', '#hash'])(
         'adds a mention with prefix %s',
         async (prefixedInput) => {
             // When
@@ -454,4 +452,45 @@ describe('mentions', () => {
             );
         },
     );
+});
+
+describe('commands', () => {
+    let button: HTMLButtonElement;
+    let textbox: HTMLDivElement;
+
+    beforeEach(async () => {
+        render(<Editor />);
+        textbox = screen.getByRole('textbox');
+        button = screen.getByRole('button', { name: 'add command' });
+        await waitFor(() =>
+            expect(textbox).toHaveAttribute('contentEditable', 'true'),
+        );
+    });
+
+    it('does not add a command on click with an incorrect prefix', async () => {
+        // When
+        const noPrefixInput = 'noPrefix';
+        fireEvent.input(textbox, {
+            data: noPrefixInput,
+            inputType: 'insertText',
+        });
+        await userEvent.click(button);
+
+        // Then
+        await expect(textbox).toContainHTML(noPrefixInput);
+    });
+
+    it('adds a command with prefix /slash', async () => {
+        const prefixedInput = '/slash';
+        // When
+        fireEvent.input(textbox, {
+            data: prefixedInput,
+            inputType: 'insertText',
+        });
+        await userEvent.click(button);
+
+        // Then
+        // nb this information is hardcoded in the button for this test
+        expect(textbox).toContainHTML('/test_command');
+    });
 });

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -16,26 +16,22 @@ limitations under the License.
 
 import { RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 
-import { InputEventProcessor } from './types.js';
+import {
+    InputEventProcessor,
+    SuggestionChar,
+    SuggestionType,
+} from './types.js';
 import { useFormattingFunctions } from './useFormattingFunctions';
 import { useComposerModel } from './useComposerModel';
 import { useListeners } from './useListeners';
 import { useTestCases } from './useTestCases';
 import { SuggestionPattern } from '../generated/wysiwyg.js';
+import { SUGGESTIONS } from './constants.js';
 
 export { richToPlain, plainToRich } from './conversion';
 
-export type SuggestionType = 'mention' | 'command' | 'unknown';
-export type SuggestionChar = '@' | '#' | '/';
-
-export type MappedSuggestion = Omit<SuggestionPattern, 'free'> & {
-    type: SuggestionType;
-    keyChar: SuggestionChar;
-};
-
 function getSuggestionChar(suggestion: SuggestionPattern): SuggestionChar {
-    const suggestionMap = ['@', '#', '/'] as const;
-    return suggestionMap[suggestion.key];
+    return SUGGESTIONS[suggestion.key];
 }
 
 function getSuggestionType(suggestion: SuggestionPattern): SuggestionType {

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -16,47 +16,14 @@ limitations under the License.
 
 import { RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 
-import {
-    InputEventProcessor,
-    MappedSuggestion,
-    SuggestionChar,
-    SuggestionType,
-} from './types.js';
+import { InputEventProcessor } from './types.js';
 import { useFormattingFunctions } from './useFormattingFunctions';
 import { useComposerModel } from './useComposerModel';
 import { useListeners } from './useListeners';
 import { useTestCases } from './useTestCases';
-import { SuggestionPattern } from '../generated/wysiwyg.js';
-import { SUGGESTIONS } from './constants.js';
+import { mapSuggestion } from './suggestion.js';
 
 export { richToPlain, plainToRich } from './conversion';
-
-function getSuggestionChar(suggestion: SuggestionPattern): SuggestionChar {
-    return SUGGESTIONS[suggestion.key];
-}
-
-function getSuggestionType(suggestion: SuggestionPattern): SuggestionType {
-    switch (suggestion.key) {
-        case 0:
-        case 1:
-            return 'mention';
-        case 2:
-            return 'command';
-        default:
-            return 'unknown';
-    }
-}
-
-function mapSuggestion(
-    suggestion: SuggestionPattern | null,
-): MappedSuggestion | null {
-    if (suggestion === null) return suggestion;
-    return {
-        ...suggestion,
-        keyChar: getSuggestionChar(suggestion),
-        type: getSuggestionType(suggestion),
-    };
-}
 
 function useEditorFocus(
     editorRef: RefObject<HTMLElement | null>,

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -25,6 +25,42 @@ import { SuggestionPattern } from '../generated/wysiwyg.js';
 
 export { richToPlain, plainToRich } from './conversion';
 
+export type SuggestionType = 'mention' | 'command' | 'unknown';
+export type SuggestionChar = '@' | '#' | '/';
+
+export type MappedSuggestion = Omit<SuggestionPattern, 'free'> & {
+    type: SuggestionType;
+    keyChar: SuggestionChar;
+};
+
+function getSuggestionChar(suggestion: SuggestionPattern): SuggestionChar {
+    const suggestionMap = ['@', '#', '/'] as const;
+    return suggestionMap[suggestion.key];
+}
+
+function getSuggestionType(suggestion: SuggestionPattern): SuggestionType {
+    switch (suggestion.key) {
+        case 0:
+        case 1:
+            return 'mention';
+        case 2:
+            return 'command';
+        default:
+            return 'unknown';
+    }
+}
+
+function mapSuggestion(
+    suggestion: SuggestionPattern | null,
+): MappedSuggestion | null {
+    if (suggestion === null) return suggestion;
+    return {
+        ...suggestion,
+        keyChar: getSuggestionChar(suggestion),
+        type: getSuggestionType(suggestion),
+    };
+}
+
 function useEditorFocus(
     editorRef: RefObject<HTMLElement | null>,
     isAutoFocusEnabled = false,
@@ -108,33 +144,5 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
             traceAction: testUtilities.traceAction,
         },
         suggestion: memoisedMappedSuggestion,
-    };
-}
-
-function getSuggestionChar(suggestion: SuggestionPattern) {
-    const suggestionMap = ['@', '#', '/'];
-    return suggestionMap[suggestion.key];
-}
-
-function getSuggestionType(suggestion: SuggestionPattern) {
-    switch (suggestion.key) {
-        case 0:
-        case 1:
-            return 'mention';
-        case 2:
-            return 'command';
-        default:
-            return 'unknown';
-    }
-}
-
-// TODO use this when passing the output out from the hook => this way we can
-// keep the state consistent, but use 'MappedSuggestion' type on the React side
-function mapSuggestion(suggestion: SuggestionPattern | null) {
-    if (suggestion === null) return suggestion;
-    return {
-        ...suggestion,
-        keyChar: getSuggestionChar(suggestion),
-        type: getSuggestionType(suggestion),
     };
 }

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -30,7 +30,7 @@ function useEditorFocus(
 ) {
     useEffect(() => {
         if (isAutoFocusEnabled) {
-            // TODO: remove this workaround
+            // TODO remove this workaround
             const id = setTimeout(() => editorRef.current?.focus(), 200);
             return () => clearTimeout(id);
         }

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -18,6 +18,7 @@ import { RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import {
     InputEventProcessor,
+    MappedSuggestion,
     SuggestionChar,
     SuggestionType,
 } from './types.js';

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -31,6 +31,7 @@ import quoteImage from './images/quote.svg';
 import indentImage from './images/indent.svg';
 import unindentImage from './images/unindent.svg';
 import { Wysiwyg, WysiwygEvent } from '../lib/types';
+import { SuggestionPattern } from '../generated/wysiwyg';
 
 type ButtonProps = {
     onClick: MouseEventHandler<HTMLButtonElement>;
@@ -54,6 +55,33 @@ function Button({ onClick, imagePath, alt, state }: ButtonProps) {
             <img alt={alt} src={imagePath} />
         </button>
     );
+}
+
+function getSuggestionChar(suggestion: SuggestionPattern) {
+    const suggestionMap = ['@', '#', '/'];
+    return suggestionMap[suggestion.key];
+}
+
+function getSuggestionType(suggestion: SuggestionPattern) {
+    switch (suggestion.key) {
+        case 0:
+        case 1:
+            return 'mention';
+        case 2:
+            return 'command';
+        default:
+            return 'unknown';
+    }
+}
+
+// TODO use this when passing the output out from the hook => this way we can
+// keep the state consistent, but use 'MappedSuggestion' type on the React side
+function mapSuggestion(suggestion: SuggestionPattern) {
+    return {
+        ...suggestion,
+        keyChar: getSuggestionChar(suggestion),
+        suggestionType: getSuggestionType(suggestion),
+    };
 }
 
 function App() {
@@ -187,7 +215,7 @@ function App() {
                         <button type="button" onClick={(_e) => wysiwyg.clear()}>
                             clear
                         </button>
-                        {suggestion && suggestion.key !== 2 && (
+                        {isMention(suggestion) && (
                             <button
                                 type="button"
                                 onClick={(_e) =>
@@ -197,10 +225,10 @@ function App() {
                                     )
                                 }
                             >
-                                Add mention
+                                Add {getSuggestionChar(suggestion)}mention
                             </button>
                         )}
-                        {suggestion && suggestion.key === 2 && (
+                        {isCommand(suggestion) && (
                             <button
                                 type="button"
                                 onClick={(_e) => wysiwyg.command('/spoiler ')}

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -31,7 +31,6 @@ import quoteImage from './images/quote.svg';
 import indentImage from './images/indent.svg';
 import unindentImage from './images/unindent.svg';
 import { Wysiwyg, WysiwygEvent } from '../lib/types';
-import { SuggestionPattern } from '../generated/wysiwyg';
 
 type ButtonProps = {
     onClick: MouseEventHandler<HTMLButtonElement>;
@@ -55,33 +54,6 @@ function Button({ onClick, imagePath, alt, state }: ButtonProps) {
             <img alt={alt} src={imagePath} />
         </button>
     );
-}
-
-function getSuggestionChar(suggestion: SuggestionPattern) {
-    const suggestionMap = ['@', '#', '/'];
-    return suggestionMap[suggestion.key];
-}
-
-function getSuggestionType(suggestion: SuggestionPattern) {
-    switch (suggestion.key) {
-        case 0:
-        case 1:
-            return 'mention';
-        case 2:
-            return 'command';
-        default:
-            return 'unknown';
-    }
-}
-
-// TODO use this when passing the output out from the hook => this way we can
-// keep the state consistent, but use 'MappedSuggestion' type on the React side
-function mapSuggestion(suggestion: SuggestionPattern) {
-    return {
-        ...suggestion,
-        keyChar: getSuggestionChar(suggestion),
-        suggestionType: getSuggestionType(suggestion),
-    };
 }
 
 function App() {
@@ -215,7 +187,7 @@ function App() {
                         <button type="button" onClick={(_e) => wysiwyg.clear()}>
                             clear
                         </button>
-                        {isMention(suggestion) && (
+                        {suggestion && suggestion.type === 'mention' && (
                             <button
                                 type="button"
                                 onClick={(_e) =>
@@ -225,10 +197,10 @@ function App() {
                                     )
                                 }
                             >
-                                Add {getSuggestionChar(suggestion)}mention
+                                Add {suggestion.keyChar}mention
                             </button>
                         )}
-                        {isCommand(suggestion) && (
+                        {suggestion && suggestion.type === 'command' && (
                             <button
                                 type="button"
                                 onClick={(_e) => wysiwyg.command('/spoiler ')}

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -187,7 +187,7 @@ function App() {
                         <button type="button" onClick={(_e) => wysiwyg.clear()}>
                             clear
                         </button>
-                        {suggestion && (
+                        {suggestion && suggestion.key !== 2 && (
                             <button
                                 type="button"
                                 onClick={(_e) =>
@@ -198,6 +198,14 @@ function App() {
                                 }
                             >
                                 Add mention
+                            </button>
+                        )}
+                        {suggestion && suggestion.key === 2 && (
+                            <button
+                                type="button"
+                                onClick={(_e) => wysiwyg.command('/spoiler ')}
+                            >
+                                Add /spoiler command
                             </button>
                         )}
                     </div>


### PR DESCRIPTION
This PR:

- integrates commands into the example app
- maps the suggestions output from the `useWysiwyg` hook to make them easier to use on the JS side of things
- adds test for the new functions relating to suggestions
- adds types for the new `MappedSuggestion` type