### PR TITLE
Write outside of links by default when cursor/selection is at the edge

### DIFF
--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -247,6 +247,10 @@ where
         self.children.get(idx)
     }
 
+    pub fn first_child_mut(&mut self) -> Option<&mut DomNode<S>> {
+        self.get_child_mut(0)
+    }
+
     pub fn last_child_mut(&mut self) -> Option<&mut DomNode<S>> {
         self.children.last_mut()
     }

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -734,6 +734,15 @@ mod test {
         assert!(!range.has_single_top_level_node(Some(DomNodeKind::CodeBlock)));
     }
 
+    #[test]
+    fn range_end_on_leading_of_a_node() {
+        let range = range_of("{abc}|<strong>def</strong>");
+        // First returned location is "abc" text node,
+        // second one should be the strong tag that has
+        // `leading_is_end` as true.
+        assert!(range.locations[1].leading_is_end());
+    }
+
     fn range_of(model: &str) -> Range {
         let model = cm(model);
         let (s, e) = model.safe_selection();

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -166,6 +166,11 @@ impl DomLocation {
         start_offset == 0
     }
 
+    /// Whether the selection ends exactly at the leading of this location.
+    pub fn leading_is_end(&self) -> bool {
+        self.is_end() && self.end_offset == 0
+    }
+
     pub fn starts_inside(&self) -> bool {
         self.start_offset > 0
     }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -716,3 +716,59 @@ fn create_link_after_enter_with_no_formatting_applied() {
         "<p>&nbsp;</p><p><a href=\"https://matrix.org\">test|</a></p>"
     );
 }
+
+#[test]
+fn replace_text_right_before_link() {
+    let mut model = cm("<a href=\"https://matrix.org\">|Matrix</a>");
+    model.replace_text("text".into());
+    assert_eq!(tx(&model), "text|<a href=\"https://matrix.org\">Matrix</a>",)
+}
+
+#[test]
+fn replace_text_right_before_link_with_prev_text() {
+    let mut model = cm("text|<a href=\"https://matrix.org\">Matrix</a>");
+    model.replace_text("text".into());
+    assert_eq!(
+        tx(&model),
+        "texttext|<a href=\"https://matrix.org\">Matrix</a>",
+    )
+}
+
+#[test]
+fn replace_text_right_before_link_with_formatted_prev_text() {
+    let mut model =
+        cm("<strong>text|</strong><a href=\"https://matrix.org\">Matrix</a>");
+    model.replace_text("text".into());
+    assert_eq!(
+        tx(&model),
+        "<strong>texttext|</strong><a href=\"https://matrix.org\">Matrix</a>",
+    )
+}
+
+#[test]
+fn replace_text_right_after_link() {
+    let mut model = cm("<a href=\"https://matrix.org\">Matrix|</a>");
+    model.replace_text("text".into());
+    assert_eq!(tx(&model), "<a href=\"https://matrix.org\">Matrix</a>text|",)
+}
+
+#[test]
+fn replace_text_right_after_link_with_next_text() {
+    let mut model = cm("<a href=\"https://matrix.org\">Matrix|</a>text");
+    model.replace_text("text".into());
+    assert_eq!(
+        tx(&model),
+        "<a href=\"https://matrix.org\">Matrix</a>text|text",
+    )
+}
+
+#[test]
+fn replace_text_right_after_link_with_next_formatted_text() {
+    let mut model =
+        cm("<a href=\"https://matrix.org\">Matrix|</a><strong>text</strong>");
+    model.replace_text("text".into());
+    assert_eq!(
+        tx(&model),
+        "<a href=\"https://matrix.org\">Matrix</a><strong>text|text</strong>",
+    )
+}


### PR DESCRIPTION
Fixes #615 

Also fixes an issue were, when effectively writing outside of the link on edge with a formatting container as sibling, a new text node was created, instead of writing in the last/first text node of the sibling container. 