### PR TITLE
Use reference and clone in wasm bindings

### DIFF
--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -287,12 +287,12 @@ impl ComposerModel {
         &mut self,
         link: &str,
         text: &str,
-        suggestion: SuggestionPattern,
+        suggestion: &SuggestionPattern,
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.set_link_suggestion(
             Utf16String::from_str(link),
             Utf16String::from_str(text),
-            wysiwyg::SuggestionPattern::from(suggestion),
+            wysiwyg::SuggestionPattern::from(suggestion.clone()),
         ))
     }
 


### PR DESCRIPTION
This is a fix for a memory issue being caused in web that was causing CI issues in react-sdk.