### PR TITLE
Add mention attributes

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -220,7 +220,10 @@ impl ComposerModel {
         let link = Utf16String::from_str(&link);
         let text = Utf16String::from_str(&text);
         Arc::new(ComposerUpdate::from(
-            self.inner.lock().unwrap().set_link_with_text(link, text),
+            self.inner
+                .lock()
+                .unwrap()
+                .set_link_with_text(link, text, None),
         ))
     }
 

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -138,7 +138,7 @@ mod test {
         );
         assert_eq!(
             model.get_content_as_html(),
-            "<a href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>\u{a0}",
+            "<a href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\" data-mention-type=\"user\">Alice</a>\u{a0}",
         )
     }
 

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -279,6 +279,7 @@ impl ComposerModel {
         ComposerUpdate::from(self.inner.set_link_with_text(
             Utf16String::from_str(link),
             Utf16String::from_str(text),
+            None,
         ))
     }
 

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -101,7 +101,7 @@ where
         let mention_type: Option<S> = match suggestion {
             Some(_sug) => match _sug.key {
                 crate::PatternKey::At => Some("user".into()),
-                crate::PatternKey::Hash => Some("user".into()),
+                crate::PatternKey::Hash => Some("room".into()),
                 crate::PatternKey::Slash => None,
             },
             None => None,

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -131,7 +131,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(model.state.dom.to_html(), r#"A<a href="link">B</a>C"#)
@@ -145,7 +145,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(model.state.dom.to_html(), r#"<a href="link">AB</a>C"#)
@@ -159,7 +159,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(model.state.dom.to_html(), r#"A<a href="link">BC</a>"#)
@@ -173,7 +173,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(model.state.dom.to_html(), r#"<a href="link">ABC</a>"#)
@@ -187,7 +187,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(
@@ -204,7 +204,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(
@@ -221,7 +221,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(
@@ -238,7 +238,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(
@@ -255,7 +255,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(
@@ -272,7 +272,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(
@@ -290,7 +290,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(
@@ -307,7 +307,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], &None),
+            DomNode::new_link(utf16("link"), vec![], None),
         );
 
         assert_eq!(

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -129,10 +129,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(model.state.dom.to_html(), r#"A<a href="link">B</a>C"#)
     }
@@ -143,10 +143,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(model.state.dom.to_html(), r#"<a href="link">AB</a>C"#)
     }
@@ -157,10 +157,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(model.state.dom.to_html(), r#"A<a href="link">BC</a>"#)
     }
@@ -171,10 +171,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(model.state.dom.to_html(), r#"<a href="link">ABC</a>"#)
     }
@@ -185,10 +185,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -202,10 +202,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -219,10 +219,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -236,10 +236,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -253,10 +253,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -270,10 +270,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -288,10 +288,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -305,10 +305,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model
-            .state
-            .dom
-            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
+        model.state.dom.insert_parent(
+            &range,
+            DomNode::new_link(utf16("link"), vec![], &None),
+        );
 
         assert_eq!(
             model.state.dom.to_html(),

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -365,11 +365,23 @@ where
         children_len + block_nodes_extra
     }
 
-    pub fn new_link(url: S, children: Vec<DomNode<S>>) -> Self {
+    pub fn new_link(
+        url: S,
+        children: Vec<DomNode<S>>,
+        mention_type: Option<S>,
+    ) -> Self {
+        let mut attrs = vec![("href".into(), url.clone())];
+        if let Some(m_type) = mention_type {
+            // if we have a mention, add attributes to make it non-editable and to track
+            // the type of mention we have
+            attrs.push(("contenteditable".into(), "false".into()));
+            attrs.push(("data-mention-type".into(), m_type))
+        }
+        // conditionally add in the content editable and mention type if we have something
         Self {
             name: "a".into(),
-            kind: ContainerNodeKind::Link(url.clone()),
-            attrs: Some(vec![("href".into(), url)]),
+            kind: ContainerNodeKind::Link(url),
+            attrs: Some(attrs),
             children,
             handle: DomHandle::new_unset(),
         }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -377,7 +377,6 @@ where
             attrs.push(("contenteditable".into(), "false".into()));
             attrs.push(("data-mention-type".into(), m_type))
         }
-        // conditionally add in the content editable and mention type if we have something
         Self {
             name: "a".into(),
             kind: ContainerNodeKind::Link(url),

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -129,22 +129,17 @@ where
         children: Vec<DomNode<S>>,
         suggestion: &Option<SuggestionPattern>,
     ) -> DomNode<S> {
-        // now the mention type depends on the suggestion pattern
-        let mention_type: S = match suggestion {
+        // now the mention type depends on the suggestion pattern - TODO extract this somewhere
+        let mention_type: Option<S> = match suggestion {
             Some(_sug) => match _sug.key {
-                crate::PatternKey::At => "user".into(),
-                crate::PatternKey::Hash | crate::PatternKey::Slash => {
-                    "room".into()
-                }
+                crate::PatternKey::At => Some("user".into()),
+                crate::PatternKey::Hash => Some("user".into()),
+                crate::PatternKey::Slash => None,
             },
-            None => "none".into(),
+            None => None,
         };
 
-        DomNode::Container(ContainerNode::new_link(
-            url,
-            children,
-            Some(mention_type),
-        ))
+        DomNode::Container(ContainerNode::new_link(url, children, mention_type))
     }
 
     pub fn is_container_node(&self) -> bool {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -129,7 +129,8 @@ where
         children: Vec<DomNode<S>>,
         suggestion: &Option<SuggestionPattern>,
     ) -> DomNode<S> {
-        // now the mention type depends on the suggestion pattern - TODO extract this somewhere
+        // TODO instead of inferring the type from the suggestion, change the initial function
+        // call from the client to pass in the mention type when creating the link
         let mention_type: Option<S> = match suggestion {
             Some(_sug) => match _sug.key {
                 crate::PatternKey::At => Some("user".into()),

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -24,7 +24,7 @@ use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{self, UnicodeString};
-use crate::{InlineFormatType, ListType};
+use crate::{InlineFormatType, ListType, SuggestionPattern};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum DomNode<S>
@@ -124,8 +124,27 @@ where
         }
     }
 
-    pub fn new_link(url: S, children: Vec<DomNode<S>>) -> DomNode<S> {
-        DomNode::Container(ContainerNode::new_link(url, children))
+    pub fn new_link(
+        url: S,
+        children: Vec<DomNode<S>>,
+        suggestion: &Option<SuggestionPattern>,
+    ) -> DomNode<S> {
+        // now the mention type depends on the suggestion pattern
+        let mention_type: S = match suggestion {
+            Some(_sug) => match _sug.key {
+                crate::PatternKey::At => "user".into(),
+                crate::PatternKey::Hash | crate::PatternKey::Slash => {
+                    "room".into()
+                }
+            },
+            None => "none".into(),
+        };
+
+        DomNode::Container(ContainerNode::new_link(
+            url,
+            children,
+            Some(mention_type),
+        ))
     }
 
     pub fn is_container_node(&self) -> bool {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -24,7 +24,7 @@ use crate::dom::to_raw_text::ToRawText;
 use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{self, UnicodeString};
-use crate::{InlineFormatType, ListType, SuggestionPattern};
+use crate::{InlineFormatType, ListType};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum DomNode<S>
@@ -127,19 +127,8 @@ where
     pub fn new_link(
         url: S,
         children: Vec<DomNode<S>>,
-        suggestion: &Option<SuggestionPattern>,
+        mention_type: Option<S>,
     ) -> DomNode<S> {
-        // TODO instead of inferring the type from the suggestion, change the initial function
-        // call from the client to pass in the mention type when creating the link
-        let mention_type: Option<S> = match suggestion {
-            Some(_sug) => match _sug.key {
-                crate::PatternKey::At => Some("user".into()),
-                crate::PatternKey::Hash => Some("user".into()),
-                crate::PatternKey::Slash => None,
-            },
-            None => None,
-        };
-
         DomNode::Container(ContainerNode::new_link(url, children, mention_type))
     }
 

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -727,7 +727,7 @@ mod js {
                                 .unwrap_or_default()
                                 .into(),
                             self.convert(node.child_nodes())?.take_children(),
-                            &None,
+                            None,
                         ));
                         self.current_path.pop();
                     }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -271,6 +271,7 @@ mod sys {
             DomNode::Container(ContainerNode::new_link(
                 child.get_attr("href").unwrap_or("").into(),
                 Vec::new(),
+                None,
             ))
         }
 
@@ -726,6 +727,7 @@ mod js {
                                 .unwrap_or_default()
                                 .into(),
                             self.convert(node.child_nodes())?.take_children(),
+                            None,
                         ));
                         self.current_path.pop();
                     }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -727,7 +727,7 @@ mod js {
                                 .unwrap_or_default()
                                 .into(),
                             self.convert(node.child_nodes())?.take_children(),
-                            None,
+                            &None,
                         ));
                         self.current_path.pop();
                     }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -384,7 +384,11 @@ fn replace_text_in_a_link_inside_a_list_partially_selected_starting_inside_endin
 #[test]
 fn set_link_with_text() {
     let mut model = cm("test|");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>"
@@ -394,7 +398,11 @@ fn set_link_with_text() {
 #[test]
 fn set_link_with_text_and_undo() {
     let mut model = cm("test|");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>"
@@ -406,7 +414,11 @@ fn set_link_with_text_and_undo() {
 #[test]
 fn set_link_with_text_in_container() {
     let mut model = cm("<b>test_bold|</b> test");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "<b>test_bold<a href=\"https://element.io\">added_link|</a></b> test"
@@ -416,14 +428,22 @@ fn set_link_with_text_in_container() {
 #[test]
 fn set_link_with_text_on_blank_selection() {
     let mut model = cm("{   }|");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
 }
 
 #[test]
 fn set_link_with_text_on_blank_selection_after_text() {
     let mut model = cm("test{   }|");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>"
@@ -433,7 +453,11 @@ fn set_link_with_text_on_blank_selection_after_text() {
 #[test]
 fn set_link_with_text_on_blank_selection_before_text() {
     let mut model = cm("{   }|test");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "<a href=\"https://element.io\">added_link|</a>test"
@@ -443,7 +467,11 @@ fn set_link_with_text_on_blank_selection_before_text() {
 #[test]
 fn set_link_with_text_on_blank_selection_between_texts() {
     let mut model = cm("test{   }|test");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>test"
@@ -453,7 +481,11 @@ fn set_link_with_text_on_blank_selection_between_texts() {
 #[test]
 fn set_link_with_text_on_blank_selection_in_container() {
     let mut model = cm("<b>test{   }| test</b>");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "<b>test<a href=\"https://element.io\">added_link|</a> test</b>"
@@ -463,7 +495,11 @@ fn set_link_with_text_on_blank_selection_in_container() {
 #[test]
 fn set_link_with_text_on_blank_selection_with_line_break() {
     let mut model = cm("test{  <br> }|test");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>test"
@@ -473,7 +509,11 @@ fn set_link_with_text_on_blank_selection_with_line_break() {
 #[test]
 fn set_link_with_text_on_blank_selection_with_different_containers() {
     let mut model = cm("<b>test_bold{ </b><br>  ~ <i> }|test_italic</i>");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(tx(&model), "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i>test_italic</i>");
 }
 
@@ -484,7 +524,11 @@ fn set_link_with_text_at_end_of_a_link() {
     // This fails returning <a href=\"https://element.io\">test_linkadded_link|</a>
     // Since it considers the added_link part as part of the first link itself
     let mut model = cm("<a href=\"https://matrix.org\">test_link|</a>");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(tx(&model), "<a href=\"https://matrix.org\">test_link</a><a href=\"https://element.io\">added_link|</a>");
 }
 
@@ -492,7 +536,11 @@ fn set_link_with_text_at_end_of_a_link() {
 fn set_link_with_text_within_a_link() {
     // This use case should never happen, but just in case it would...
     let mut model = cm("<a href=\"https://matrix.org\">test|_link</a>");
-    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("https://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "<a href=\"https://element.io\">testadded_link|_link</a>"
@@ -502,14 +550,18 @@ fn set_link_with_text_within_a_link() {
 #[test]
 fn set_link_without_http_scheme_and_www() {
     let mut model = cm("|");
-    model.set_link_with_text(utf16("element.io"), utf16("added_link"));
+    model.set_link_with_text(utf16("element.io"), utf16("added_link"), None);
     assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
 }
 
 #[test]
 fn set_link_without_http_scheme() {
     let mut model = cm("|");
-    model.set_link_with_text(utf16("www.element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("www.element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "<a href=\"https://www.element.io\">added_link|</a>"
@@ -522,6 +574,7 @@ fn set_link_do_not_change_scheme_for_http() {
     model.set_link_with_text(
         utf16("https://www.element.io"),
         utf16("added_link"),
+        None,
     );
     assert_eq!(
         tx(&model),
@@ -532,7 +585,11 @@ fn set_link_do_not_change_scheme_for_http() {
 #[test]
 fn set_link_do_not_change_scheme_for_udp() {
     let mut model = cm("|");
-    model.set_link_with_text(utf16("udp://element.io"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("udp://element.io"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(tx(&model), "<a href=\"udp://element.io\">added_link|</a>");
 }
 
@@ -542,6 +599,7 @@ fn set_link_do_not_change_scheme_for_mail() {
     model.set_link_with_text(
         utf16("mailto:mymail@mail.com"),
         utf16("added_link"),
+        None,
     );
     assert_eq!(
         tx(&model),
@@ -552,7 +610,11 @@ fn set_link_do_not_change_scheme_for_mail() {
 #[test]
 fn set_link_add_mail_scheme() {
     let mut model = cm("|");
-    model.set_link_with_text(utf16("mymail@mail.com"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("mymail@mail.com"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "<a href=\"mailto:mymail@mail.com\">added_link|</a>"
@@ -562,7 +624,11 @@ fn set_link_add_mail_scheme() {
 #[test]
 fn set_link_add_mail_scheme_with_plus() {
     let mut model = cm("|");
-    model.set_link_with_text(utf16("mymail+01@mail.com"), utf16("added_link"));
+    model.set_link_with_text(
+        utf16("mymail+01@mail.com"),
+        utf16("added_link"),
+        None,
+    );
     assert_eq!(
         tx(&model),
         "<a href=\"mailto:mymail+01@mail.com\">added_link|</a>"
@@ -699,7 +765,7 @@ fn create_link_after_enter_with_formatting_applied() {
     model.bold();
     model.replace_text("test".into());
     model.enter();
-    model.set_link_with_text("https://matrix.org".into(), "test".into());
+    model.set_link_with_text("https://matrix.org".into(), "test".into(), None);
     assert_eq!(
         tx(&model),
         "<p>test <strong>test</strong></p><p><a href=\"https://matrix.org\"><strong>test|</strong></a></p>",
@@ -710,7 +776,7 @@ fn create_link_after_enter_with_formatting_applied() {
 fn create_link_after_enter_with_no_formatting_applied() {
     let mut model = cm("|");
     model.enter();
-    model.set_link_with_text("https://matrix.org".into(), "test".into());
+    model.set_link_with_text("https://matrix.org".into(), "test".into(), None);
     assert_eq!(
         tx(&model),
         "<p>&nbsp;</p><p><a href=\"https://matrix.org\">test|</a></p>"

--- a/crates/wysiwyg/src/tests/test_suggestions.rs
+++ b/crates/wysiwyg/src/tests/test_suggestions.rs
@@ -41,6 +41,6 @@ fn test_set_link_suggestion() {
     );
     assert_eq!(
         tx(&model),
-        "<a href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>&nbsp;|",
+        "<a href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\" data-mention-type=\"user\">Alice</a>&nbsp;|",
     );
 }

--- a/crates/wysiwyg/src/tests/testutils_dom.rs
+++ b/crates/wysiwyg/src/tests/testutils_dom.rs
@@ -29,7 +29,11 @@ pub fn dom<'a>(
 pub fn a<'a>(
     children: impl IntoIterator<Item = &'a DomNode<Utf16String>>,
 ) -> DomNode<Utf16String> {
-    DomNode::new_link(utf16("https://element.io"), clone_children(children))
+    DomNode::new_link(
+        utf16("https://element.io"),
+        clone_children(children),
+        &None,
+    )
 }
 
 pub fn b<'a>(

--- a/crates/wysiwyg/src/tests/testutils_dom.rs
+++ b/crates/wysiwyg/src/tests/testutils_dom.rs
@@ -32,7 +32,7 @@ pub fn a<'a>(
     DomNode::new_link(
         utf16("https://element.io"),
         clone_children(children),
-        &None,
+        None,
     )
 }
 

--- a/platforms/web/lib/useWysiwyg.formatting.test.tsx
+++ b/platforms/web/lib/useWysiwyg.formatting.test.tsx
@@ -17,7 +17,6 @@ limitations under the License.
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, MutableRefObject } from 'react';
-import { preview } from 'vite';
 
 import { Editor } from './testUtils/Editor';
 import { select } from './testUtils/selection';

--- a/platforms/web/lib/useWysiwyg.formatting.test.tsx
+++ b/platforms/web/lib/useWysiwyg.formatting.test.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, MutableRefObject } from 'react';
+import { preview } from 'vite';
 
 import { Editor } from './testUtils/Editor';
 import { select } from './testUtils/selection';
@@ -446,10 +447,11 @@ describe('mentions', () => {
             // Then
             // nb this information is hardcoded in the button for these tests so
             // they should all yield the same result
-
-            expect(textbox).toContainHTML(
-                '<a href="https://matrix.to/#/@test_user:element.io">test user</a>',
-            );
+            const link = screen.getByText('test user');
+            expect(link).toBeInTheDocument();
+            expect(link).toHaveAttribute('contenteditable', 'false');
+            screen.debug();
+            expect(link).toHaveAttribute('data-mention-type');
         },
     );
 });


### PR DESCRIPTION
This adds `contenteditable=false` and `data-mention-type=...` fields to the mention types when they are added.

Extra work will be required to add the ability for clients to pass the mention type in when calling this function, so that's been added as a comment. 