### PR TITLE
Allow updating both url and link text

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -205,42 +205,54 @@ impl ComposerModel {
         Arc::new(ComposerUpdate::from(self.inner.lock().unwrap().redo()))
     }
 
-    pub fn set_link(self: &Arc<Self>, link: String) -> Arc<ComposerUpdate> {
-        let link = Utf16String::from_str(&link);
+    pub fn set_link(self: &Arc<Self>, url: String) -> Arc<ComposerUpdate> {
+        let url = Utf16String::from_str(&url);
         Arc::new(ComposerUpdate::from(
-            self.inner.lock().unwrap().set_link(link),
+            self.inner.lock().unwrap().set_link(url),
         ))
     }
 
     pub fn set_link_with_text(
         self: &Arc<Self>,
-        link: String,
+        url: String,
         text: String,
     ) -> Arc<ComposerUpdate> {
-        let link = Utf16String::from_str(&link);
-        let text = Utf16String::from_str(&text);
         Arc::new(ComposerUpdate::from(
-            self.inner
-                .lock()
-                .unwrap()
-                .set_link_with_text(link, text, None),
+            self.inner.lock().unwrap().set_link_with_text(
+                Utf16String::from_str(&url),
+                Utf16String::from_str(&text),
+                None,
+            ),
+        ))
+    }
+
+    pub fn edit_link_with_text(
+        self: &Arc<Self>,
+        url: String,
+        text: String,
+    ) -> Arc<ComposerUpdate> {
+        Arc::new(ComposerUpdate::from(
+            self.inner.lock().unwrap().edit_link_with_text(
+                Utf16String::from_str(&url),
+                Utf16String::from_str(&text),
+            ),
         ))
     }
 
     pub fn set_link_suggestion(
         self: &Arc<Self>,
-        link: String,
+        url: String,
         text: String,
         suggestion: SuggestionPattern,
     ) -> Arc<ComposerUpdate> {
-        let link = Utf16String::from_str(&link);
+        let url = Utf16String::from_str(&url);
         let text = Utf16String::from_str(&text);
         let suggestion = wysiwyg::SuggestionPattern::from(suggestion);
         Arc::new(ComposerUpdate::from(
             self.inner
                 .lock()
                 .unwrap()
-                .set_link_suggestion(link, text, suggestion),
+                .set_link_suggestion(url, text, suggestion),
         ))
     }
 

--- a/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
@@ -3,7 +3,7 @@ use widestring::Utf16String;
 pub enum LinkAction {
     CreateWithText,
     Create,
-    Edit { link: String },
+    Edit { url: String, text: String },
 }
 
 impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
@@ -11,8 +11,9 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
         match inner {
             wysiwyg::LinkAction::CreateWithText => Self::CreateWithText,
             wysiwyg::LinkAction::Create => Self::Create,
-            wysiwyg::LinkAction::Edit(link) => Self::Edit {
-                link: link.to_string(),
+            wysiwyg::LinkAction::Edit { url, text } => Self::Edit {
+                url: url.to_string(),
+                text: text.to_string(),
             },
         }
     }

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -44,9 +44,10 @@ interface ComposerModel {
     ComposerUpdate redo();
     ComposerUpdate indent();
     ComposerUpdate unindent();
-    ComposerUpdate set_link(string link);
-    ComposerUpdate set_link_with_text(string link, string text);
-    ComposerUpdate set_link_suggestion(string link, string text, SuggestionPattern suggestion);
+    ComposerUpdate set_link(string url);
+    ComposerUpdate set_link_with_text(string url, string text);
+    ComposerUpdate edit_link_with_text(string url, string text);
+    ComposerUpdate set_link_suggestion(string url, string text, SuggestionPattern suggestion);
     ComposerUpdate remove_links();
     ComposerUpdate code_block();
     ComposerUpdate quote();

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -142,7 +142,8 @@ interface LinkAction {
     CreateWithText();
     Create();
     Edit(
-        string link
+        string url,
+        string text
     );
 };
 

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -753,7 +753,8 @@ pub struct Create;
 #[derive(Clone)]
 #[wasm_bindgen(getter_with_clone)]
 pub struct Edit {
-    pub link: String,
+    pub url: String,
+    pub text: String,
 }
 
 #[wasm_bindgen(getter_with_clone)]
@@ -776,12 +777,13 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
                 create: Some(Create),
                 edit_link: None,
             },
-            wysiwyg::LinkAction::Edit(link) => {
-                let link = link.to_string();
+            wysiwyg::LinkAction::Edit { url, text } => {
+                let url = url.to_string();
+                let text = text.to_string();
                 Self {
                     create_with_text: None,
                     create: None,
-                    edit_link: Some(Edit { link }),
+                    edit_link: Some(Edit { url, text }),
                 }
             }
         }

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -267,17 +267,17 @@ impl ComposerModel {
         self.inner.get_link_action().into()
     }
 
-    pub fn set_link(&mut self, link: &str) -> ComposerUpdate {
-        ComposerUpdate::from(self.inner.set_link(Utf16String::from_str(link)))
+    pub fn set_link(&mut self, url: &str) -> ComposerUpdate {
+        ComposerUpdate::from(self.inner.set_link(Utf16String::from_str(url)))
     }
 
     pub fn set_link_with_text(
         &mut self,
-        link: &str,
+        url: &str,
         text: &str,
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.set_link_with_text(
-            Utf16String::from_str(link),
+            Utf16String::from_str(url),
             Utf16String::from_str(text),
             None,
         ))
@@ -285,12 +285,12 @@ impl ComposerModel {
 
     pub fn set_link_suggestion(
         &mut self,
-        link: &str,
+        url: &str,
         text: &str,
         suggestion: SuggestionPattern,
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.set_link_suggestion(
-            Utf16String::from_str(link),
+            Utf16String::from_str(url),
             Utf16String::from_str(text),
             wysiwyg::SuggestionPattern::from(suggestion),
         ))

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -19,6 +19,7 @@ use crate::dom::nodes::dom_node::DomNodeKind::{Link, List};
 use crate::dom::nodes::dom_node::{DomNodeKind::LineBreak, DomNodeKind::Text};
 use crate::dom::nodes::ContainerNodeKind;
 use crate::dom::nodes::DomNode;
+use crate::dom::to_plain_text::ToPlainText;
 use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::Range;
 use crate::{
@@ -38,8 +39,9 @@ where
         for loc in range.locations.iter() {
             if loc.kind == DomNodeKind::Link {
                 let node = self.state.dom.lookup_node(&loc.node_handle);
-                let link = node.as_container().unwrap().get_link().unwrap();
-                return LinkAction::Edit(link);
+                let url = node.as_container().unwrap().get_link().unwrap();
+                let text = node.as_container().unwrap().to_plain_text();
+                return LinkAction::Edit { url, text };
             }
         }
         if s == e || self.is_blank_selection(range) {

--- a/crates/wysiwyg/src/link_action.rs
+++ b/crates/wysiwyg/src/link_action.rs
@@ -18,5 +18,5 @@ use crate::UnicodeString;
 pub enum LinkAction<S: UnicodeString> {
     CreateWithText,
     Create,
-    Edit(S),
+    Edit { url: S, text: S },
 }

--- a/crates/wysiwyg/src/tests/test_get_link_action.rs
+++ b/crates/wysiwyg/src/tests/test_get_link_action.rs
@@ -52,8 +52,11 @@ fn get_link_action_from_highlighted_link() {
     let model = cm("{<a href=\"https://element.io\">test</a>}|");
     assert_eq!(
         model.get_link_action(),
-        LinkAction::Edit(utf16("https://element.io"))
-    )
+        LinkAction::Edit {
+            url: utf16("https://element.io"),
+            text: utf16("test"),
+        },
+    );
 }
 
 #[test]
@@ -61,8 +64,11 @@ fn get_link_action_from_cursor_at_the_end_of_a_link() {
     let model = cm("<a href=\"https://element.io\">test</a>|");
     assert_eq!(
         model.get_link_action(),
-        LinkAction::Edit(utf16("https://element.io"))
-    )
+        LinkAction::Edit {
+            url: utf16("https://element.io"),
+            text: utf16("test"),
+        },
+    );
 }
 
 #[test]
@@ -70,8 +76,11 @@ fn get_link_action_from_cursor_inside_a_link() {
     let model = cm("<a href=\"https://element.io\">te|st</a>");
     assert_eq!(
         model.get_link_action(),
-        LinkAction::Edit(utf16("https://element.io"))
-    )
+        LinkAction::Edit {
+            url: utf16("https://element.io"),
+            text: utf16("test"),
+        },
+    );
 }
 
 #[test]
@@ -79,8 +88,11 @@ fn get_link_action_from_cursor_at_the_start_of_a_link() {
     let model = cm("|<a href=\"https://element.io\">test</a>");
     assert_eq!(
         model.get_link_action(),
-        LinkAction::Edit(utf16("https://element.io"))
-    )
+        LinkAction::Edit {
+            url: utf16("https://element.io"),
+            text: utf16("test"),
+        },
+    );
 }
 
 #[test]
@@ -88,8 +100,11 @@ fn get_link_action_from_selection_that_contains_a_link_and_non_links() {
     let model = cm("<b>{test_bold <a href=\"https://element.io\">test}|_link</a> test_bold</b>");
     assert_eq!(
         model.get_link_action(),
-        LinkAction::Edit(utf16("https://element.io"))
-    )
+        LinkAction::Edit {
+            url: utf16("https://element.io"),
+            text: utf16("test_link"),
+        },
+    );
 }
 
 #[test]
@@ -97,8 +112,11 @@ fn get_link_action_from_selection_that_contains_multiple_links() {
     let model = cm("{<a href=\"https://element.io\">test_element</a> <a href=\"https://matrix.org\">test_matrix</a>}|");
     assert_eq!(
         model.get_link_action(),
-        LinkAction::Edit(utf16("https://element.io"))
-    )
+        LinkAction::Edit {
+            url: utf16("https://element.io"),
+            text: utf16("test_element"),
+        },
+    );
 }
 
 #[test]
@@ -106,8 +124,11 @@ fn get_link_action_from_selection_that_contains_multiple_links_partially() {
     let model = cm("<a href=\"https://element.io\">test_{element</a> <a href=\"https://matrix.org\">test}|_matrix</a>");
     assert_eq!(
         model.get_link_action(),
-        LinkAction::Edit(utf16("https://element.io"))
-    )
+        LinkAction::Edit {
+            url: utf16("https://element.io"),
+            text: utf16("test_element"),
+        },
+    );
 }
 
 #[test]
@@ -116,8 +137,11 @@ fn get_link_action_from_selection_that_contains_multiple_links_partially_in_diff
     let model = cm("<a href=\"https://element.io\"> <b>test_{element</b></a> <i><a href=\"https://matrix.org\">test}|_matrix</a></i>");
     assert_eq!(
         model.get_link_action(),
-        LinkAction::Edit(utf16("https://element.io"))
-    )
+        LinkAction::Edit {
+            url: utf16("https://element.io"),
+            text: utf16(" test_element"),
+        },
+    );
 }
 
 #[test]
@@ -174,6 +198,9 @@ fn get_link_action_on_blank_selection_after_a_link() {
     // This is the correct behaviour because the end of a link should be considered part of the link itself
     assert_eq!(
         model.get_link_action(),
-        LinkAction::Edit(utf16("https://element.io"))
-    )
+        LinkAction::Edit {
+            url: utf16("https://element.io"),
+            text: utf16("test"),
+        },
+    );
 }

--- a/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/MainActivity.kt
+++ b/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/MainActivity.kt
@@ -20,23 +20,32 @@ class MainActivity : AppCompatActivity() {
         val context = this
 
         binding.editor.onSetLinkListener = object: OnSetLinkListener {
-            override fun openSetLinkDialog(currentLink: String?, callback: (url: String?) -> Unit) {
+            override fun openSetLinkDialog(callback: (url: String) -> Unit) {
                 val dialogBinding = DialogSetLinkBinding.inflate(LayoutInflater.from(context))
-                val title = if(currentLink == null) R.string.add_link else R.string.edit_link
-                dialogBinding.link.setText(currentLink)
                 dialogBinding.text.visibility = View.GONE
                 AlertDialog.Builder(context)
-                    .setTitle(title)
+                    .setTitle(R.string.add_link)
                     .setView(dialogBinding.root)
                     .setPositiveButton(android.R.string.ok) { _, _ ->
                         callback(dialogBinding.link.text.toString())
                     }
-                    .apply {
-                        if(currentLink != null) {
-                            setNeutralButton(R.string.remove_link) { _, _ ->
-                                callback(null)
-                            }
-                        }
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .show()
+
+                dialogBinding.link.performClick()
+            }
+            override fun openEditLinkDialog(text: String, url: String, callback: (text: String?, url: String?) -> Unit) {
+                val dialogBinding = DialogSetLinkBinding.inflate(LayoutInflater.from(context))
+                dialogBinding.link.setText(url)
+                dialogBinding.text.setText(text)
+                AlertDialog.Builder(context)
+                    .setTitle(R.string.edit_link)
+                    .setView(dialogBinding.root)
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
+                        callback(dialogBinding.text.text.toString(), dialogBinding.link.text.toString())
+                    }
+                    .setNeutralButton(R.string.remove_link) { _, _ ->
+                        callback(null, null)
                     }
                     .setNegativeButton(android.R.string.cancel, null)
                     .show()

--- a/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
+++ b/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
@@ -72,13 +72,17 @@ class RichTextEditor : LinearLayout {
                 val linkAction = richTextEditText.getLinkAction() ?: return@setOnClickListener
                 when(linkAction) {
                     is LinkAction.InsertLink -> {
-                        onSetLinkListener?.openInsertLinkDialog { text, link ->
-                            richTextEditText.insertLink(link = link, text = text)
+                        onSetLinkListener?.openInsertLinkDialog { text, url ->
+                            richTextEditText.insertLink(text, url)
                         }
                     }
                     is LinkAction.SetLink ->
-                        onSetLinkListener?.openSetLinkDialog(linkAction.currentLink) { link ->
-                            richTextEditText.setLink(link)
+                        onSetLinkListener?.openSetLinkDialog { url ->
+                            richTextEditText.setLink(url)
+                        }
+                    is LinkAction.EditLink ->
+                        onSetLinkListener?.openEditLinkDialog(linkAction.text, linkAction.url) { text, url ->
+                            richTextEditText.editLink(text, url)
                         }
                 }
             }
@@ -143,6 +147,7 @@ class RichTextEditor : LinearLayout {
 }
 
 interface OnSetLinkListener {
-    fun openSetLinkDialog(currentLink: String?, callback: (url: String?) -> Unit)
+    fun openSetLinkDialog(callback: (url: String) -> Unit)
+    fun openEditLinkDialog(text: String, url: String, callback: (text: String?, url: String?) -> Unit)
     fun openInsertLinkDialog(callback: (text: String, url: String) -> Unit)
 }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/EditorEditTextInputTests.kt
@@ -254,6 +254,22 @@ class EditorEditTextInputTests {
     }
 
     @Test
+    fun testCreatingAndEditingALink() {
+        onView(withId(R.id.rich_text_edit_text))
+            .perform(ImeActions.setComposingText("link"))
+            .perform(ImeActions.setSelection(0, 4))
+            .perform(EditorActions.setLink("https://element.io"))
+            .check(matches(TextViewMatcher {
+                it.editableText.getSpans<LinkSpan>().first().url == "https://element.io"
+            }))
+            .perform(EditorActions.editLink("matrix", "https://matrix.org"))
+            .check(matches(withText("matrix")))
+            .check(matches(TextViewMatcher {
+                it.editableText.getSpans<LinkSpan>().first().url == "https://matrix.org"
+            }))
+    }
+
+    @Test
     @Ignore("Lists are being refactored at the moment")
     fun testAddingOrderedList() {
         onView(withId(R.id.rich_text_edit_text))

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
@@ -63,17 +63,31 @@ object Editor {
         }
     }
 
-    data class InsertLink(
+    data class EditLink(
         val text: String,
-        val link: String,
+        val url: String,
     ) : ViewAction {
         override fun getConstraints(): Matcher<View> = isDisplayed()
 
-        override fun getDescription(): String = "Insert text ($text) linking to $link"
+        override fun getDescription(): String = "Insert text ($text) linking to $url"
 
         override fun perform(uiController: UiController?, view: View?) {
             val editor = view as? EditorEditText ?: return
-            editor.insertLink(link = link, text = text)
+            editor.editLink(text, url)
+        }
+    }
+
+    data class InsertLink(
+        val text: String,
+        val url: String,
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Insert text ($text) linking to $url"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val editor = view as? EditorEditText ?: return
+            editor.insertLink(text, url)
         }
     }
 
@@ -167,6 +181,7 @@ object EditorActions {
     fun setText(text: String) = Editor.SetText(text)
     fun setHtml(html: String) = Editor.SetHtml(html)
     fun setLink(url: String) = Editor.SetLink(url)
+    fun editLink(text: String, url: String) = Editor.EditLink(text, url)
     fun insertLink(text: String, url: String) = Editor.InsertLink(text, url)
     fun removeLink() = Editor.RemoveLink
     fun toggleList(ordered: Boolean) = Editor.ToggleList(ordered)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -309,11 +309,24 @@ class EditorEditText : TextInputEditText {
     /**
      * Set a link for the current selection. This method does nothing if there is no text selected.
      *
-     * @param link The link to set or null to remove
+     * @param url The url to set
      */
-    fun setLink(link: String?) {
+    fun setLink(url: String) {
+        val result = viewModel.processInput(EditorInputAction.SetLink(url)) ?: return
+
+        setTextFromComposerUpdate(result)
+        setSelectionFromComposerUpdate(result.selection.last)
+    }
+
+    /**
+     * Edit link for the current selection.
+     *
+     * @param text The new text for the link or null to remove
+     * @param url The url to set or null to remove
+     */
+    fun editLink(text: String?, url: String?, ) {
         val result = viewModel.processInput(
-            if (link != null) EditorInputAction.SetLink(link) else EditorInputAction.RemoveLink
+            if (text != null && url != null) EditorInputAction.EditLink(text, url) else EditorInputAction.RemoveLink
         ) ?: return
 
         setTextFromComposerUpdate(result)
@@ -321,20 +334,23 @@ class EditorEditText : TextInputEditText {
     }
 
     /**
-     * Remove a link for the current selection. Convenience for setLink(null).
-     *
-     * @see [setLink]
+     * Remove a link for the current selection.
      */
-    fun removeLink() = setLink(null)
+    fun removeLink() {
+        val result = viewModel.processInput(EditorInputAction.RemoveLink) ?: return
+
+        setTextFromComposerUpdate(result)
+        setSelectionFromComposerUpdate(result.selection.last)
+    }
 
     /**
-     * Insert new text with a link.
+     * Insert new link with text and url.
      *
-     * @param link The link to set
      * @param text The new text to insert
+     * @param url The url to set
      */
-    fun insertLink(link: String, text: String) {
-        val result = viewModel.processInput(EditorInputAction.SetLinkWithText(link, text)) ?: return
+    fun insertLink(text: String, url: String) {
+        val result = viewModel.processInput(EditorInputAction.SetLinkWithText(url, text)) ?: return
 
         setTextFromComposerUpdate(result)
         setSelectionFromComposerUpdate(result.selection.last)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/EditorInputAction.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/EditorInputAction.kt
@@ -67,9 +67,14 @@ internal sealed interface EditorInputAction {
     object Redo: EditorInputAction
 
     /**
-     * Add or edit a link to the [link] url in the current selection.
+     * Add or edit a link to the [url] in the current selection.
      */
-    data class SetLink(val link: String): EditorInputAction
+    data class SetLink(val url: String): EditorInputAction
+
+    /**
+     * Edit a link in the current selection with the [text] and [url].
+     */
+    data class EditLink(val text: String, val url: String): EditorInputAction
 
     /**
      * Remove link on the current selection.
@@ -79,7 +84,7 @@ internal sealed interface EditorInputAction {
     /**
      * Create text with a link.
      */
-    data class SetLinkWithText(val link: String, val text: String): EditorInputAction
+    data class SetLinkWithText(val url: String, val text: String): EditorInputAction
 
     /**
      * Creates a list, [ordered] if true or unordered in the current selection.

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/LinkAction.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/LinkAction.kt
@@ -10,7 +10,12 @@ sealed class LinkAction {
     object InsertLink : LinkAction()
 
     /**
-     * Add or change the link for the current selection, without supplying text.
+     * Add a link for the current selection, without supplying text.
      */
-    data class SetLink(val currentLink: String?) : LinkAction()
+    object SetLink : LinkAction()
+
+    /**
+     * Edit the text and the url of link for the current selection.
+     */
+    data class EditLink(val text: String, val url: String) : LinkAction()
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
@@ -78,9 +78,10 @@ internal class EditorViewModel(
                     action.end.toUInt()
                 )
                 is EditorInputAction.Delete -> composer?.delete()
-                is EditorInputAction.SetLink -> composer?.setLink(link = action.link)
+                is EditorInputAction.SetLink -> composer?.setLink(url = action.url)
+                is EditorInputAction.EditLink -> composer?.editLinkWithText(url = action.url, text = action.text)
                 is EditorInputAction.RemoveLink -> composer?.removeLinks()
-                is EditorInputAction.SetLinkWithText -> composer?.setLinkWithText(action.link, action.text)
+                is EditorInputAction.SetLinkWithText -> composer?.setLinkWithText(action.url, action.text)
                 is EditorInputAction.ReplaceAllHtml -> composer?.setContentFromHtml(action.html)
                 is EditorInputAction.ReplaceAllMarkdown -> composer?.setContentFromMarkdown(action.markdown)
                 is EditorInputAction.Undo -> composer?.undo()
@@ -137,8 +138,8 @@ internal class EditorViewModel(
     fun getLinkAction(): LinkAction? =
         composer?.getLinkAction()?.let {
             when (it) {
-                is ComposerLinkAction.Edit -> LinkAction.SetLink(currentLink = it.link)
-                is ComposerLinkAction.Create -> LinkAction.SetLink(currentLink = null)
+                is ComposerLinkAction.Edit -> LinkAction.EditLink(url = it.url, text = it.text)
+                is ComposerLinkAction.Create -> LinkAction.SetLink
                 is ComposerLinkAction.CreateWithText -> LinkAction.InsertLink
             }
         }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
@@ -73,15 +73,15 @@ class MockComposer {
     ) = every { instance.getLinkAction() } returns linkAction
 
     fun givenSetLinkResult(
-        link: String,
+        url: String,
         update: ComposerUpdate = MockComposerUpdateFactory.create(),
-    ) = every { instance.setLink(link = link) } returns update
+    ) = every { instance.setLink(url = url) } returns update
 
     fun givenSetLinkWithTextResult(
-        link: String,
+        url: String,
         text: String,
         update: ComposerUpdate = MockComposerUpdateFactory.create(),
-    ) = every { instance.setLinkWithText(link = link, text = text) } returns update
+    ) = every { instance.setLinkWithText(url = url, text = text) } returns update
 
     fun givenRemoveLinkResult(
         update: ComposerUpdate = MockComposerUpdateFactory.create(),

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
@@ -42,7 +42,7 @@ internal class EditorViewModelTest {
             "<p><b>$paragraph</b></p>" +
                     "<p><i>$paragraph</i></p>"
         private const val markdownParagraphs = "**paragraph**\n**paragraph**"
-        private const val link = "https://matrix.org"
+        private const val linkUrl = "https://matrix.org"
         private const val linkText = "Matrix"
         private val actionStates =
             mapOf(
@@ -210,14 +210,10 @@ internal class EditorViewModelTest {
 
     @Test
     fun `given internal edit link action, when get, it returns the right action`() {
-        composer.givenLinkAction(ComposerLinkAction.Edit(link))
+        composer.givenLinkAction(ComposerLinkAction.Edit(linkUrl, linkText))
 
         assertThat(
-            viewModel.getLinkAction(), equalTo(
-                LinkAction.SetLink(
-                    currentLink = link
-                )
-            )
+            viewModel.getLinkAction(), equalTo(LinkAction.EditLink(linkText, linkUrl))
         )
     }
 
@@ -233,11 +229,7 @@ internal class EditorViewModelTest {
         composer.givenLinkAction(ComposerLinkAction.Create)
 
         assertThat(
-            viewModel.getLinkAction(), equalTo(
-                LinkAction.SetLink(
-                    currentLink = null
-                )
-            )
+            viewModel.getLinkAction(), equalTo(LinkAction.SetLink)
         )
     }
 
@@ -270,17 +262,17 @@ internal class EditorViewModelTest {
     @Test
     fun `when process set link with text action, it returns a text update`() {
         composer.givenSetLinkWithTextResult(
-            link = link, text = linkText,
+            url = linkUrl, text = linkText,
             composerStateUpdate
         )
 
         val result = viewModel.processInput(
-            EditorInputAction.SetLinkWithText(link, linkText)
+            EditorInputAction.SetLinkWithText(linkUrl, linkText)
         )
 
         verify {
             composer.instance.setLinkWithText(
-                link = link, text = linkText
+                url = linkUrl, text = linkText
             )
             actionsStatesCallback(actionStates)
         }

--- a/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
+++ b/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
@@ -52,13 +52,13 @@ struct WysiwygActionToolbar: View {
     func makeAlertConfig() -> AlertConfig {
         var actions: [AlertConfig.Action] = [.cancel(title: "Cancel")]
         let createLinkTitle = "Create Link"
-        let singleTextAction: ([String]) -> Void = { strings in
-            let urlString = strings[0]
-            viewModel.select(range: linkAttributedRange)
-            viewModel.applyLinkOperation(.setLink(urlString: urlString))
-        }
         switch linkAction {
         case .create:
+            let singleTextAction: ([String]) -> Void = { strings in
+                let urlString = strings[0]
+                viewModel.select(range: linkAttributedRange)
+                viewModel.applyLinkOperation(.setLink(urlString: urlString))
+            }
             actions.append(createAction(singleTextAction: singleTextAction))
             return AlertConfig(title: createLinkTitle, actions: actions)
         case .createWithText:
@@ -70,9 +70,15 @@ struct WysiwygActionToolbar: View {
             }
             actions.append(createWithTextAction(doubleTextAction: doubleTextAction))
             return AlertConfig(title: createLinkTitle, actions: actions)
-        case let .edit(link):
+        case let .edit(url, text):
             let editLinktitle = "Edit Link"
-            actions.append(editTextAction(singleTextAction: singleTextAction, link: link))
+            let doubleTextAction: ([String]) -> Void = { strings in
+                let urlString = strings[0]
+                let text = strings[1]
+                viewModel.select(range: linkAttributedRange)
+                viewModel.applyLinkOperation(.editLink(urlString: urlString, text: text))
+            }
+            actions.append(editTextAction(doubleTextAction: doubleTextAction, url: url, text: text))
             let removeAction = {
                 viewModel.select(range: linkAttributedRange)
                 viewModel.applyLinkOperation(.removeLinks)
@@ -119,17 +125,22 @@ private extension WysiwygActionToolbar {
         )
     }
 
-    private func editTextAction(singleTextAction: @escaping ([String]) -> Void, link: String) -> AlertConfig.Action {
+    private func editTextAction(doubleTextAction: @escaping ([String]) -> Void, url: String, text: String) -> AlertConfig.Action {
         .textAction(
             title: "Ok",
             textFieldsData: [
                 .init(
                     accessibilityIdentifier: .linkUrlTextField,
                     placeholder: "URL",
-                    defaultValue: link
+                    defaultValue: url
+                ),
+                .init(
+                    accessibilityIdentifier: .linkTextTextField,
+                    placeholder: "Text",
+                    defaultValue: text
                 ),
             ],
-            action: singleTextAction
+            action: doubleTextAction
         )
     }
 }

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Links.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Links.swift
@@ -49,7 +49,7 @@ extension WysiwygUITests {
 
         // Remove
         button(.linkButton).tap()
-        XCTAssertFalse(textField(.linkTextTextField).exists)
+        XCTAssertTrue(textField(.linkTextTextField).exists)
         app.buttons["Remove"].tap()
         assertTreeEquals(
             """

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Links.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Links.swift
@@ -35,7 +35,8 @@ extension WysiwygUITests {
 
         // Edit
         button(.linkButton).tap()
-        XCTAssertFalse(textField(.linkTextTextField).exists)
+        XCTAssertTrue(textField(.linkUrlTextField).exists)
+        XCTAssertTrue(textField(.linkTextTextField).exists)
         textField(.linkUrlTextField).doubleTap()
         textField(.linkUrlTextField).typeTextCharByChar("new_url")
         app.buttons["Ok"].tap()

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
@@ -30,9 +30,10 @@ protocol ComposerModelWrapperProtocol {
     func replaceTextSuggestion(newText: String, suggestion: SuggestionPattern) -> ComposerUpdate
     func backspace() -> ComposerUpdate
     func enter() -> ComposerUpdate
-    func setLink(link: String) -> ComposerUpdate
-    func setLinkWithText(link: String, text: String) -> ComposerUpdate
-    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern) -> ComposerUpdate
+    func setLink(url: String) -> ComposerUpdate
+    func setLinkWithText(url: String, text: String) -> ComposerUpdate
+    func editLinkWithText(url: String, text: String) -> ComposerUpdate
+    func setLinkSuggestion(url: String, text: String, suggestion: SuggestionPattern) -> ComposerUpdate
     func removeLinks() -> ComposerUpdate
     func toTree() -> String
     func getCurrentDomState() -> ComposerState
@@ -113,16 +114,20 @@ final class ComposerModelWrapper: ComposerModelWrapperProtocol {
         execute { try $0.enter() }
     }
 
-    func setLink(link: String) -> ComposerUpdate {
-        execute { try $0.setLink(link: link) }
+    func setLink(url: String) -> ComposerUpdate {
+        execute { try $0.setLink(url: url) }
     }
 
-    func setLinkWithText(link: String, text: String) -> ComposerUpdate {
-        execute { try $0.setLinkWithText(link: link, text: text) }
+    func setLinkWithText(url: String, text: String) -> ComposerUpdate {
+        execute { try $0.setLinkWithText(url: url, text: text) }
     }
 
-    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern) -> ComposerUpdate {
-        execute { try $0.setLinkSuggestion(link: link, text: text, suggestion: suggestion) }
+    func editLinkWithText(url: String, text: String) -> ComposerUpdate {
+        execute { try $0.editLinkWithText(url: url, text: text) }
+    }
+
+    func setLinkSuggestion(url: String, text: String, suggestion: SuggestionPattern) -> ComposerUpdate {
+        execute { try $0.setLinkSuggestion(url: url, text: text, suggestion: suggestion) }
     }
 
     func removeLinks() -> ComposerUpdate {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -231,9 +231,9 @@ public extension WysiwygComposerViewModel {
     func setMention(link: String, name: String, key: PatternKey) {
         let update: ComposerUpdate
         if let suggestionPattern, suggestionPattern.key == key {
-            update = model.setLinkSuggestion(link: link, text: name, suggestion: suggestionPattern)
+            update = model.setLinkSuggestion(url: link, text: name, suggestion: suggestionPattern)
         } else {
-            _ = model.setLinkWithText(link: link, text: name)
+            _ = model.setLinkWithText(url: link, text: name)
             // FIXME: remove this if Rust adds this space for free
             update = model.replaceText(newText: " ")
         }
@@ -360,9 +360,11 @@ public extension WysiwygComposerViewModel {
         let update: ComposerUpdate
         switch linkOperation {
         case let .createLink(urlString, text):
-            update = model.setLinkWithText(link: urlString, text: text)
+            update = model.setLinkWithText(url: urlString, text: text)
+        case let .editLink(urlString, text):
+            update = model.editLinkWithText(url: urlString, text: text)
         case let .setLink(urlString):
-            update = model.setLink(link: urlString)
+            update = model.setLink(url: urlString)
         case .removeLinks:
             update = model.removeLinks()
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygLinkOperation.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygLinkOperation.swift
@@ -18,6 +18,7 @@ import Foundation
 
 public enum WysiwygLinkOperation: Equatable {
     case setLink(urlString: String)
+    case editLink(urlString: String, text: String)
     case createLink(urlString: String, text: String)
     case removeLinks
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
@@ -31,15 +31,15 @@ extension WysiwygComposerTests {
     }
 
     func testEditLinkAction() {
-        let link = "test_url"
+        let url = "test_url"
         ComposerModelWrapper()
-            .action { $0.setLinkWithText(link: link, text: "test") }
-            .assertLinkAction(.edit(url: "https://\(link)", text: "test"))
+            .action { $0.setLinkWithText(url: url, text: "test") }
+            .assertLinkAction(.edit(url: "https://\(url)", text: "test"))
     }
 
     func testSetLinkWithText() {
         ComposerModelWrapper()
-            .action { $0.setLinkWithText(link: "link", text: "text") }
+            .action { $0.setLinkWithText(url: "link", text: "text") }
             .assertTree(
                 """
 
@@ -52,7 +52,7 @@ extension WysiwygComposerTests {
     
     func testSetLinkWithTextWithIncludedScheme() {
         ComposerModelWrapper()
-            .action { $0.setLinkWithText(link: "http://link", text: "text") }
+            .action { $0.setLinkWithText(url: "http://link", text: "text") }
             .assertTree(
                 """
 
@@ -65,7 +65,7 @@ extension WysiwygComposerTests {
     
     func testSetMailLinkWithText() {
         ComposerModelWrapper()
-            .action { $0.setLinkWithText(link: "test@element.io", text: "text") }
+            .action { $0.setLinkWithText(url: "test@element.io", text: "text") }
             .assertTree(
                 """
 
@@ -80,7 +80,7 @@ extension WysiwygComposerTests {
         ComposerModelWrapper()
             .action { $0.replaceText(newText: "text") }
             .action { $0.select(startUtf16Codeunit: 0, endUtf16Codeunit: 4) }
-            .action { $0.setLink(link: "link") }
+            .action { $0.setLink(url: "link") }
             .assertTree(
                 """
 
@@ -93,7 +93,7 @@ extension WysiwygComposerTests {
 
     func testRemoveLinks() {
         ComposerModelWrapper()
-            .action { $0.setLinkWithText(link: "link", text: "text") }
+            .action { $0.setLinkWithText(url: "link", text: "text") }
             .assertTree(
                 """
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Links.swift
@@ -34,7 +34,7 @@ extension WysiwygComposerTests {
         let link = "test_url"
         ComposerModelWrapper()
             .action { $0.setLinkWithText(link: link, text: "test") }
-            .assertLinkAction(.edit(link: "https://\(link)"))
+            .assertLinkAction(.edit(url: "https://\(link)", text: "test"))
     }
 
     func testSetLinkWithText() {

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
@@ -29,7 +29,7 @@ extension WysiwygComposerTests {
 
         model
             .action {
-                $0.setLinkSuggestion(link: "https://matrix.to/#/@alice:matrix.org",
+                $0.setLinkSuggestion(url: "https://matrix.to/#/@alice:matrix.org",
                                      text: "Alice",
                                      suggestion: suggestionPattern)
             }
@@ -51,7 +51,7 @@ extension WysiwygComposerTests {
 
         model
             .action {
-                $0.setLinkSuggestion(link: "https://matrix.to/#/#room1:matrix.org",
+                $0.setLinkSuggestion(url: "https://matrix.to/#/#room1:matrix.org",
                                      text: "Room 1",
                                      suggestion: suggestionPattern)
             }


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rich-text-editor/issues/616

* Provides tools to allow editing both the url and the text of a link
* Rename link API to use `url` and avoid ambiguity
* Update example apps for both Android & iOS

iOS demo:

https://user-images.githubusercontent.com/80891108/225628909-aee65427-adce-462d-b554-09de409402de.mp4

