### PR TITLE
Auto-insert a whitespace after creating a link with text

### DIFF
--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -58,8 +58,7 @@ where
         self.do_replace_text_in(S::default(), suggestion.start, suggestion.end);
         self.state.start = Location::from(suggestion.start);
         self.state.end = self.state.start;
-        self.set_link_with_text(link, text);
-        self.do_replace_text(" ".into())
+        self.set_link_with_text(link, text)
     }
 
     fn is_blank_selection(&self, range: Range) -> bool {
@@ -92,6 +91,7 @@ where
         let (s, _) = self.safe_selection();
         self.push_state_to_history();
         self.do_replace_text(text.clone());
+        self.do_replace_text(" ".into());
         let e = s + text.len();
         let range = self.state.dom.find_range(s, e);
         self.set_link_in_range(link, range)

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -387,7 +387,7 @@ fn set_link_with_text() {
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "test<a href=\"https://element.io\">added_link|</a>"
+        "test<a href=\"https://element.io\">added_link</a>&nbsp;|",
     );
 }
 
@@ -397,7 +397,7 @@ fn set_link_with_text_and_undo() {
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "test<a href=\"https://element.io\">added_link|</a>"
+        "test<a href=\"https://element.io\">added_link</a>&nbsp;|",
     );
     model.undo();
     assert_eq!(tx(&model), "test|");
@@ -409,7 +409,7 @@ fn set_link_with_text_in_container() {
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "<b>test_bold<a href=\"https://element.io\">added_link|</a></b> test"
+        "<b>test_bold<a href=\"https://element.io\">added_link</a>&nbsp;|</b> test",
     );
 }
 
@@ -417,7 +417,10 @@ fn set_link_with_text_in_container() {
 fn set_link_with_text_on_blank_selection() {
     let mut model = cm("{   }|");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
-    assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
+    assert_eq!(
+        tx(&model),
+        "<a href=\"https://element.io\">added_link</a>&nbsp;|",
+    );
 }
 
 #[test]
@@ -426,7 +429,7 @@ fn set_link_with_text_on_blank_selection_after_text() {
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "test<a href=\"https://element.io\">added_link|</a>"
+        "test<a href=\"https://element.io\">added_link</a>&nbsp;|",
     );
 }
 
@@ -436,7 +439,7 @@ fn set_link_with_text_on_blank_selection_before_text() {
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "<a href=\"https://element.io\">added_link|</a>test"
+        "<a href=\"https://element.io\">added_link</a> |test",
     );
 }
 
@@ -446,7 +449,7 @@ fn set_link_with_text_on_blank_selection_between_texts() {
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "test<a href=\"https://element.io\">added_link|</a>test"
+        "test<a href=\"https://element.io\">added_link</a> |test",
     );
 }
 
@@ -456,7 +459,7 @@ fn set_link_with_text_on_blank_selection_in_container() {
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "<b>test<a href=\"https://element.io\">added_link|</a> test</b>"
+        "<b>test<a href=\"https://element.io\">added_link</a>&nbsp;|&nbsp;test</b>",
     );
 }
 
@@ -466,7 +469,7 @@ fn set_link_with_text_on_blank_selection_with_line_break() {
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "test<a href=\"https://element.io\">added_link|</a>test"
+        "test<a href=\"https://element.io\">added_link</a> |test",
     );
 }
 
@@ -474,7 +477,7 @@ fn set_link_with_text_on_blank_selection_with_line_break() {
 fn set_link_with_text_on_blank_selection_with_different_containers() {
     let mut model = cm("<b>test_bold{ </b><br>  ~ <i> }|test_italic</i>");
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
-    assert_eq!(tx(&model), "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i>test_italic</i>");
+    assert_eq!(tx(&model), "<b>test_bold<a href=\"https://element.io\">added_link</a>&nbsp;|</b><i>test_italic</i>");
 }
 
 #[test]
@@ -495,7 +498,7 @@ fn set_link_with_text_within_a_link() {
     model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "<a href=\"https://element.io\">testadded_link|_link</a>"
+        "<a href=\"https://element.io\">testadded_link |_link</a>",
     );
 }
 
@@ -503,7 +506,10 @@ fn set_link_with_text_within_a_link() {
 fn set_link_without_http_scheme_and_www() {
     let mut model = cm("|");
     model.set_link_with_text(utf16("element.io"), utf16("added_link"));
-    assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
+    assert_eq!(
+        tx(&model),
+        "<a href=\"https://element.io\">added_link</a>&nbsp;|",
+    );
 }
 
 #[test]
@@ -512,7 +518,7 @@ fn set_link_without_http_scheme() {
     model.set_link_with_text(utf16("www.element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "<a href=\"https://www.element.io\">added_link|</a>"
+        "<a href=\"https://www.element.io\">added_link</a>&nbsp;|",
     );
 }
 
@@ -525,7 +531,7 @@ fn set_link_do_not_change_scheme_for_http() {
     );
     assert_eq!(
         tx(&model),
-        "<a href=\"https://www.element.io\">added_link|</a>"
+        "<a href=\"https://www.element.io\">added_link</a>&nbsp;|",
     );
 }
 
@@ -533,7 +539,10 @@ fn set_link_do_not_change_scheme_for_http() {
 fn set_link_do_not_change_scheme_for_udp() {
     let mut model = cm("|");
     model.set_link_with_text(utf16("udp://element.io"), utf16("added_link"));
-    assert_eq!(tx(&model), "<a href=\"udp://element.io\">added_link|</a>");
+    assert_eq!(
+        tx(&model),
+        "<a href=\"udp://element.io\">added_link</a>&nbsp;|",
+    );
 }
 
 #[test]
@@ -545,7 +554,7 @@ fn set_link_do_not_change_scheme_for_mail() {
     );
     assert_eq!(
         tx(&model),
-        "<a href=\"mailto:mymail@mail.com\">added_link|</a>"
+        "<a href=\"mailto:mymail@mail.com\">added_link</a>&nbsp;|",
     );
 }
 
@@ -555,7 +564,7 @@ fn set_link_add_mail_scheme() {
     model.set_link_with_text(utf16("mymail@mail.com"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "<a href=\"mailto:mymail@mail.com\">added_link|</a>"
+        "<a href=\"mailto:mymail@mail.com\">added_link</a>&nbsp;|",
     );
 }
 
@@ -565,7 +574,7 @@ fn set_link_add_mail_scheme_with_plus() {
     model.set_link_with_text(utf16("mymail+01@mail.com"), utf16("added_link"));
     assert_eq!(
         tx(&model),
-        "<a href=\"mailto:mymail+01@mail.com\">added_link|</a>"
+        "<a href=\"mailto:mymail+01@mail.com\">added_link</a>&nbsp;|",
     );
 }
 
@@ -702,7 +711,7 @@ fn create_link_after_enter_with_formatting_applied() {
     model.set_link_with_text("https://matrix.org".into(), "test".into());
     assert_eq!(
         tx(&model),
-        "<p>test <strong>test</strong></p><p><a href=\"https://matrix.org\"><strong>test|</strong></a></p>",
+        "<p>test <strong>test</strong></p><p><strong><a href=\"https://matrix.org\">test</a>&nbsp;|</strong></p>",
     );
 }
 
@@ -713,6 +722,6 @@ fn create_link_after_enter_with_no_formatting_applied() {
     model.set_link_with_text("https://matrix.org".into(), "test".into());
     assert_eq!(
         tx(&model),
-        "<p>&nbsp;</p><p><a href=\"https://matrix.org\">test|</a></p>"
+        "<p>&nbsp;</p><p><a href=\"https://matrix.org\">test</a>&nbsp;|</p>"
     );
 }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
@@ -250,7 +250,7 @@ class EditorEditTextInputTests {
             .check(matches(TextViewMatcher {
                 it.editableText.getSpans<LinkSpan>().isNotEmpty()
             }))
-            .check(matches(withText("a Element to set")))
+            .check(matches(withText("a Element  to set")))
     }
 
     @Test

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Links.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Links.swift
@@ -28,12 +28,14 @@ extension WysiwygUITests {
         app.buttons["Ok"].tap()
         assertTreeEquals(
             """
-            └>a "https://url"
-              └>"text"
+            ├>a "https://url"
+            │ └>"text"
+            └>" "
             """
         )
 
         // Edit
+        textView.doubleTap()
         button(.linkButton).tap()
         XCTAssertFalse(textField(.linkTextTextField).exists)
         textField(.linkUrlTextField).doubleTap()
@@ -41,8 +43,9 @@ extension WysiwygUITests {
         app.buttons["Ok"].tap()
         assertTreeEquals(
             """
-            └>a "https://new_url"
-              └>"text"
+            ├>a "https://new_url"
+            │ └>"text"
+            └>" "
             """
         )
 
@@ -52,7 +55,7 @@ extension WysiwygUITests {
         app.buttons["Remove"].tap()
         assertTreeEquals(
             """
-            └>"text"
+            └>"text "
             """
         )
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -232,9 +232,7 @@ public extension WysiwygComposerViewModel {
         if let suggestionPattern, suggestionPattern.key == key {
             update = model.setLinkSuggestion(link: link, text: name, suggestion: suggestionPattern)
         } else {
-            _ = model.setLinkWithText(link: link, text: name)
-            // FIXME: remove this if Rust adds this space for free
-            update = model.replaceText(newText: " ")
+            update = model.setLinkWithText(link: link, text: name)
         }
         applyUpdate(update)
         hasPendingFormats = true

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -126,6 +126,7 @@ final class WysiwygComposerViewModelTests: XCTestCase {
     
     func testReplaceTextAfterLinkIsNotAccepted() {
         viewModel.applyLinkOperation(.createLink(urlString: "https://element.io", text: "test"))
+        _ = viewModel.replaceText(range: .init(location: 4, length: 1), replacementText: "")
         let result = viewModel.replaceText(range: .init(location: 4, length: 0), replacementText: "abc")
         XCTAssertFalse(result)
         XCTAssertEqual(viewModel.content.html, "<a href=\"https://element.io\">test</a>abc")
@@ -136,7 +137,7 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         viewModel.applyLinkOperation(.createLink(urlString: "https://element.io", text: "test"))
         let result = viewModel.replaceText(range: .init(location: 3, length: 1), replacementText: "abc")
         XCTAssertFalse(result)
-        XCTAssertEqual(viewModel.content.html, "<a href=\"https://element.io\">tes</a>abc")
+        XCTAssertEqual(viewModel.content.html, "<a href=\"https://element.io\">tes</a>abc ")
         XCTAssertTrue(viewModel.textView.attributedText.isEqual(to: viewModel.attributedContent.text))
     }
     
@@ -144,7 +145,7 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         viewModel.applyLinkOperation(.createLink(urlString: "https://element.io", text: "test"))
         let result = viewModel.replaceText(range: .init(location: 2, length: 0), replacementText: "abc")
         XCTAssertTrue(result)
-        XCTAssertEqual(viewModel.content.html, "<a href=\"https://element.io\">teabcst</a>")
+        XCTAssertEqual(viewModel.content.html, "<a href=\"https://element.io\">teabcst</a> ")
     }
 
     func testCrashRecoveryUsesLatestPlainText() {

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
@@ -34,6 +34,7 @@ extension WysiwygComposerTests {
         let link = "test_url"
         ComposerModelWrapper()
             .action { $0.setLinkWithText(link: link, text: "test") }
+            .action { $0.backspace() }
             .assertLinkAction(.edit(link: "https://\(link)"))
     }
 
@@ -43,8 +44,9 @@ extension WysiwygComposerTests {
             .assertTree(
                 """
 
-                └>a \"https://link\"
-                  └>\"text\"
+                ├>a "https://link"
+                │ └>"text"
+                └>" "
 
                 """
             )
@@ -56,8 +58,9 @@ extension WysiwygComposerTests {
             .assertTree(
                 """
 
-                └>a \"http://link\"
-                  └>\"text\"
+                ├>a "http://link"
+                │ └>"text"
+                └>" "
 
                 """
             )
@@ -69,8 +72,9 @@ extension WysiwygComposerTests {
             .assertTree(
                 """
 
-                └>a \"mailto:test@element.io\"
-                  └>\"text\"
+                ├>a "mailto:test@element.io"
+                │ └>"text"
+                └>" "
 
                 """
             )
@@ -97,11 +101,13 @@ extension WysiwygComposerTests {
             .assertTree(
                 """
 
-                └>a \"https://link\"
-                  └>\"text\"
+                ├>a "https://link"
+                │ └>"text"
+                └>" "
 
                 """
             )
+            .action { $0.backspace() }
             .action { $0.removeLinks() }
             .assertTree(
                 """


### PR DESCRIPTION
Automatically inserts a whitespace after creating a link with text (e.g. using UI elements to create the link from scratch)

Note: we can see in the updated tests (e.g. the updated Android test) that if we do that in the middle of some text where current location is followed by a whitespace already, it looks a bit whacky to insert an additional space. Do we want to lookup the next character and only insert if the following character is either inexistant or something other than a whitespace ?