### PR TITLE
Pass "data-mention-type" to model

### DIFF
--- a/platforms/ios/example/Wysiwyg/Views/WysiwygSuggestionList.swift
+++ b/platforms/ios/example/Wysiwyg/Views/WysiwygSuggestionList.swift
@@ -31,7 +31,7 @@ struct WysiwygSuggestionList: View {
                         Text(Users.title).underline()
                         ForEach(users) { user in
                             Button {
-                                viewModel.setMention(link: user.url, name: user.name, key: .at)
+                                viewModel.setMention(link: user.url, name: user.name, mentionType: .user)
                             } label: {
                                 HStack(spacing: 4) {
                                     Image(systemName: user.iconSystemName)
@@ -47,7 +47,7 @@ struct WysiwygSuggestionList: View {
                         Text(Rooms.title).underline()
                         ForEach(rooms) { room in
                             Button {
-                                viewModel.setMention(link: room.url, name: room.name, key: .hash)
+                                viewModel.setMention(link: room.url, name: room.name, mentionType: .room)
                             } label: {
                                 HStack(spacing: 4) {
                                     Image(systemName: room.iconSystemName)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
@@ -32,7 +32,7 @@ protocol ComposerModelWrapperProtocol {
     func enter() -> ComposerUpdate
     func setLink(link: String) -> ComposerUpdate
     func setLinkWithText(link: String, text: String) -> ComposerUpdate
-    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern) -> ComposerUpdate
+    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern, mentionType: WysiwygMentionType) -> ComposerUpdate
     func removeLinks() -> ComposerUpdate
     func toTree() -> String
     func getCurrentDomState() -> ComposerState
@@ -121,8 +121,11 @@ final class ComposerModelWrapper: ComposerModelWrapperProtocol {
         execute { try $0.setLinkWithText(link: link, text: text) }
     }
 
-    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern) -> ComposerUpdate {
-        execute { try $0.setLinkSuggestion(link: link, text: text, suggestion: suggestion) }
+    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern, mentionType: WysiwygMentionType) -> ComposerUpdate {
+        let attributes = [
+            Attribute(key: "data-mention-type", value: mentionType.rawValue)
+        ]
+        return execute { try $0.setLinkSuggestion(link: link, text: text, suggestion: suggestion, attributes: attributes) }
     }
 
     func removeLinks() -> ComposerUpdate {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -227,10 +227,10 @@ public extension WysiwygComposerViewModel {
     ///   - link: The link to the user.
     ///   - name: The display name of the user.
     ///   - key: The pattern key to use.
-    func setMention(link: String, name: String, key: PatternKey) {
+    func setMention(link: String, name: String, mentionType: WysiwygMentionType) {
         let update: ComposerUpdate
-        if let suggestionPattern, suggestionPattern.key == key {
-            update = model.setLinkSuggestion(link: link, text: name, suggestion: suggestionPattern)
+        if let suggestionPattern, suggestionPattern.key == mentionType.patternKey {
+            update = model.setLinkSuggestion(link: link, text: name, suggestion: suggestionPattern, mentionType: mentionType)
         } else {
             _ = model.setLinkWithText(link: link, text: name)
             // FIXME: remove this if Rust adds this space for free

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygMentionType.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygMentionType.swift
@@ -1,0 +1,46 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public enum WysiwygMentionType: String {
+    case user
+    case room
+}
+
+extension WysiwygMentionType {
+    public var patternKey: PatternKey {
+        switch self {
+        case .user:
+            return .at
+        case .room:
+            return .hash
+        }
+    }
+}
+
+extension PatternKey {
+    public var mentionType: WysiwygMentionType? {
+        switch self {
+        case .at:
+            return .user
+        case .hash:
+            return .room
+        case .slash:
+            return nil
+        }
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
@@ -50,11 +50,11 @@ extension WysiwygComposerViewModelTests {
 
     func testAtSuggestionCanBeUsed() {
         _ = viewModel.replaceText(range: .zero, replacementText: "@ali")
-        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", key: .at)
+        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", mentionType: .user)
         XCTAssertEqual(
             viewModel.content.html,
             """
-            <a href="https://matrix.to/#/@alice:matrix.org" contenteditable="false" data-mention-type="user">Alice</a>\u{00A0}
+            <a data-mention-type="user" contenteditable="false" href="https://matrix.to/#/@alice:matrix.org">Alice</a>\u{00A0}
             """
         )
     }
@@ -62,7 +62,7 @@ extension WysiwygComposerViewModelTests {
     func testAtMentionWithNoSuggestion() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
         viewModel.select(range: .init(location: 0, length: 4))
-        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", key: .at)
+        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", mentionType: .user)
         // Text is not removed, and the
         // mention is added after the text
         XCTAssertEqual(
@@ -76,7 +76,7 @@ extension WysiwygComposerViewModelTests {
     func testAtMentionWithNoSuggestionAtLeading() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
         viewModel.select(range: .init(location: 0, length: 0))
-        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", key: .at)
+        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", mentionType: .user)
         // Text is not removed, and the mention is added before the text
         XCTAssertEqual(
             viewModel.content.html,
@@ -88,11 +88,11 @@ extension WysiwygComposerViewModelTests {
 
     func testHashSuggestionCanBeUsed() {
         _ = viewModel.replaceText(range: .zero, replacementText: "#roo")
-        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", key: .hash)
+        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", mentionType: .room)
         XCTAssertEqual(
             viewModel.content.html,
             """
-            <a href="https://matrix.to/#/#room1:matrix.org" contenteditable="false" data-mention-type="room">Room 1</a>\u{00A0}
+            <a data-mention-type="room" contenteditable="false" href="https://matrix.to/#/#room1:matrix.org">Room 1</a>\u{00A0}
             """
         )
     }
@@ -100,7 +100,7 @@ extension WysiwygComposerViewModelTests {
     func testHashMentionWithNoSuggestion() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
         viewModel.select(range: .init(location: 0, length: 4))
-        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", key: .hash)
+        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", mentionType: .room)
         XCTAssertEqual(
             viewModel.content.html,
             """
@@ -112,7 +112,7 @@ extension WysiwygComposerViewModelTests {
     func testHashMentionWithNoSuggestionAtLeading() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
         viewModel.select(range: .init(location: 0, length: 0))
-        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", key: .hash)
+        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", mentionType: .room)
         XCTAssertEqual(
             viewModel.content.html,
             """

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
@@ -29,13 +29,16 @@ extension WysiwygComposerTests {
 
         model
             .action {
-                $0.setLinkSuggestion(link: "https://matrix.to/#/@alice:matrix.org",
-                                     text: "Alice",
-                                     suggestion: suggestionPattern)
+                $0.setLinkSuggestion(
+                    link: "https://matrix.to/#/@alice:matrix.org",
+                    text: "Alice",
+                    suggestion: suggestionPattern,
+                    mentionType: .user
+                )
             }
             .assertHtml(
                 """
-                <a href="https://matrix.to/#/@alice:matrix.org" contenteditable="false" data-mention-type="user">Alice</a>\(String.nbsp)
+                <a data-mention-type="user" contenteditable="false" href="https://matrix.to/#/@alice:matrix.org">Alice</a>\(String.nbsp)
                 """
             )
     }
@@ -51,13 +54,16 @@ extension WysiwygComposerTests {
 
         model
             .action {
-                $0.setLinkSuggestion(link: "https://matrix.to/#/#room1:matrix.org",
-                                     text: "Room 1",
-                                     suggestion: suggestionPattern)
+                $0.setLinkSuggestion(
+                    link: "https://matrix.to/#/#room1:matrix.org",
+                    text: "Room 1",
+                    suggestion: suggestionPattern,
+                    mentionType: .room
+                )
             }
             .assertHtml(
                 """
-                <a href="https://matrix.to/#/#room1:matrix.org" contenteditable="false" data-mention-type="room">Room 1</a>\(String.nbsp)
+                <a data-mention-type="room" contenteditable="false" href="https://matrix.to/#/#room1:matrix.org">Room 1</a>\(String.nbsp)
                 """
             )
     }


### PR DESCRIPTION
- Pass `data-mention-type` to model
- Add `WysiwygMentionType` to clean up the ViewModel api/logic a bit.
- Fix tests