### PR TITLE
Fix selection issue

### DIFF
--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -852,6 +852,23 @@ describe('textNodeNeedsExtraOffset', () => {
         expect(node).toBe(editor.childNodes[0].childNodes[0]);
         expect(textNodeNeedsExtraOffset(node)).toBe(false);
     });
+
+    // eslint-disable-next-line max-len
+    it('applies extra offset for nested formatting inside a paragraph adjacent to a populated list', () => {
+        // When
+        setEditorHtml(
+            '<p><strong>line one</strong></p><ul><li>item one</li></ul>',
+        );
+
+        // put the cursor before the "l" of line
+        const { node } = computeNodeAndOffset(editor, 0);
+
+        // Then
+        // check that the node we have is the text node "line one" and that we
+        // will add an offset for it
+        expect(node).toBe(editor.childNodes[0].childNodes[0].childNodes[0]);
+        expect(textNodeNeedsExtraOffset(node)).toBe(true);
+    });
 });
 
 describe('textLength', () => {

--- a/platforms/web/lib/dom.test.ts
+++ b/platforms/web/lib/dom.test.ts
@@ -854,10 +854,27 @@ describe('textNodeNeedsExtraOffset', () => {
     });
 
     // eslint-disable-next-line max-len
-    it('applies extra offset for nested formatting inside a paragraph adjacent to a populated list', () => {
+    it('applies extra offset for nested formatting inside a paragraph adjacent to unordered list', () => {
         // When
         setEditorHtml(
             '<p><strong>line one</strong></p><ul><li>item one</li></ul>',
+        );
+
+        // put the cursor before the "l" of line
+        const { node } = computeNodeAndOffset(editor, 0);
+
+        // Then
+        // check that the node we have is the text node "line one" and that we
+        // will add an offset for it
+        expect(node).toBe(editor.childNodes[0].childNodes[0].childNodes[0]);
+        expect(textNodeNeedsExtraOffset(node)).toBe(true);
+    });
+
+    // eslint-disable-next-line max-len
+    it('applies extra offset for nested formatting inside a paragraph adjacent to unordered list', () => {
+        // When
+        setEditorHtml(
+            '<p><strong>line one</strong></p><ol><li>item one</li></ol>',
         );
 
         // put the cursor before the "l" of line

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -538,6 +538,8 @@ function isInlineNode(node: Node | ParentNode | null) {
 // _OFFSET_NODE_NAMES array will require the addition of an offset (of one).
 // Nb, whilst lists require this offset, we consider the offset to apply to each
 // list item, the enclosing list type tag does not add an extra offset.
+// We need the enclosing list tags in the array as we also use this check on
+// sibling nodes.
 function isNodeRequiringExtraOffset(node: Node) {
     return EXTRA_OFFSET_NODE_NAMES.includes(node.nodeName || '');
 }

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -527,24 +527,18 @@ export function textNodeNeedsExtraOffset(node: Node | null) {
 }
 
 const INLINE_NODE_NAMES = ['EM', 'U', 'STRONG', 'DEL', 'CODE', 'A'];
-const EXTRA_OFFSET_NODE_NAMES = ['LI', 'PRE', 'BLOCKQUOTE', 'P'];
+const EXTRA_OFFSET_NODE_NAMES = ['OL', 'UL', 'LI', 'PRE', 'BLOCKQUOTE', 'P'];
 
 function isInlineNode(node: Node | ParentNode | null) {
     if (node === null) return false;
     return INLINE_NODE_NAMES.includes(node.nodeName || '');
 }
 
+// Due to the way the rust model handles indexing, all of the nodes in the EXTRA
+// _OFFSET_NODE_NAMES array will require the addition of an offset (of one).
+// Nb, whilst lists require this offset, we consider the offset to apply to each
+// list item, the enclosing list type tag does not add an extra offset.
 function isNodeRequiringExtraOffset(node: Node) {
-    // note this isn't simply a block node, we need to ensure that for lists we
-    // do not add an extra offset for the ol/ul tag, only for the list items
-    // themselves
-
-    // with the paragraph refactor, we could end up in a situation where we have
-    // a p tag containing formatted text next to a list, so if this is the case,
-    // we do want to add an extra offset _if_ the list has any children
-    if (node.nodeName === 'UL' || node.nodeName === 'OL') {
-        return node.hasChildNodes();
-    }
     return EXTRA_OFFSET_NODE_NAMES.includes(node.nodeName || '');
 }
 

--- a/platforms/web/lib/dom.ts
+++ b/platforms/web/lib/dom.ts
@@ -538,6 +538,13 @@ function isNodeRequiringExtraOffset(node: Node) {
     // note this isn't simply a block node, we need to ensure that for lists we
     // do not add an extra offset for the ol/ul tag, only for the list items
     // themselves
+
+    // with the paragraph refactor, we could end up in a situation where we have
+    // a p tag containing formatted text next to a list, so if this is the case,
+    // we do want to add an extra offset _if_ the list has any children
+    if (node.nodeName === 'UL' || node.nodeName === 'OL') {
+        return node.hasChildNodes();
+    }
     return EXTRA_OFFSET_NODE_NAMES.includes(node.nodeName || '');
 }
 


### PR DESCRIPTION
Fixes #638 

This has probably been around a little while, since we introduced paragraphs. It was the particular edge case where you have a formatting node in a paragraph node that's a sibling of a list.

Have made the fix and added a test to cover both list cases.