### PR TITLE
Mention delete behaviour fix

### DIFF
--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -215,6 +215,9 @@ where
         // case, we handle it by calling the relecant method once which will adjust the
         // selection to cover that node and then remove it, ending the recursive calls
         if self.cursor_is_inside_non_editable_text_node() {
+            // TODO fix the divergence in behaviour between delete and backspace.
+            // `do_delete` was recently added and there's some work needed to make
+            // backspace and delete be equivalent, as well as the do_* functions
             return match direction {
                 Direction::Forwards => self.do_delete(),
                 Direction::Backwards => self.backspace(),

--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -113,10 +113,12 @@ where
     /// the whole of that node before continuing with the backspace/deletion flow
     fn handle_non_editable_selection(&mut self, direction: &Direction) {
         let (s, e) = self.safe_selection();
-        let range = if direction == &Direction::Backwards {
-            self.state.dom.find_range(s, e)
-        } else {
-            self.state.dom.find_range(s, e + 1)
+
+        // when deleting (ie going "forwards"), to include the relevant leaf node we need to
+        // add one to the end of the range to make sure we can find it
+        let range = match direction {
+            Direction::Forwards => self.state.dom.find_range(s, e + 1),
+            Direction::Backwards => self.state.dom.find_range(s, e),
         };
 
         let first_leaf = range.locations.iter().find(|loc| {

--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -46,7 +46,7 @@ where
 {
     pub fn backspace(&mut self) -> ComposerUpdate<S> {
         self.push_state_to_history();
-        self.handle_non_editable_selection();
+        self.handle_non_editable_selection(&Direction::Backwards);
 
         let (s, e) = self.safe_selection();
         if s == e {
@@ -111,9 +111,13 @@ where
 
     /// If we have cursor at the edge of or inside a non-editable text node, expand the selection to cover
     /// the whole of that node before continuing with the backspace/deletion flow
-    fn handle_non_editable_selection(&mut self) {
+    fn handle_non_editable_selection(&mut self, direction: &Direction) {
         let (s, e) = self.safe_selection();
-        let range = self.state.dom.find_range(s, e);
+        let range = if direction == &Direction::Backwards {
+            self.state.dom.find_range(s, e)
+        } else {
+            self.state.dom.find_range(s, e + 1)
+        };
 
         let first_leaf = range.locations.iter().find(|loc| {
             loc.is_leaf() || (loc.kind.is_block_kind() && loc.is_empty())
@@ -144,7 +148,7 @@ where
     }
 
     pub fn do_delete(&mut self) -> ComposerUpdate<S> {
-        self.handle_non_editable_selection();
+        self.handle_non_editable_selection(&Direction::Forwards);
 
         if self.state.start == self.state.end {
             let (s, _) = self.safe_selection();
@@ -206,10 +210,13 @@ where
         location: DomLocation,
     ) -> ComposerUpdate<S> {
         // we could have entered a non-editable node during this run, if this is the
-        // case, we handle it by calling the delete method once which will adjust the
+        // case, we handle it by calling the relecant method once which will adjust the
         // selection to cover that node and then remove it, ending the recursive calls
         if self.cursor_is_inside_non_editable_text_node() {
-            return self.do_delete();
+            return match direction {
+                Direction::Forwards => self.do_delete(),
+                Direction::Backwards => self.backspace(),
+            };
         }
         match self.state.dom.lookup_node_mut(&location.node_handle) {
             // we should never be passed a container

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -921,17 +921,29 @@ fn delete_mention_from_inside_link() {
 }
 
 #[test]
-fn delete_mention_multiple() {
+fn delete_first_mention_of_multiple() {
     let mut model = cm(
         "<a contenteditable=\"false\" href=\"https://matrix.org\">|first</a><a contenteditable=\"false\" href=\"https://matrix.org\">second</a>",
     );
-    model.backspace();
+    model.delete();
     assert_eq!(
         restore_whitespace(&tx(&model)),
         "<a contenteditable=\"false\" href=\"https://matrix.org\">|second</a>"
     );
-    model.backspace();
+    model.delete();
     assert_eq!(restore_whitespace(&tx(&model)), "|");
+}
+
+#[test]
+fn delete_second_mention_of_multiple() {
+    let mut model = cm(
+        "<a contenteditable=\"false\" href=\"https://matrix.org\">first</a> <a contenteditable=\"false\" href=\"https://matrix.org\">|second</a>",
+    );
+    model.delete();
+    assert_eq!(
+        restore_whitespace(&tx(&model)),
+        "<a contenteditable=\"false\" href=\"https://matrix.org\">first</a> |"
+    );
 }
 
 #[test]


### PR DESCRIPTION
I noticed some incorrect behaviour when deleting the second of multiple mentions - it would delete the first letter of the immutable link, not the whole link.

Example of side by side behaviour in video below, before on the left, after on the right:

https://user-images.githubusercontent.com/56027671/228244598-3e76a9f2-4edb-4ff2-aad9-21d5c6c72861.mov

This PR fixes the unwanted behaviour and adds tests to cover it