### PR TITLE
Fix mention command output

### DIFF
--- a/platforms/web/lib/suggestion.test.tsx
+++ b/platforms/web/lib/suggestion.test.tsx
@@ -73,10 +73,10 @@ describe('mapSuggestion', () => {
         };
 
         const mappedSuggestion = mapSuggestion(suggestion);
-        expect(mappedSuggestion).toMatchObject(suggestion);
         expect(mappedSuggestion).toMatchObject({
             keyChar: '@',
             type: 'mention',
+            text: suggestion.text,
         });
     });
 });

--- a/platforms/web/lib/suggestion.ts
+++ b/platforms/web/lib/suggestion.ts
@@ -43,7 +43,7 @@ export function mapSuggestion(
 ): MappedSuggestion | null {
     if (suggestion === null) return suggestion;
     return {
-        ...suggestion,
+        text: suggestion.text,
         keyChar: getSuggestionChar(suggestion),
         type: getSuggestionType(suggestion),
     };

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { SuggestionPattern } from '../generated/wysiwyg';
 import { ACTION_TYPES, SUGGESTIONS } from './constants';
 import { LinkEvent } from './useListeners/types';
 
@@ -61,7 +60,8 @@ export type InputEventProcessor = (
 
 export type SuggestionChar = typeof SUGGESTIONS[number] | '';
 export type SuggestionType = 'mention' | 'command' | 'unknown';
-export type MappedSuggestion = Omit<SuggestionPattern, 'free'> & {
-    type: SuggestionType;
+export type MappedSuggestion = {
     keyChar: SuggestionChar;
+    text: string;
+    type: SuggestionType;
 };


### PR DESCRIPTION
It turns out my plan for changing the output from the wysiwyg hook just doesn't work. We can either export the `suggestion` directly, in which case it works as planned, or we need to manually pick the properties we want. We can't do both.

Have elected to only select properties as and when required, which I think is the neater way of doing it.

Also updated the type that element web will receive and a test that broke after the type change