### PR TITLE
Fix Android build for disabled link action

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/viewmodel/EditorViewModel.kt
@@ -140,6 +140,7 @@ internal class EditorViewModel(
                 is ComposerLinkAction.Edit -> LinkAction.SetLink(currentLink = it.link)
                 is ComposerLinkAction.Create -> LinkAction.SetLink(currentLink = null)
                 is ComposerLinkAction.CreateWithText -> LinkAction.InsertLink
+                is ComposerLinkAction.Disabled -> null
             }
         }
 


### PR DESCRIPTION
Add missing new case (nothing to do in this context since link button is disabled from Rust -> https://github.com/matrix-org/matrix-rich-text-editor/pull/627)