### PR TITLE
Fix plain text mode markdown with Pills

### DIFF
--- a/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
+++ b/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		A68E713C291D34A50023CC04 /* View+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C2157428C0E95C00C8E727 /* View+Accessibility.swift */; };
 		A68E7140291D40710023CC04 /* WysiwygSharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68E713F291D40710023CC04 /* WysiwygSharedConstants.swift */; };
 		A68E7141291D40710023CC04 /* WysiwygSharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68E713F291D40710023CC04 /* WysiwygSharedConstants.swift */; };
+		A69356B229BB71F700A81F71 /* WysiwygUITests+PlainTextMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69356B129BB71F700A81F71 /* WysiwygUITests+PlainTextMode.swift */; };
 		A6C2157528C0E95C00C8E727 /* View+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C2157428C0E95C00C8E727 /* View+Accessibility.swift */; };
 		A6C2157928C0F62000C8E727 /* WysiwygActionToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C2157828C0F62000C8E727 /* WysiwygActionToolbar.swift */; };
 		A6C2157C28C0FAAD00C8E727 /* WysiwygAction+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C2157B28C0FAAD00C8E727 /* WysiwygAction+Utils.swift */; };
@@ -74,6 +75,7 @@
 		A6852F022981643900632252 /* WysiwygUITests+Lists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WysiwygUITests+Lists.swift"; sourceTree = "<group>"; };
 		A6852F042981661000632252 /* WysiwygUITests+Indent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WysiwygUITests+Indent.swift"; sourceTree = "<group>"; };
 		A68E713F291D40710023CC04 /* WysiwygSharedConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygSharedConstants.swift; sourceTree = "<group>"; };
+		A69356B129BB71F700A81F71 /* WysiwygUITests+PlainTextMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WysiwygUITests+PlainTextMode.swift"; sourceTree = "<group>"; };
 		A6C2157428C0E95C00C8E727 /* View+Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Accessibility.swift"; sourceTree = "<group>"; };
 		A6C2157828C0F62000C8E727 /* WysiwygActionToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygActionToolbar.swift; sourceTree = "<group>"; };
 		A6C2157B28C0FAAD00C8E727 /* WysiwygAction+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WysiwygAction+Utils.swift"; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				A64AB141296C744200F08494 /* WysiwygUITests+InlineCode.swift */,
 				A64AB13F296C73CE00F08494 /* WysiwygUITests+Links.swift */,
 				A6852F022981643900632252 /* WysiwygUITests+Lists.swift */,
+				A69356B129BB71F700A81F71 /* WysiwygUITests+PlainTextMode.swift */,
 				A64AB145296C759A00F08494 /* WysiwygUITests+Quotes.swift */,
 				A661FDA629B0ACB400E799A6 /* WysiwygUITests+Suggestions.swift */,
 				A64AB13D296C732500F08494 /* WysiwygUITests+Typing.swift */,
@@ -431,6 +434,7 @@
 				A6852F032981643900632252 /* WysiwygUITests+Lists.swift in Sources */,
 				A68E713C291D34A50023CC04 /* View+Accessibility.swift in Sources */,
 				A64AB146296C759A00F08494 /* WysiwygUITests+Quotes.swift in Sources */,
+				A69356B229BB71F700A81F71 /* WysiwygUITests+PlainTextMode.swift in Sources */,
 				A64AB142296C744200F08494 /* WysiwygUITests+InlineCode.swift in Sources */,
 				A64AB148296C769000F08494 /* WysiwygUITests+CodeBlocks.swift in Sources */,
 			);

--- a/platforms/ios/example/Wysiwyg/Pills/WysiwygAttachmentView.swift
+++ b/platforms/ios/example/Wysiwyg/Pills/WysiwygAttachmentView.swift
@@ -61,6 +61,7 @@ class WysiwygAttachmentView: UIView {
         label.text = pillData.displayName
         label.font = pillData.font
         label.textColor = UIColor.label
+        label.accessibilityIdentifier = "WysiwygAttachmentViewLabel" + pillData.displayName
         let labelSize = label.sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude,
                                                   height: sizes.pillBackgroundHeight))
         label.frame = CGRect(x: sizes.displaynameLabelLeading,

--- a/platforms/ios/example/Wysiwyg/Pills/WysiwygPermalinkReplacer.swift
+++ b/platforms/ios/example/Wysiwyg/Pills/WysiwygPermalinkReplacer.swift
@@ -15,18 +15,70 @@
 //
 
 import Foundation
-import HTMLParser
 import UIKit
+import WysiwygComposer
 
 final class WysiwygPermalinkReplacer: PermalinkReplacer {
-    func replacementForLink(_ link: String, text: String) -> NSAttributedString? {
+    func replacementForLink(_ url: String, text: String) -> NSAttributedString? {
         if #available(iOS 15.0, *),
-           link.starts(with: "https://matrix.to/#/"),
+           url.starts(with: "https://matrix.to/#/"),
            let attachment = WysiwygTextAttachment(displayName: text,
+                                                  url: url,
                                                   font: UIFont.preferredFont(forTextStyle: .body)) {
             return NSAttributedString(attachment: attachment)
         } else {
             return nil
         }
+    }
+
+    func postProcessMarkdown(in attributedString: NSAttributedString) -> NSAttributedString {
+        // Create a regexp that detects markdown links.
+        let pattern = "\\[([^\\]]+)\\]\\(([^\\)\"\\s]+)(?:\\s+\"(.*)\")?\\)"
+        guard #available(iOS 15.0, *),
+              let regExp = try? NSRegularExpression(pattern: pattern) else {
+            return attributedString
+        }
+
+        let matches = regExp.matches(in: attributedString.string,
+                                     range: .init(location: 0, length: attributedString.length))
+
+        // If we have some matches, replace permalinks by a pill version.
+        let mutable = NSMutableAttributedString(attributedString: attributedString)
+        for match in matches.reversed() {
+            let displayNameRange = match.range(at: 1)
+            let urlRange = match.range(at: 2)
+            let displayName = attributedString.attributedSubstring(from: displayNameRange).string
+            var url = attributedString.attributedSubstring(from: urlRange).string
+
+            // Note: a valid markdown link can be written with
+            // enclosing <..>, remove them for userId detection.
+            if url.first == "<", url.last == ">" {
+                url = String(url[url.index(after: url.startIndex)...url.index(url.endIndex, offsetBy: -2)])
+            }
+
+            if url.starts(with: "https://matrix.to/#/"),
+               let attachment = WysiwygTextAttachment(displayName: displayName,
+                                                      url: url,
+                                                      font: UIFont.preferredFont(forTextStyle: .body)) {
+                mutable.replaceCharacters(in: match.range, with: NSAttributedString(attachment: attachment))
+            }
+        }
+
+        return mutable
+    }
+
+    func restoreMarkdown(in attributedString: NSAttributedString) -> String {
+        guard #available(iOS 15.0, *) else { return attributedString.string }
+
+        let newAttr = NSMutableAttributedString(attributedString: attributedString)
+        newAttr.enumerateTypedAttribute(.attachment) { (attachment: WysiwygTextAttachment, range: NSRange, _) in
+            if let displayName = attachment.data?.displayName,
+               let url = attachment.data?.url {
+                let markdownString = "[\(displayName)](\(url))"
+                newAttr.replaceCharacters(in: range, with: markdownString)
+            }
+        }
+
+        return newAttr.string
     }
 }

--- a/platforms/ios/example/Wysiwyg/Pills/WysiwygPermalinkReplacer.swift
+++ b/platforms/ios/example/Wysiwyg/Pills/WysiwygPermalinkReplacer.swift
@@ -51,7 +51,7 @@ final class WysiwygPermalinkReplacer: PermalinkReplacer {
             var url = attributedString.attributedSubstring(from: urlRange).string
 
             // Note: a valid markdown link can be written with
-            // enclosing <..>, remove them for userId detection.
+            // enclosing <..>, remove them for url check.
             if url.first == "<", url.last == ">" {
                 url = String(url[url.index(after: url.startIndex)...url.index(url.endIndex, offsetBy: -2)])
             }

--- a/platforms/ios/example/Wysiwyg/Pills/WysiwygTextAttachment.swift
+++ b/platforms/ios/example/Wysiwyg/Pills/WysiwygTextAttachment.swift
@@ -52,10 +52,13 @@ class WysiwygTextAttachment: NSTextAttachment {
     ///
     /// - Parameters:
     ///   - displayName: the display name for the pill
+    ///   - url: The absolute URL for the item.
     ///   - font: the text font
     convenience init?(displayName: String,
+                      url: String,
                       font: UIFont) {
         let data = WysiwygTextAttachmentData(displayName: displayName,
+                                             url: url,
                                              font: font)
 
         guard let encodedData = try? Self.serializationService.serialize(data) else {

--- a/platforms/ios/example/Wysiwyg/Pills/WysiwygTextAttachmentData.swift
+++ b/platforms/ios/example/Wysiwyg/Pills/WysiwygTextAttachmentData.swift
@@ -24,6 +24,8 @@ struct WysiwygTextAttachmentData: Codable {
 
     /// Display name.
     var displayName: String
+    /// The absolute URL for the item.
+    var url: String
     /// Font for the display name
     var font: UIFont
 
@@ -33,10 +35,13 @@ struct WysiwygTextAttachmentData: Codable {
     ///
     /// - Parameters:
     ///   - displayName: Item display name (user or room display name)
+    ///   - url: The absolute URL for the item.
     ///   - font: Font for the display name
     init(displayName: String,
+         url: String,
          font: UIFont) {
         self.displayName = displayName
+        self.url = url
         self.font = font
     }
 
@@ -44,6 +49,7 @@ struct WysiwygTextAttachmentData: Codable {
 
     enum CodingKeys: String, CodingKey {
         case displayName
+        case url
         case font
     }
 
@@ -54,6 +60,7 @@ struct WysiwygTextAttachmentData: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         displayName = try container.decode(String.self, forKey: .displayName)
+        url = try container.decode(String.self, forKey: .url)
         let fontData = try container.decode(Data.self, forKey: .font)
         if let font = try NSKeyedUnarchiver.unarchivedObject(ofClass: UIFont.self, from: fontData) {
             self.font = font
@@ -65,6 +72,7 @@ struct WysiwygTextAttachmentData: Codable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(displayName, forKey: .displayName)
+        try container.encode(url, forKey: .url)
         let fontData = try NSKeyedArchiver.archivedData(withRootObject: font, requiringSecureCoding: false)
         try container.encode(fontData, forKey: .font)
     }

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+PlainTextMode.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+PlainTextMode.swift
@@ -1,0 +1,62 @@
+//
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+extension WysiwygUITests {
+    func testMarkdownFromPlainTextModeIsParsed() throws {
+        textView.typeTextCharByChar("text ")
+        button(.plainRichButton).tap()
+        textView.typeTextCharByChar("__bold__ *italic*")
+        assertTextViewContent("text __bold__ *italic*")
+        button(.plainRichButton).tap()
+        assertTextViewContent("text bold italic")
+        assertTreeEquals(
+            """
+            ├>"text "
+            ├>strong
+            │ └>"bold"
+            ├>" "
+            └>em
+              └>"italic"
+            """
+        )
+        // Re-toggling restores the markdown.
+        button(.plainRichButton).tap()
+        assertTextViewContent("text __bold__ *italic*")
+    }
+
+    func testPlainTextModePreservesPills() throws {
+        // Create a Pill in RTE.
+        textView.typeTextCharByChar("@ali")
+        button(.aliceButton).tap()
+        // Switch to plain text mode and assert Pill exists
+        button(.plainRichButton).tap()
+        assertMatchingPill("Alice")
+        // Write something.
+        textView.typeTextCharByChar("hello")
+        // Switch back to RTE and assert model.
+        button(.plainRichButton).tap()
+        assertMatchingPill("Alice")
+        assertTreeEquals(
+            """
+            ├>a "https://matrix.to/#/@alice:matrix.org"
+            │ └>"Alice"
+            └>" hello"
+            """
+        )
+    }
+}

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Suggestions.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Suggestions.swift
@@ -21,6 +21,7 @@ extension WysiwygUITests {
         textView.typeTextCharByChar("@ali")
         XCTAssertTrue(button(.aliceButton).exists)
         button(.aliceButton).tap()
+        assertMatchingPill("Alice")
         // Mention is replaced by a pill view, so there
         // is only the space after it in the field.
         assertTextViewContent("￼\u{00A0}")

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -119,12 +119,22 @@ internal extension WysiwygUITests {
         id.rawValue
     }
     
-    /// Shows or updates the current tree content of the text view and checks if is equal to provided content
+    /// Check if the current tree content of the text view is equal to provided content
     ///
     /// - Parameter content: the tree content to assert, must be provided without newlines at the start and at the end.
     func assertTreeEquals(_ content: String) {
         sleep(1)
         XCTAssertEqual(staticText(.treeText).label, "\n\(content)\n")
+    }
+
+    /// Assert that a Pill for given `displayName` currently
+    /// exists in the text view and that the label matches.
+    ///
+    /// - Parameter displayName: The display name for the Pill.
+    func assertMatchingPill(_ displayName: String) {
+        let pill = textView.staticTexts["WysiwygAttachmentViewLabel" + displayName]
+        XCTAssertTrue(pill.exists)
+        XCTAssertEqual(pill.label, displayName)
     }
 }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
@@ -42,10 +42,10 @@ extension NSMutableAttributedString {
     }
 
     /// Replace parts of the attributed string that represents links by
-    /// a new attributed string part provided by the hosting app `PermalinkReplacer`.
+    /// a new attributed string part provided by the hosting app `HTMLPermalinkReplacer`.
     ///
     /// - Parameter permalinkReplacer: The permalink replacer providing new attributed strings.
-    func replaceLinks(with permalinkReplacer: PermalinkReplacer) {
+    func replaceLinks(with permalinkReplacer: HTMLPermalinkReplacer) {
         enumerateTypedAttribute(.link) { (url: URL, range: NSRange, _) in
             if let replacement = permalinkReplacer.replacementForLink(
                 url.absoluteString,

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
@@ -57,13 +57,14 @@ public final class HTMLParser {
     ///
     /// - Parameters:
     ///   - html: HTML to parse
-    ///   - encoding: string encoding to use
-    ///   - style: style to apply for HTML parsing
-    /// - Returns: an attributed string representation of the HTML content
+    ///   - encoding: String encoding to use
+    ///   - style: Style to apply for HTML parsing
+    ///   - permalinkReplacer:An object that might replace detected links.
+    /// - Returns: An attributed string representation of the HTML content
     public static func parse(html: String,
                              encoding: String.Encoding = .utf16,
                              style: HTMLParserStyle = .standard,
-                             permalinkReplacer: PermalinkReplacer? = nil) throws -> NSAttributedString {
+                             permalinkReplacer: HTMLPermalinkReplacer? = nil) throws -> NSAttributedString {
         guard !html.isEmpty else {
             return NSAttributedString(string: "")
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLPermalinkReplacer.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLPermalinkReplacer.swift
@@ -17,15 +17,15 @@
 import Foundation
 
 /// Defines an API for permalink replacement with other objects (e.g. pills)
-public protocol PermalinkReplacer {
+public protocol HTMLPermalinkReplacer {
     /// Called when the parser of the composer steps upon a link.
     /// This can be used to provide custom attributed string parts, such
     /// as a pillified representation of a link.
     /// If nothing is provided, the composer will use a standard link.
     ///
     /// - Parameters:
-    ///   - link: URL of the link
+    ///   - url: URL of the link
     ///   - text: Text of the link
     /// - Returns: Replacement for the attributed link.
-    func replacementForLink(_ link: String, text: String) -> NSAttributedString?
+    func replacementForLink(_ url: String, text: String) -> NSAttributedString?
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -88,6 +88,9 @@ public class WysiwygTextView: UITextView {
         willSet {
             flusher.flush()
         }
+        didSet {
+            delegate?.textViewDidChange?(self)
+        }
     }
     
     override public func draw(_ rect: CGRect) {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/PermalinkReplacer.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/PermalinkReplacer.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import HTMLParser
+
+/// Extension protocol for HTMLParser's `HTMLPermalinkReplacer` that handles replacement for markdown.
+public protocol PermalinkReplacer: HTMLPermalinkReplacer {
+    /// Called when the composer switches to plain text mode or when
+    /// the client sets an HTML body as the current content of the composer
+    /// in plain text mode. Provides the ability for the client to replace
+    /// e.g. markdown links with a pillified representation.
+    ///
+    /// - Parameter attributedString: An attributed string containing the parsed markdown.
+    /// - Returns: An attributed string with replaced content.
+    func postProcessMarkdown(in attributedString: NSAttributedString) -> NSAttributedString
+
+    /// Called when the composer switches out of plain text mode.
+    /// Provides the ability for the client to restore a markdown-valid content
+    /// for items altered using `postProcessMarkdown`.
+    ///
+    /// - Parameter attributedString: An attributed string containing the current content of the text view.
+    /// - Returns: A valid markdown string.
+    func restoreMarkdown(in attributedString: NSAttributedString) -> String
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/HTMLParserTests/HTMLParserTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/HTMLParserTests/HTMLParserTests.swift
@@ -70,7 +70,7 @@ final class HTMLParserTests: XCTestCase {
 
     func testReplaceLinks() throws {
         let html = "<a href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>:\(String.nbsp)"
-        let attributed = try HTMLParser.parse(html: html, permalinkReplacer: CustomPermalinkReplacer())
+        let attributed = try HTMLParser.parse(html: html, permalinkReplacer: CustomHTMLPermalinkReplacer())
         // A text attachment is added.
         XCTAssertTrue(attributed.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
         // The original length is added to the new part of the attributed string.
@@ -92,9 +92,9 @@ final class HTMLParserTests: XCTestCase {
     }
 }
 
-private class CustomPermalinkReplacer: PermalinkReplacer {
-    func replacementForLink(_ link: String, text: String) -> NSAttributedString? {
-        if link.starts(with: "https://matrix.to/#/"),
+private class CustomHTMLPermalinkReplacer: HTMLPermalinkReplacer {
+    func replacementForLink(_ url: String, text: String) -> NSAttributedString? {
+        if url.starts(with: "https://matrix.to/#/"),
            let image = UIImage(systemName: "link") {
             // Set a text attachment with an arbitrary image.
             return NSAttributedString(attachment: NSTextAttachment(image: image))


### PR DESCRIPTION
* API update for PermalinkReplacer (rename link -> url, protocol is now decomposed between HTML parsing requirements and other composer requirements)
* Allow for the client to post process markdown right before it is set in the text view in plain text mode
* Allow for the client to restore altered markdown when switching to RTE
* Plain text mode content is now published in order for the client to implement some pattern detection in plain text mode
* Added Pills representation in plain text mode in the example app & UI tests for it