### PR TITLE
Enable parsing link attributes & move link button disabling for immutable links to Rust

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
@@ -4,6 +4,7 @@ pub enum LinkAction {
     CreateWithText,
     Create,
     Edit { link: String },
+    Disabled,
 }
 
 impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
@@ -14,6 +15,7 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
             wysiwyg::LinkAction::Edit(link) => Self::Edit {
                 link: link.to_string(),
             },
+            wysiwyg::LinkAction::Disabled => Self::Disabled,
         }
     }
 }

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -144,6 +144,7 @@ interface LinkAction {
     Edit(
         string link
     );
+    Disabled();
 };
 
 [Error]

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -756,11 +756,16 @@ pub struct Edit {
     pub link: String,
 }
 
+#[derive(Clone)]
+#[wasm_bindgen]
+pub struct Disabled;
+
 #[wasm_bindgen(getter_with_clone)]
 pub struct LinkAction {
     pub create_with_text: Option<CreateWithText>,
     pub create: Option<Create>,
     pub edit_link: Option<Edit>,
+    pub disabled: Option<Disabled>,
 }
 
 impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
@@ -770,11 +775,13 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
                 create_with_text: Some(CreateWithText),
                 create: None,
                 edit_link: None,
+                disabled: None,
             },
             wysiwyg::LinkAction::Create => Self {
                 create_with_text: None,
                 create: Some(Create),
                 edit_link: None,
+                disabled: None,
             },
             wysiwyg::LinkAction::Edit(link) => {
                 let link = link.to_string();
@@ -782,8 +789,15 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
                     create_with_text: None,
                     create: None,
                     edit_link: Some(Edit { link }),
+                    disabled: None,
                 }
             }
+            wysiwyg::LinkAction::Disabled => Self {
+                create_with_text: None,
+                create: None,
+                edit_link: None,
+                disabled: Some(Disabled),
+            },
         }
     }
 }

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -40,21 +40,23 @@ where
             .iter()
             .filter(|loc| loc.kind == DomNodeKind::Link);
 
-        if iter.clone().any(|loc| {
-            self.state
-                .dom
-                .lookup_container(&loc.node_handle)
-                .is_immutable()
-        }) {
-            LinkAction::Disabled
-        } else if let Some(loc) = iter.next() {
-            let link = self
-                .state
-                .dom
-                .lookup_container(&loc.node_handle)
-                .get_link()
-                .unwrap();
-            LinkAction::Edit(link)
+        if let Some(first_loc) = iter.next() {
+            let first_link =
+                self.state.dom.lookup_container(&first_loc.node_handle);
+            // If any of the link in the selection is immutable, link actions are disabled.
+            if first_link.is_immutable()
+                || iter.any(|loc| {
+                    self.state
+                        .dom
+                        .lookup_container(&loc.node_handle)
+                        .is_immutable()
+                })
+            {
+                LinkAction::Disabled
+            } else {
+                // Otherwise we edit the first link of the selection.
+                LinkAction::Edit(first_link.get_link().unwrap())
+            }
         } else if s == e || self.is_blank_selection(range) {
             LinkAction::CreateWithText
         } else {

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -20,10 +20,12 @@ use crate::dom::nodes::{ContainerNode, ContainerNodeKind};
 use crate::dom::range::DomLocationPosition::{After, Before};
 use crate::dom::{DomLocation, Range};
 use crate::menu_state::MenuStateUpdate;
-use crate::ComposerAction::{Indent, OrderedList, Unindent, UnorderedList};
+use crate::ComposerAction::{
+    Indent, Link, OrderedList, Unindent, UnorderedList,
+};
 use crate::{
     ComposerAction, ComposerModel, DomHandle, DomNode, InlineFormatType,
-    ListType, MenuState, UnicodeString,
+    LinkAction, ListType, MenuState, UnicodeString,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -212,6 +214,9 @@ where
         }
         if !self.can_unindent(&top_most_list_locations) {
             disabled_actions.insert(Unindent);
+        }
+        if self.get_link_action() == LinkAction::Disabled {
+            disabled_actions.insert(Link);
         }
         // XOR on inline code in selection & toggled format types.
         // If selection is not a cursor, toggled format types is always

--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -129,13 +129,7 @@ where
                         );
                     }
                     // If list becomes empty, remove it too
-                    if self
-                        .state
-                        .dom
-                        .lookup_node(&list_handle)
-                        .as_container()
-                        .unwrap()
-                        .is_empty()
+                    if self.state.dom.lookup_container(&list_handle).is_empty()
                     {
                         self.state.dom.remove(&list_handle);
 
@@ -197,9 +191,7 @@ where
             let child_count = self
                 .state
                 .dom
-                .lookup_node(&block_node_handle)
-                .as_container()
-                .unwrap()
+                .lookup_container(&block_node_handle)
                 .children()
                 .len();
             let last_child_handle =

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -347,6 +347,17 @@ where
         self.document_node().lookup_node(node_handle)
     }
 
+    /// Shortcut for looking up a container at given handle.
+    /// Should only be used from contexts where node is
+    /// guaranteed to be a container. (e.g. if `DomLocation`
+    /// provides a DomNodeKind matching container type).
+    pub fn lookup_container(
+        &self,
+        node_handle: &DomHandle,
+    ) -> &ContainerNode<S> {
+        self.lookup_node(node_handle).as_container().unwrap()
+    }
+
     /// Find the node based on its handle and returns a mutable reference.
     /// Panics if the handle is invalid or unset
     pub fn lookup_node_mut(

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -320,6 +320,16 @@ where
         matches!(self.kind, ContainerNodeKind::Link(_))
     }
 
+    pub fn is_immutable(&self) -> bool {
+        self.attributes()
+            .unwrap_or(&vec![])
+            .contains(&("contenteditable".into(), "false".into()))
+    }
+
+    pub fn is_immutable_link(&self) -> bool {
+        matches!(self.kind, ContainerNodeKind::Link(_) if self.is_immutable())
+    }
+
     pub fn is_list_item(&self) -> bool {
         matches!(self.kind, ContainerNodeKind::ListItem)
     }
@@ -371,10 +381,15 @@ where
 
     pub fn new_link(
         url: S,
+        attributes: Option<Vec<(S, S)>>,
         children: Vec<DomNode<S>>,
         mention_type: Option<S>,
     ) -> Self {
-        let mut attrs = vec![("href".into(), url.clone())];
+        // FIXME: mention_type could be removed, and the hosting application could just provide attributes
+        // this would allow the Rust code to stay as generic as possible, since it should only care abouy
+        // `contenteditable="false"` to implement custom behaviours for immutable links.
+        let mut attrs =
+            attributes.unwrap_or_else(|| vec![("href".into(), url.clone())]);
         if let Some(m_type) = mention_type {
             // if we have a mention, add attributes to make it non-editable and to track
             // the type of mention we have

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -129,7 +129,12 @@ where
         children: Vec<DomNode<S>>,
         mention_type: Option<S>,
     ) -> DomNode<S> {
-        DomNode::Container(ContainerNode::new_link(url, children, mention_type))
+        DomNode::Container(ContainerNode::new_link(
+            url,
+            None,
+            children,
+            mention_type,
+        ))
     }
 
     pub fn is_container_node(&self) -> bool {

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -268,8 +268,15 @@ mod sys {
         where
             S: UnicodeString,
         {
+            let attributes = child
+                .attrs
+                .iter()
+                .map(|(k, v)| (k.as_str().into(), v.as_str().into()))
+                .collect();
+
             DomNode::Container(ContainerNode::new_link(
                 child.get_attr("href").unwrap_or("").into(),
+                Some(attributes),
                 Vec::new(),
                 None,
             ))

--- a/crates/wysiwyg/src/link_action.rs
+++ b/crates/wysiwyg/src/link_action.rs
@@ -19,4 +19,5 @@ pub enum LinkAction<S: UnicodeString> {
     CreateWithText,
     Create,
     Edit(S),
+    Disabled,
 }

--- a/crates/wysiwyg/src/tests/test_get_link_action.rs
+++ b/crates/wysiwyg/src/tests/test_get_link_action.rs
@@ -177,3 +177,35 @@ fn get_link_action_on_blank_selection_after_a_link() {
         LinkAction::Edit(utf16("https://element.io"))
     )
 }
+
+#[test]
+fn get_link_action_on_selected_immutable_link() {
+    let model = cm(
+        "<a contenteditable=\"false\" href=\"https://matrix.org\">{test}|</a>",
+    );
+    assert_eq!(model.get_link_action(), LinkAction::Disabled,)
+}
+
+#[test]
+fn get_link_action_on_immutable_link_leading() {
+    let model = cm(
+        "<a contenteditable=\"false\" href=\"https://matrix.org\">|test</a>",
+    );
+    assert_eq!(model.get_link_action(), LinkAction::Disabled,)
+}
+
+#[test]
+fn get_link_action_on_immutable_link_trailing() {
+    let model = cm(
+        "<a contenteditable=\"false\" href=\"https://matrix.org\">test|</a>",
+    );
+    assert_eq!(model.get_link_action(), LinkAction::Disabled,)
+}
+
+#[test]
+fn get_link_action_on_cross_selected_immutable_link() {
+    let model = cm(
+        "<a contenteditable=\"false\" href=\"https://matrix.org\">te{st</a>text}|",
+    );
+    assert_eq!(model.get_link_action(), LinkAction::Disabled,)
+}

--- a/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
+++ b/platforms/ios/example/Wysiwyg/Views/WysiwygActionToolbar.swift
@@ -79,7 +79,7 @@ struct WysiwygActionToolbar: View {
             }
             actions.append(.destructive(title: "Remove", action: removeAction))
             return AlertConfig(title: editLinktitle, actions: actions)
-        case .none:
+        case .disabled, .none:
             return AlertConfig(title: "", actions: actions)
         }
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Attributes.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Attributes.swift
@@ -67,33 +67,4 @@ public extension NSAttributedString {
         let color = attribute(.backgroundColor, at: index, effectiveRange: nil) as? UIColor
         return color ?? .clear
     }
-
-    /// Computes whether given range or its surroundings contains
-    /// a link that has been replaced with something else (e.g.: a pill)
-    ///
-    /// - Parameter range: the range to lookup
-    /// - Returns: a boolean indicating the result
-    func hasReplacementLinkNear(in range: NSRange) -> Bool {
-        var hasInnerReplacement = false
-        enumerateTypedAttribute(.replacementContent, in: range) { (_: ReplacementContent, _, stop) in
-            hasInnerReplacement = true
-            stop.pointee = true
-        }
-        return hasInnerReplacement
-            || hasAttribute(.replacementContent, at: range.location - 1)
-            || hasAttribute(.replacementContent, at: range.upperBound)
-    }
-}
-
-private extension NSAttributedString {
-    /// Computes whether the attributed string contains given attribute at index.
-    ///
-    /// - Parameters:
-    ///   - attrName: the key for the attribute to test
-    ///   - index: the index to lookup
-    /// - Returns: a boolean indicating the result
-    func hasAttribute(_ attrName: NSAttributedString.Key, at index: Int) -> Bool {
-        guard index >= 0, index < length else { return false }
-        return attribute(attrName, at: index, effectiveRange: nil) != nil
-    }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -119,7 +119,6 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
     }
 
     private var hasPendingFormats = false
-    private var storedLinkActionState: ActionState?
 
     // MARK: - Public
 
@@ -408,7 +407,6 @@ private extension WysiwygComposerViewModel {
         switch update.menuState() {
         case let .update(actionStates: actionStates):
             self.actionStates = actionStates
-            storedLinkActionState = actionStates[.link]
         default:
             break
         }
@@ -420,17 +418,6 @@ private extension WysiwygComposerViewModel {
             suggestionPattern = nil
         case let .suggestion(suggestionPattern: pattern):
             suggestionPattern = pattern
-        }
-
-        disableLinkActionIfNeeded()
-    }
-
-    /// Disable the link action button if we are near a pillified version of a link.
-    func disableLinkActionIfNeeded() {
-        if attributedContent.text.hasReplacementLinkNear(in: attributedContent.selection) {
-            actionStates[.link] = .disabled
-        } else {
-            actionStates[.link] = storedLinkActionState
         }
     }
 


### PR DESCRIPTION
* Defines helpers for immutable content in Rust
* Disable link button when an immutable link is in range
* Allow parsing link attributes properly to get them in the model
* Removed the iOS code disabling buttons on Pills locations (this means that we could edit a Pill with the link button, if the link does not contain `contenteditable="false"`, but it should be the hosting application responsibility to provide proper HTML)