### PR TITLE
[iOS] Disable link action when selection contains/touches Pills

### DIFF
--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Suggestions.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Suggestions.swift
@@ -32,6 +32,13 @@ extension WysiwygUITests {
             └>" "
             """
         )
+        // Removing the whitespace afterwards disables the
+        // link button as the caret is right after the pill.
+        app.keys["delete"].tap()
+        XCTAssertFalse(button(.linkButton).isEnabled)
+        // Link button can be re-enabled.
+        app.keys["space"].tap()
+        XCTAssertTrue(button(.linkButton).isEnabled)
     }
 
     func testHashMention() throws {

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Attributes.swift
@@ -67,4 +67,33 @@ public extension NSAttributedString {
         let color = attribute(.backgroundColor, at: index, effectiveRange: nil) as? UIColor
         return color ?? .clear
     }
+
+    /// Computes whether given range or its surroundings contains
+    /// a link that has been replaced with something else (e.g.: a pill)
+    ///
+    /// - Parameter range: the range to lookup
+    /// - Returns: a boolean indicating the result
+    func hasReplacementLinkNear(in range: NSRange) -> Bool {
+        var hasInnerReplacement = false
+        enumerateTypedAttribute(.originalLength, in: range) { (_: Int, _, stop) in
+            hasInnerReplacement = true
+            stop.pointee = true
+        }
+        return hasInnerReplacement
+            || hasAttribute(.originalLength, at: range.location - 1)
+            || hasAttribute(.originalLength, at: range.upperBound)
+    }
+}
+
+private extension NSAttributedString {
+    /// Computes whether the attributed string contains given attribute at index.
+    ///
+    /// - Parameters:
+    ///   - attrName: the key for the attribute to test
+    ///   - index: the index to lookup
+    /// - Returns: a boolean indicating the result
+    func hasAttribute(_ attrName: NSAttributedString.Key, at index: Int) -> Bool {
+        guard index >= 0, index < length else { return false }
+        return attribute(attrName, at: index, effectiveRange: nil) != nil
+    }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Attributes.swift
@@ -75,13 +75,13 @@ public extension NSAttributedString {
     /// - Returns: a boolean indicating the result
     func hasReplacementLinkNear(in range: NSRange) -> Bool {
         var hasInnerReplacement = false
-        enumerateTypedAttribute(.originalLength, in: range) { (_: Int, _, stop) in
+        enumerateTypedAttribute(.replacementContent, in: range) { (_: ReplacementContent, _, stop) in
             hasInnerReplacement = true
             stop.pointee = true
         }
         return hasInnerReplacement
-            || hasAttribute(.originalLength, at: range.location - 1)
-            || hasAttribute(.originalLength, at: range.upperBound)
+            || hasAttribute(.replacementContent, at: range.location - 1)
+            || hasAttribute(.replacementContent, at: range.upperBound)
     }
 }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
@@ -91,8 +91,8 @@ extension NSAttributedString {
     func replacementTextRanges(in range: NSRange? = nil) -> [(range: NSRange, offset: Int)] {
         var ranges = [(NSRange, Int)]()
 
-        enumerateTypedAttribute(.originalLength) { (originalLength: Int, range: NSRange, _) in
-            ranges.append((range, range.length - originalLength))
+        enumerateTypedAttribute(.replacementContent) { (replacementContent: ReplacementContent, range: NSRange, _) in
+            ranges.append((range, range.length - replacementContent.originalLength))
         }
 
         return ranges

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString.Key.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString.Key.swift
@@ -31,7 +31,7 @@ extension NSAttributedString.Key {
     /// Attribute for parts of the string that should be removed for HTML selection computation.
     /// Should include both placeholder characters such as NBSP and ZWSP, as well as list prefixes.
     static let discardableText: NSAttributedString.Key = .init(rawValue: "DiscardableAttributeKey")
-    /// Attributes for original length of a replaced element. This should be added anytime a part of the attributed string
+    /// Attribute for a replacement element. This should be added anytime a part of the attributed string
     /// is replaced, in order for the composer to compute the expected HTML/attributed range properly.
-    static let originalLength: NSAttributedString.Key = .init(rawValue: "OriginalLengthAttributeKey")
+    static let replacementContent: NSAttributedString.Key = .init(rawValue: "ReplacementContentAttributeKey")
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSMutableAttributedString.swift
@@ -52,8 +52,8 @@ extension NSMutableAttributedString {
                 text: self.mutableString.substring(with: range)
             ) {
                 self.replaceCharacters(in: range, with: replacement)
-                self.addAttribute(.originalLength,
-                                  value: range.length,
+                self.addAttribute(.replacementContent,
+                                  value: ReplacementContent(originalLength: range.length),
                                   range: .init(location: range.location, length: replacement.length))
             }
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/ReplacementContent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/ReplacementContent.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// A struct that can be used as an attribute to reflect replaced content in the `NSAttributedString`.
+struct ReplacementContent {
+    /// The original length of the content that has been replaced.
+    let originalLength: Int
+}

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -40,6 +40,8 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
 
     /// The composer minimal height.
     public let minHeight: CGFloat
+    /// The permalink replacer defined by the hosting application.
+    public var permalinkReplacer: PermalinkReplacer?
     /// Published object for the composer attributed content.
     @Published public var attributedContent: WysiwygComposerAttributedContent = .init()
     /// Published value for the content of the text view in plain text mode.
@@ -117,8 +119,7 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
     }
 
     private var hasPendingFormats = false
-
-    public var permalinkReplacer: PermalinkReplacer?
+    private var storedLinkActionState: ActionState?
 
     // MARK: - Public
 
@@ -407,6 +408,7 @@ private extension WysiwygComposerViewModel {
         switch update.menuState() {
         case let .update(actionStates: actionStates):
             self.actionStates = actionStates
+            storedLinkActionState = actionStates[.link]
         default:
             break
         }
@@ -418,6 +420,17 @@ private extension WysiwygComposerViewModel {
             suggestionPattern = nil
         case let .suggestion(suggestionPattern: pattern):
             suggestionPattern = pattern
+        }
+
+        disableLinkActionIfNeeded()
+    }
+
+    /// Disable the link action button if we are near a pillified version of a link.
+    func disableLinkActionIfNeeded() {
+        if attributedContent.text.hasReplacementLinkNear(in: attributedContent.selection) {
+            actionStates[.link] = .disabled
+        } else {
+            actionStates[.link] = storedLinkActionState
         }
     }
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/HTMLParserTests/HTMLParserTests+PermalinkReplacer.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/HTMLParserTests/HTMLParserTests+PermalinkReplacer.swift
@@ -24,8 +24,9 @@ extension HTMLParserTests {
         // A text attachment is added.
         XCTAssertTrue(attributed.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
         // The original length is added to the new part of the attributed string.
+        let replacementContent = attributed.attribute(.replacementContent, at: 0, effectiveRange: nil) as? ReplacementContent
         XCTAssertEqual(
-            attributed.attribute(.originalLength, at: 0, effectiveRange: nil) as? Int,
+            replacementContent?.originalLength,
             5
         )
         // HTML and attributed range matches


### PR DESCRIPTION
* Disable link button when a link is replaced by a pill
* Update tests for this use case