### PR TITLE
Fix plain text mode pill flush

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -200,6 +200,7 @@ public extension WysiwygComposerViewModel {
     func clearContent() {
         if plainTextMode {
             textView.attributedText = NSAttributedString(string: "", attributes: defaultTextAttributes)
+            updateCompressedHeightIfNeeded()
         } else {
             applyUpdate(model.clear())
         }
@@ -313,7 +314,7 @@ public extension WysiwygComposerViewModel {
 
     func select(range: NSRange) {
         do {
-            guard let text = textView.attributedText else { return }
+            guard let text = textView.attributedText, !plainTextMode else { return }
             let htmlSelection = try text.htmlRange(from: range)
             Logger.viewModel.logDebug(["Sel(att): \(range)",
                                        "Sel: \(htmlSelection)",
@@ -482,6 +483,7 @@ private extension WysiwygComposerViewModel {
             let attributed = NSAttributedString(string: model.getContentAsMarkdown(),
                                                 attributes: defaultTextAttributes)
             textView.attributedText = attributed
+            updateCompressedHeightIfNeeded()
         } else {
             let update = model.setContentFromMarkdown(markdown: textView.text)
             applyUpdate(update)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -72,7 +72,6 @@ public class WysiwygTextView: UITextView {
         guard content.text != attributedText || content.selection != selectedRange else { return }
 
         performWithoutDelegate {
-            flusher.flush()
             self.attributedText = content.text
             // Set selection to {0, 0} then to expected position
             // avoids an issue with autocapitalization.
@@ -82,6 +81,12 @@ public class WysiwygTextView: UITextView {
             // Force redraw when applying content
             // FIXME: this could be improved further as we sometimes draw twice in a row.
             self.drawBackgroundStyleLayers()
+        }
+    }
+
+    override public var attributedText: NSAttributedString! {
+        willSet {
+            flusher.flush()
         }
     }
     


### PR DESCRIPTION
* Fixes an issue with pill not clearing when switching to plain text mode.
* Recomputes the size of the field when the content is explicitly set during plain text mode (e.g. when clearing because a message has been sent, or right after a switch to plain text mode)
* Remove an unnecessary call to `select` when plain text mode is active