### PR TITLE
Fix iOS mention tests

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
@@ -54,7 +54,7 @@ extension WysiwygComposerViewModelTests {
         XCTAssertEqual(
             viewModel.content.html,
             """
-            <a href="https://matrix.to/#/@alice:matrix.org">Alice</a>\u{00A0}
+            <a href="https://matrix.to/#/@alice:matrix.org" contenteditable="false" data-mention-type="user">Alice</a>\u{00A0}
             """
         )
     }
@@ -92,7 +92,7 @@ extension WysiwygComposerViewModelTests {
         XCTAssertEqual(
             viewModel.content.html,
             """
-            <a href="https://matrix.to/#/#room1:matrix.org">Room 1</a>\u{00A0}
+            <a href="https://matrix.to/#/#room1:matrix.org" contenteditable="false" data-mention-type="room">Room 1</a>\u{00A0}
             """
         )
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
@@ -33,7 +33,11 @@ extension WysiwygComposerTests {
                                      text: "Alice",
                                      suggestion: suggestionPattern)
             }
-            .assertHtml("<a href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>\(String.nbsp)")
+            .assertHtml(
+                """
+                <a href="https://matrix.to/#/@alice:matrix.org" contenteditable="false" data-mention-type="user">Alice</a>\(String.nbsp)
+                """
+            )
     }
 
     func testSuggestionForHashPattern() {
@@ -51,7 +55,11 @@ extension WysiwygComposerTests {
                                      text: "Room 1",
                                      suggestion: suggestionPattern)
             }
-            .assertHtml("<a href=\"https://matrix.to/#/#room1:matrix.org\">Room 1</a>\(String.nbsp)")
+            .assertHtml(
+                """
+                <a href="https://matrix.to/#/#room1:matrix.org" contenteditable="false" data-mention-type="room">Room 1</a>\(String.nbsp)
+                """
+            )
     }
 
     func testSuggestionForSlashPattern() {


### PR DESCRIPTION
Fixes tests that display mention links with `content-editable` and `data-mention-type`.