### PR TITLE
Use attributes - contenteditable from client

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -227,6 +227,9 @@ impl ComposerModel {
         ))
     }
 
+    /// This function creates a link with the first argument being the href, the second being the
+    /// display text, the third being the (rust model) suggestion that is being replaced and the
+    /// final argument being a list of attributes that will be added to the Link.
     pub fn set_link_suggestion(
         self: &Arc<Self>,
         link: String,

--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -223,7 +223,7 @@ impl ComposerModel {
             self.inner
                 .lock()
                 .unwrap()
-                .set_link_with_text(link, text, None),
+                .set_link_with_text(link, text, vec![]),
         ))
     }
 
@@ -232,16 +232,25 @@ impl ComposerModel {
         link: String,
         text: String,
         suggestion: SuggestionPattern,
-        attributes: Option<Vec<(Utf16String, Utf16String)>>,
+        attributes: Vec<Attribute>,
     ) -> Arc<ComposerUpdate> {
         let link = Utf16String::from_str(&link);
         let text = Utf16String::from_str(&text);
         let suggestion = wysiwyg::SuggestionPattern::from(suggestion);
+        let attrs = attributes
+            .iter()
+            .map(|attr| {
+                (
+                    Utf16String::from_str(&attr.key),
+                    Utf16String::from_str(&attr.value),
+                )
+            })
+            .collect();
         Arc::new(ComposerUpdate::from(
             self.inner
                 .lock()
                 .unwrap()
-                .set_link_suggestion(link, text, suggestion, attributes),
+                .set_link_suggestion(link, text, suggestion, attrs),
         ))
     }
 
@@ -296,4 +305,9 @@ impl ComposerModel {
     pub fn debug_panic(self: &Arc<Self>) {
         panic!("This should only happen in tests.");
     }
+}
+
+pub struct Attribute {
+    pub key: String,
+    pub value: String,
 }

--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -232,6 +232,7 @@ impl ComposerModel {
         link: String,
         text: String,
         suggestion: SuggestionPattern,
+        attributes: Option<Vec<(Utf16String, Utf16String)>>,
     ) -> Arc<ComposerUpdate> {
         let link = Utf16String::from_str(&link);
         let text = Utf16String::from_str(&text);
@@ -240,7 +241,7 @@ impl ComposerModel {
             self.inner
                 .lock()
                 .unwrap()
-                .set_link_suggestion(link, text, suggestion),
+                .set_link_suggestion(link, text, suggestion, attributes),
         ))
     }
 

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -135,7 +135,7 @@ mod test {
             "https://matrix.to/#/@alice:matrix.org".into(),
             "Alice".into(),
             suggestion_pattern,
-            None,
+            vec![],
         );
         assert_eq!(
             model.get_content_as_html(),

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -31,8 +31,8 @@ mod test {
     use std::{collections::HashMap, sync::Arc};
 
     use crate::{
-        ActionState, ComposerAction, ComposerModel, MenuAction, MenuState,
-        SuggestionPattern,
+        ActionState, Attribute, ComposerAction, ComposerModel, MenuAction,
+        MenuState, SuggestionPattern,
     };
 
     #[test]
@@ -135,11 +135,20 @@ mod test {
             "https://matrix.to/#/@alice:matrix.org".into(),
             "Alice".into(),
             suggestion_pattern,
-            vec![],
+            vec![
+                Attribute {
+                    key: "contenteditable".into(),
+                    value: "false".into(),
+                },
+                Attribute {
+                    key: "data-mention-type".into(),
+                    value: "user".into(),
+                },
+            ],
         );
         assert_eq!(
             model.get_content_as_html(),
-            "<a href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\" data-mention-type=\"user\">Alice</a>\u{a0}",
+            "<a contenteditable=\"false\" data-mention-type=\"user\" href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>\u{a0}",
         )
     }
 

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -135,6 +135,7 @@ mod test {
             "https://matrix.to/#/@alice:matrix.org".into(),
             "Alice".into(),
             suggestion_pattern,
+            None,
         );
         assert_eq!(
             model.get_content_as_html(),

--- a/bindings/wysiwyg-ffi/src/lib.rs
+++ b/bindings/wysiwyg-ffi/src/lib.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 
 pub use crate::ffi_action_state::ActionState;
 pub use crate::ffi_composer_action::ComposerAction;
+pub use crate::ffi_composer_model::Attribute;
 pub use crate::ffi_composer_model::ComposerModel;
 pub use crate::ffi_composer_state::ComposerState;
 pub use crate::ffi_composer_update::ComposerUpdate;

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -46,7 +46,7 @@ interface ComposerModel {
     ComposerUpdate unindent();
     ComposerUpdate set_link(string link);
     ComposerUpdate set_link_with_text(string link, string text);
-    ComposerUpdate set_link_suggestion(string link, string text, SuggestionPattern suggestion);
+    ComposerUpdate set_link_suggestion(string link, string text, SuggestionPattern suggestion, sequence<Attribute> attributes);
     ComposerUpdate remove_links();
     ComposerUpdate code_block();
     ComposerUpdate quote();
@@ -56,6 +56,11 @@ interface ComposerModel {
     ComposerState get_current_dom_state();
     record<ComposerAction, ActionState> action_states();
     LinkAction get_link_action();
+};
+
+dictionary Attribute {
+    string key;
+    string value;
 };
 
 interface ComposerUpdate {

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -75,6 +75,23 @@ impl IntoFfi for &HashMap<wysiwyg::ComposerAction, wysiwyg::ActionState> {
     }
 }
 
+trait ToUtf16TupleVec {
+    fn into_vec(self) -> Vec<(Utf16String, Utf16String)>;
+}
+
+impl ToUtf16TupleVec for js_sys::Map {
+    fn into_vec(self) -> Vec<(Utf16String, Utf16String)> {
+        let mut vec = vec![];
+        self.for_each(&mut |value, key| {
+            vec.push((
+                Utf16String::from_str(&key.as_string().unwrap()),
+                Utf16String::from_str(&value.as_string().unwrap()),
+            ));
+        });
+        vec
+    }
+}
+
 #[wasm_bindgen]
 #[derive(Default)]
 pub struct ComposerModel {
@@ -279,7 +296,7 @@ impl ComposerModel {
         ComposerUpdate::from(self.inner.set_link_with_text(
             Utf16String::from_str(link),
             Utf16String::from_str(text),
-            None,
+            vec![],
         ))
     }
 
@@ -288,13 +305,13 @@ impl ComposerModel {
         link: &str,
         text: &str,
         suggestion: SuggestionPattern,
-        attributes: Option<Vec<(&str, &str)>>,
+        attributes: js_sys::Map,
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.set_link_suggestion(
             Utf16String::from_str(link),
             Utf16String::from_str(text),
             wysiwyg::SuggestionPattern::from(suggestion),
-            attributes,
+            attributes.into_vec(),
         ))
     }
 

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -288,11 +288,13 @@ impl ComposerModel {
         link: &str,
         text: &str,
         suggestion: SuggestionPattern,
+        attributes: Option<Vec<(S, S)>>,
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.set_link_suggestion(
             Utf16String::from_str(link),
             Utf16String::from_str(text),
             wysiwyg::SuggestionPattern::from(suggestion),
+            attributes,
         ))
     }
 

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -300,6 +300,9 @@ impl ComposerModel {
         ))
     }
 
+    /// This function creates a link with the first argument being the href, the second being the
+    /// display text, the third being the (rust model) suggestion that is being replaced and the
+    /// final argument being a map of html attributes that will be added to the Link.
     pub fn set_link_suggestion(
         &mut self,
         link: &str,

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -288,7 +288,7 @@ impl ComposerModel {
         link: &str,
         text: &str,
         suggestion: SuggestionPattern,
-        attributes: Option<Vec<(S, S)>>,
+        attributes: Option<Vec<(&str, &str)>>,
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.set_link_suggestion(
             Utf16String::from_str(link),

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -69,7 +69,7 @@ where
         link: S,
         text: S,
         suggestion: SuggestionPattern,
-        attributes: Option<Vec<(S, S)>>,
+        attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
         self.do_replace_text_in(S::default(), suggestion.start, suggestion.end);
         self.state.start = Location::from(suggestion.start);
@@ -104,7 +104,7 @@ where
         &mut self,
         link: S,
         text: S,
-        attributes: Option<Vec<(S, S)>>,
+        attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
         let (s, _) = self.safe_selection();
         self.push_state_to_history();
@@ -120,14 +120,14 @@ where
 
         let range = self.state.dom.find_range(s, e);
 
-        self.set_link_in_range(link, range, None)
+        self.set_link_in_range(link, range, vec![])
     }
 
     fn set_link_in_range(
         &mut self,
         mut link: S,
         range: Range,
-        attributes: Option<Vec<(S, S)>>,
+        attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
         self.add_http_scheme(&mut link);
 

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -71,6 +71,10 @@ where
         suggestion: SuggestionPattern,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
+        // TODO - this function allows us to accept a Vec of attributes to add to the Link we create,
+        // but these attributes will be present in the html of the message we output. We may need to
+        // add a step in the future that strips these attributes from the html before it is sent.
+
         self.do_replace_text_in(S::default(), suggestion.start, suggestion.end);
         self.state.start = Location::from(suggestion.start);
         self.state.end = self.state.start;

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -213,7 +213,7 @@ where
             // Create a new link node containing the passed range
             let inserted = self.state.dom.insert_parent(
                 &range,
-                DomNode::new_link(link.clone(), vec![], attributes),
+                DomNode::new_link(link.clone(), vec![], attributes.clone()),
             );
             // Remove any child links inside it
             self.delete_child_links(&inserted);

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -685,8 +685,6 @@ impl Display for ItemNode {
 
 #[cfg(test)]
 mod test {
-    use std::ffi::FromVecWithNulError;
-
     use widestring::Utf16String;
 
     use crate::dom::nodes::dom_node::DomNode;

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -131,7 +131,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(model.state.dom.to_html(), r#"A<a href="link">B</a>C"#)
@@ -145,7 +145,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(model.state.dom.to_html(), r#"<a href="link">AB</a>C"#)
@@ -159,7 +159,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(model.state.dom.to_html(), r#"A<a href="link">BC</a>"#)
@@ -173,7 +173,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(model.state.dom.to_html(), r#"<a href="link">ABC</a>"#)
@@ -187,7 +187,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(
@@ -204,7 +204,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(
@@ -221,7 +221,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(
@@ -238,7 +238,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(
@@ -255,7 +255,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(
@@ -272,7 +272,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(
@@ -290,7 +290,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(
@@ -307,7 +307,7 @@ mod test {
 
         model.state.dom.insert_parent(
             &range,
-            DomNode::new_link(utf16("link"), vec![], None),
+            DomNode::new_link(utf16("link"), vec![], vec![]),
         );
 
         assert_eq!(

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -381,21 +381,15 @@ where
 
     pub fn new_link(
         url: S,
-        attributes: Option<Vec<(S, S)>>,
         children: Vec<DomNode<S>>,
-        mention_type: Option<S>,
+        attributes: Option<Vec<(S, S)>>,
     ) -> Self {
-        // FIXME: mention_type could be removed, and the hosting application could just provide attributes
-        // this would allow the Rust code to stay as generic as possible, since it should only care abouy
+        // Hosting application may provide attributes but always provides url, this
+        // allows the Rust code to stay as generic as possible, since it should only care about
         // `contenteditable="false"` to implement custom behaviours for immutable links.
-        let mut attrs =
-            attributes.unwrap_or_else(|| vec![("href".into(), url.clone())]);
-        if let Some(m_type) = mention_type {
-            // if we have a mention, add attributes to make it non-editable and to track
-            // the type of mention we have
-            attrs.push(("contenteditable".into(), "false".into()));
-            attrs.push(("data-mention-type".into(), m_type))
-        }
+        let mut attrs = attributes.unwrap_or_else(|| vec![]);
+        attrs.push(("href".into(), url.clone()));
+
         Self {
             name: "a".into(),
             kind: ContainerNodeKind::Link(url),

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -382,13 +382,13 @@ where
     pub fn new_link(
         url: S,
         children: Vec<DomNode<S>>,
-        attributes: Option<Vec<(S, S)>>,
+        attributes: Vec<(S, S)>,
     ) -> Self {
         // Hosting application may provide attributes but always provides url, this
         // allows the Rust code to stay as generic as possible, since it should only care about
         // `contenteditable="false"` to implement custom behaviours for immutable links.
-        let mut attrs = attributes.unwrap_or_else(|| vec![]);
-        attrs.push(("href".into(), url.clone()));
+        let mut attrs = attributes.clone();
+        attrs.push(("href".into(), url.clone())); // don't clone here
 
         Self {
             name: "a".into(),

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -382,18 +382,17 @@ where
     pub fn new_link(
         url: S,
         children: Vec<DomNode<S>>,
-        attributes: Vec<(S, S)>,
+        mut attributes: Vec<(S, S)>,
     ) -> Self {
         // Hosting application may provide attributes but always provides url, this
         // allows the Rust code to stay as generic as possible, since it should only care about
         // `contenteditable="false"` to implement custom behaviours for immutable links.
-        let mut attrs = attributes.clone();
-        attrs.push(("href".into(), url.clone())); // don't clone here
+        attributes.push(("href".into(), url.clone()));
 
         Self {
             name: "a".into(),
             kind: ContainerNodeKind::Link(url),
-            attrs: Some(attrs),
+            attrs: Some(attributes),
             children,
             handle: DomHandle::new_unset(),
         }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -127,14 +127,9 @@ where
     pub fn new_link(
         url: S,
         children: Vec<DomNode<S>>,
-        mention_type: Option<S>,
+        attributes: Option<Vec<(S, S)>>,
     ) -> DomNode<S> {
-        DomNode::Container(ContainerNode::new_link(
-            url,
-            None,
-            children,
-            mention_type,
-        ))
+        DomNode::Container(ContainerNode::new_link(url, children, attributes))
     }
 
     pub fn is_container_node(&self) -> bool {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -127,7 +127,7 @@ where
     pub fn new_link(
         url: S,
         children: Vec<DomNode<S>>,
-        attributes: Option<Vec<(S, S)>>,
+        attributes: Vec<(S, S)>,
     ) -> DomNode<S> {
         DomNode::Container(ContainerNode::new_link(url, children, attributes))
     }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -276,9 +276,8 @@ mod sys {
 
             DomNode::Container(ContainerNode::new_link(
                 child.get_attr("href").unwrap_or("").into(),
-                Some(attributes),
                 Vec::new(),
-                None,
+                Some(attributes),
             ))
         }
 

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -271,6 +271,7 @@ mod sys {
             let attributes = child
                 .attrs
                 .iter()
+                .filter(|(k, _)| k != &String::from("href"))
                 .map(|(k, v)| (k.as_str().into(), v.as_str().into()))
                 .collect();
 

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -277,7 +277,7 @@ mod sys {
             DomNode::Container(ContainerNode::new_link(
                 child.get_attr("href").unwrap_or("").into(),
                 Vec::new(),
-                Some(attributes),
+                attributes,
             ))
         }
 

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -733,7 +733,7 @@ mod js {
                                 .unwrap_or_default()
                                 .into(),
                             self.convert(node.child_nodes())?.take_children(),
-                            None,
+                            vec![],
                         ));
                         self.current_path.pop();
                     }

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -387,7 +387,7 @@ fn set_link_with_text() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -401,7 +401,7 @@ fn set_link_with_text_and_undo() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -417,7 +417,7 @@ fn set_link_with_text_in_container() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -431,7 +431,7 @@ fn set_link_with_text_on_blank_selection() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
 }
@@ -442,7 +442,7 @@ fn set_link_with_text_on_blank_selection_after_text() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -456,7 +456,7 @@ fn set_link_with_text_on_blank_selection_before_text() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -470,7 +470,7 @@ fn set_link_with_text_on_blank_selection_between_texts() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -484,7 +484,7 @@ fn set_link_with_text_on_blank_selection_in_container() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -498,7 +498,7 @@ fn set_link_with_text_on_blank_selection_with_line_break() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -512,7 +512,7 @@ fn set_link_with_text_on_blank_selection_with_different_containers() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(tx(&model), "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i>test_italic</i>");
 }
@@ -527,7 +527,7 @@ fn set_link_with_text_at_end_of_a_link() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(tx(&model), "<a href=\"https://matrix.org\">test_link</a><a href=\"https://element.io\">added_link|</a>");
 }
@@ -539,7 +539,7 @@ fn set_link_with_text_within_a_link() {
     model.set_link_with_text(
         utf16("https://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -550,7 +550,7 @@ fn set_link_with_text_within_a_link() {
 #[test]
 fn set_link_without_http_scheme_and_www() {
     let mut model = cm("|");
-    model.set_link_with_text(utf16("element.io"), utf16("added_link"), None);
+    model.set_link_with_text(utf16("element.io"), utf16("added_link"), vec![]);
     assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
 }
 
@@ -560,7 +560,7 @@ fn set_link_without_http_scheme() {
     model.set_link_with_text(
         utf16("www.element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -574,7 +574,7 @@ fn set_link_do_not_change_scheme_for_http() {
     model.set_link_with_text(
         utf16("https://www.element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -588,7 +588,7 @@ fn set_link_do_not_change_scheme_for_udp() {
     model.set_link_with_text(
         utf16("udp://element.io"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(tx(&model), "<a href=\"udp://element.io\">added_link|</a>");
 }
@@ -599,7 +599,7 @@ fn set_link_do_not_change_scheme_for_mail() {
     model.set_link_with_text(
         utf16("mailto:mymail@mail.com"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -613,7 +613,7 @@ fn set_link_add_mail_scheme() {
     model.set_link_with_text(
         utf16("mymail@mail.com"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -627,7 +627,7 @@ fn set_link_add_mail_scheme_with_plus() {
     model.set_link_with_text(
         utf16("mymail+01@mail.com"),
         utf16("added_link"),
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -765,7 +765,11 @@ fn create_link_after_enter_with_formatting_applied() {
     model.bold();
     model.replace_text("test".into());
     model.enter();
-    model.set_link_with_text("https://matrix.org".into(), "test".into(), None);
+    model.set_link_with_text(
+        "https://matrix.org".into(),
+        "test".into(),
+        vec![],
+    );
     assert_eq!(
         tx(&model),
         "<p>test <strong>test</strong></p><p><a href=\"https://matrix.org\"><strong>test|</strong></a></p>",
@@ -776,7 +780,11 @@ fn create_link_after_enter_with_formatting_applied() {
 fn create_link_after_enter_with_no_formatting_applied() {
     let mut model = cm("|");
     model.enter();
-    model.set_link_with_text("https://matrix.org".into(), "test".into(), None);
+    model.set_link_with_text(
+        "https://matrix.org".into(),
+        "test".into(),
+        vec![],
+    );
     assert_eq!(
         tx(&model),
         "<p>&nbsp;</p><p><a href=\"https://matrix.org\">test|</a></p>"

--- a/crates/wysiwyg/src/tests/test_suggestions.rs
+++ b/crates/wysiwyg/src/tests/test_suggestions.rs
@@ -38,7 +38,7 @@ fn test_set_link_suggestion() {
         "https://matrix.to/#/@alice:matrix.org".into(),
         "Alice".into(),
         suggestion,
-        None,
+        vec![],
     );
     assert_eq!(
         tx(&model),

--- a/crates/wysiwyg/src/tests/test_suggestions.rs
+++ b/crates/wysiwyg/src/tests/test_suggestions.rs
@@ -38,6 +38,7 @@ fn test_set_link_suggestion() {
         "https://matrix.to/#/@alice:matrix.org".into(),
         "Alice".into(),
         suggestion,
+        None,
     );
     assert_eq!(
         tx(&model),

--- a/crates/wysiwyg/src/tests/test_suggestions.rs
+++ b/crates/wysiwyg/src/tests/test_suggestions.rs
@@ -28,7 +28,7 @@ fn test_replace_text_suggestion() {
 }
 
 #[test]
-fn test_set_link_suggestion() {
+fn test_set_link_suggestion_no_attributes() {
     let mut model = cm("|");
     let update = model.replace_text("@alic".into());
     let MenuAction::Suggestion(suggestion) = update.menu_action else {
@@ -42,6 +42,28 @@ fn test_set_link_suggestion() {
     );
     assert_eq!(
         tx(&model),
-        "<a href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\" data-mention-type=\"user\">Alice</a>&nbsp;|",
+        "<a href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>&nbsp;|",
+    );
+}
+
+#[test]
+fn test_set_link_suggestion_with_attributes() {
+    let mut model = cm("|");
+    let update = model.replace_text("@alic".into());
+    let MenuAction::Suggestion(suggestion) = update.menu_action else {
+        panic!("No suggestion pattern found")
+    };
+    model.set_link_suggestion(
+        "https://matrix.to/#/@alice:matrix.org".into(),
+        "Alice".into(),
+        suggestion,
+        vec![
+            ("contenteditable".into(), "false".into()),
+            ("data-mention-type".into(), "user".into()),
+        ],
+    );
+    assert_eq!(
+        tx(&model),
+        "<a contenteditable=\"false\" data-mention-type=\"user\" href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>&nbsp;|",
     );
 }

--- a/crates/wysiwyg/src/tests/testutils_dom.rs
+++ b/crates/wysiwyg/src/tests/testutils_dom.rs
@@ -32,7 +32,7 @@ pub fn a<'a>(
     DomNode::new_link(
         utf16("https://element.io"),
         clone_children(children),
-        None,
+        vec![],
     )
 }
 

--- a/platforms/ios/example/Wysiwyg/Views/WysiwygSuggestionList.swift
+++ b/platforms/ios/example/Wysiwyg/Views/WysiwygSuggestionList.swift
@@ -31,7 +31,7 @@ struct WysiwygSuggestionList: View {
                         Text(Users.title).underline()
                         ForEach(users) { user in
                             Button {
-                                viewModel.setMention(link: user.url, name: user.name, key: .at)
+                                viewModel.setMention(link: user.url, name: user.name, mentionType: .user)
                             } label: {
                                 HStack(spacing: 4) {
                                     Image(systemName: user.iconSystemName)
@@ -47,7 +47,7 @@ struct WysiwygSuggestionList: View {
                         Text(Rooms.title).underline()
                         ForEach(rooms) { room in
                             Button {
-                                viewModel.setMention(link: room.url, name: room.name, key: .hash)
+                                viewModel.setMention(link: room.url, name: room.name, mentionType: .room)
                             } label: {
                                 HStack(spacing: 4) {
                                     Image(systemName: room.iconSystemName)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
@@ -32,7 +32,7 @@ protocol ComposerModelWrapperProtocol {
     func enter() -> ComposerUpdate
     func setLink(link: String) -> ComposerUpdate
     func setLinkWithText(link: String, text: String) -> ComposerUpdate
-    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern) -> ComposerUpdate
+    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern, mentionType: WysiwygMentionType) -> ComposerUpdate
     func removeLinks() -> ComposerUpdate
     func toTree() -> String
     func getCurrentDomState() -> ComposerState
@@ -121,8 +121,11 @@ final class ComposerModelWrapper: ComposerModelWrapperProtocol {
         execute { try $0.setLinkWithText(link: link, text: text) }
     }
 
-    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern) -> ComposerUpdate {
-        execute { try $0.setLinkSuggestion(link: link, text: text, suggestion: suggestion) }
+    func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern, mentionType: WysiwygMentionType) -> ComposerUpdate {
+        let attributes = [
+            Attribute(key: "data-mention-type", value: mentionType.rawValue)
+        ]
+        return execute { try $0.setLinkSuggestion(link: link, text: text, suggestion: suggestion, attributes: attributes) }
     }
 
     func removeLinks() -> ComposerUpdate {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
@@ -123,7 +123,8 @@ final class ComposerModelWrapper: ComposerModelWrapperProtocol {
 
     func setLinkSuggestion(link: String, text: String, suggestion: SuggestionPattern, mentionType: WysiwygMentionType) -> ComposerUpdate {
         let attributes = [
-            Attribute(key: "data-mention-type", value: mentionType.rawValue)
+            Attribute(key: "data-mention-type", value: mentionType.rawValue),
+            Attribute(key: "contenteditable", value: "false")
         ]
         return execute { try $0.setLinkSuggestion(link: link, text: text, suggestion: suggestion, attributes: attributes) }
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -227,10 +227,10 @@ public extension WysiwygComposerViewModel {
     ///   - link: The link to the user.
     ///   - name: The display name of the user.
     ///   - key: The pattern key to use.
-    func setMention(link: String, name: String, key: PatternKey) {
+    func setMention(link: String, name: String, mentionType: WysiwygMentionType) {
         let update: ComposerUpdate
-        if let suggestionPattern, suggestionPattern.key == key {
-            update = model.setLinkSuggestion(link: link, text: name, suggestion: suggestionPattern)
+        if let suggestionPattern, suggestionPattern.key == mentionType.patternKey {
+            update = model.setLinkSuggestion(link: link, text: name, suggestion: suggestionPattern, mentionType: mentionType)
         } else {
             _ = model.setLinkWithText(link: link, text: name)
             // FIXME: remove this if Rust adds this space for free

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygMentionType.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygMentionType.swift
@@ -1,0 +1,46 @@
+// 
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public enum WysiwygMentionType: String {
+    case user
+    case room
+}
+
+extension WysiwygMentionType {
+    public var patternKey: PatternKey {
+        switch self {
+        case .user:
+            return .at
+        case .room:
+            return .hash
+        }
+    }
+}
+
+extension PatternKey {
+    public var mentionType: WysiwygMentionType? {
+        switch self {
+        case .at:
+            return .user
+        case .hash:
+            return .room
+        case .slash:
+            return nil
+        }
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
@@ -50,11 +50,11 @@ extension WysiwygComposerViewModelTests {
 
     func testAtSuggestionCanBeUsed() {
         _ = viewModel.replaceText(range: .zero, replacementText: "@ali")
-        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", key: .at)
+        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", mentionType: .user)
         XCTAssertEqual(
             viewModel.content.html,
             """
-            <a href="https://matrix.to/#/@alice:matrix.org" contenteditable="false" data-mention-type="user">Alice</a>\u{00A0}
+            <a data-mention-type="user" contenteditable="false" href="https://matrix.to/#/@alice:matrix.org">Alice</a>\u{00A0}
             """
         )
     }
@@ -62,7 +62,7 @@ extension WysiwygComposerViewModelTests {
     func testAtMentionWithNoSuggestion() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
         viewModel.select(range: .init(location: 0, length: 4))
-        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", key: .at)
+        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", mentionType: .user)
         // Text is not removed, and the
         // mention is added after the text
         XCTAssertEqual(
@@ -76,7 +76,7 @@ extension WysiwygComposerViewModelTests {
     func testAtMentionWithNoSuggestionAtLeading() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
         viewModel.select(range: .init(location: 0, length: 0))
-        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", key: .at)
+        viewModel.setMention(link: "https://matrix.to/#/@alice:matrix.org", name: "Alice", mentionType: .user)
         // Text is not removed, and the mention is added before the text
         XCTAssertEqual(
             viewModel.content.html,
@@ -88,11 +88,11 @@ extension WysiwygComposerViewModelTests {
 
     func testHashSuggestionCanBeUsed() {
         _ = viewModel.replaceText(range: .zero, replacementText: "#roo")
-        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", key: .hash)
+        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", mentionType: .room)
         XCTAssertEqual(
             viewModel.content.html,
             """
-            <a href="https://matrix.to/#/#room1:matrix.org" contenteditable="false" data-mention-type="room">Room 1</a>\u{00A0}
+            <a data-mention-type="room" contenteditable="false" href="https://matrix.to/#/#room1:matrix.org">Room 1</a>\u{00A0}
             """
         )
     }
@@ -100,7 +100,7 @@ extension WysiwygComposerViewModelTests {
     func testHashMentionWithNoSuggestion() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
         viewModel.select(range: .init(location: 0, length: 4))
-        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", key: .hash)
+        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", mentionType: .room)
         XCTAssertEqual(
             viewModel.content.html,
             """
@@ -112,7 +112,7 @@ extension WysiwygComposerViewModelTests {
     func testHashMentionWithNoSuggestionAtLeading() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
         viewModel.select(range: .init(location: 0, length: 0))
-        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", key: .hash)
+        viewModel.setMention(link: "https://matrix.to/#/#room1:matrix.org", name: "Room 1", mentionType: .room)
         XCTAssertEqual(
             viewModel.content.html,
             """

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
@@ -29,13 +29,16 @@ extension WysiwygComposerTests {
 
         model
             .action {
-                $0.setLinkSuggestion(link: "https://matrix.to/#/@alice:matrix.org",
-                                     text: "Alice",
-                                     suggestion: suggestionPattern)
+                $0.setLinkSuggestion(
+                    link: "https://matrix.to/#/@alice:matrix.org",
+                    text: "Alice",
+                    suggestion: suggestionPattern,
+                    mentionType: .user
+                )
             }
             .assertHtml(
                 """
-                <a href="https://matrix.to/#/@alice:matrix.org" contenteditable="false" data-mention-type="user">Alice</a>\(String.nbsp)
+                <a data-mention-type="user" contenteditable="false" href="https://matrix.to/#/@alice:matrix.org">Alice</a>\(String.nbsp)
                 """
             )
     }
@@ -51,13 +54,16 @@ extension WysiwygComposerTests {
 
         model
             .action {
-                $0.setLinkSuggestion(link: "https://matrix.to/#/#room1:matrix.org",
-                                     text: "Room 1",
-                                     suggestion: suggestionPattern)
+                $0.setLinkSuggestion(
+                    link: "https://matrix.to/#/#room1:matrix.org",
+                    text: "Room 1",
+                    suggestion: suggestionPattern,
+                    mentionType: .room
+                )
             }
             .assertHtml(
                 """
-                <a href="https://matrix.to/#/#room1:matrix.org" contenteditable="false" data-mention-type="room">Room 1</a>\(String.nbsp)
+                <a data-mention-type="room" contenteditable="false" href="https://matrix.to/#/#room1:matrix.org">Room 1</a>\(String.nbsp)
                 """
             )
     }

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -72,7 +72,7 @@ export function processInput(
     switch (event.inputType) {
         case 'insertSuggestion': {
             if (suggestion && isSuggestionEvent(event)) {
-                const { text, link } = event.data;
+                const { text, link, attributes } = event.data;
                 const defaultMap = new Map();
                 defaultMap.set('contenteditable', 'false');
                 return action(

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -75,6 +75,9 @@ export function processInput(
                 const { text, link, attributes } = event.data;
                 const defaultMap = new Map();
                 defaultMap.set('contenteditable', 'false');
+                Object.entries(attributes).forEach(([key, value]) => {
+                    defaultMap.set(key, value);
+                });
                 return action(
                     composerModel.set_link_suggestion(
                         link,

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -73,14 +73,14 @@ export function processInput(
         case 'insertSuggestion': {
             if (suggestion && isSuggestionEvent(event)) {
                 const { text, link } = event.data;
-                const map = new Map();
-                map.set('data-avatar-url', 'something');
+                const defaultMap = new Map();
+                defaultMap.set('contenteditable', 'false');
                 return action(
                     composerModel.set_link_suggestion(
                         link,
                         text,
                         suggestion,
-                        map,
+                        defaultMap,
                     ),
                     'set_link_suggestion',
                 );

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -73,8 +73,15 @@ export function processInput(
         case 'insertSuggestion': {
             if (suggestion && isSuggestionEvent(event)) {
                 const { text, link } = event.data;
+                const map = new Map();
+                map.set('data-avatar-url', 'something');
                 return action(
-                    composerModel.set_link_suggestion(link, text, suggestion),
+                    composerModel.set_link_suggestion(
+                        link,
+                        text,
+                        suggestion,
+                        map,
+                    ),
                     'set_link_suggestion',
                 );
             }

--- a/platforms/web/lib/testUtils/Editor.tsx
+++ b/platforms/web/lib/testUtils/Editor.tsx
@@ -121,6 +121,10 @@ export const Editor = forwardRef<HTMLDivElement, EditorProps>(function Editor(
                     wysiwyg.mention(
                         'https://matrix.to/#/@test_user:element.io',
                         'test user',
+                        {
+                            'contentEditable': 'false',
+                            'data-mention-type': 'user',
+                        },
                     );
                 }}
             >

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ACTION_TYPES, SUGGESTIONS } from './constants';
-import { LinkEvent } from './useListeners/types';
+import { Attributes, LinkEvent } from './useListeners/types';
 
 export type BlockType = InputEvent['inputType'] | 'formatInlineCode' | 'clear';
 
@@ -41,11 +41,7 @@ export type FormattingFunctions = Record<
 > & {
     insertText: (text: string) => void;
     link: (link: string, text?: string) => void;
-    mention: (
-        link: string,
-        text: string,
-        attributes: Record<string, string>,
-    ) => void;
+    mention: (link: string, text: string, attributes: Attributes) => void;
     command: (text: string) => void;
     removeLinks: () => void;
     getLink: () => string;

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -41,7 +41,11 @@ export type FormattingFunctions = Record<
 > & {
     insertText: (text: string) => void;
     link: (link: string, text?: string) => void;
-    mention: (link: string, text: string) => void;
+    mention: (
+        link: string,
+        text: string,
+        attributes: Record<string, string>,
+    ) => void;
     command: (text: string) => void;
     removeLinks: () => void;
     getLink: () => string;

--- a/platforms/web/lib/useFormattingFunctions.ts
+++ b/platforms/web/lib/useFormattingFunctions.ts
@@ -18,7 +18,7 @@ import { RefObject, useMemo } from 'react';
 
 import { BlockType, FormattingFunctions } from './types';
 import { sendWysiwygInputEvent } from './useListeners';
-import { LinkEvent, SuggestionEvent } from './useListeners/types';
+import { Attributes, LinkEvent, SuggestionEvent } from './useListeners/types';
 import { ComposerModel } from '../generated/wysiwyg';
 
 export function useFormattingFunctions(
@@ -63,11 +63,8 @@ export function useFormattingFunctions(
             quote: () => sendEvent('insertQuote'),
             indent: () => sendEvent('formatIndent'),
             unindent: () => sendEvent('formatOutdent'),
-            mention: (
-                link: string,
-                text: string,
-                attributes: Record<string, string>,
-            ) => sendEvent('insertSuggestion', { link, text, attributes }),
+            mention: (link: string, text: string, attributes: Attributes) =>
+                sendEvent('insertSuggestion', { link, text, attributes }),
             command: (text: string) => sendEvent('insertCommand', text),
         };
     }, [editorRef, composerModel]);

--- a/platforms/web/lib/useFormattingFunctions.ts
+++ b/platforms/web/lib/useFormattingFunctions.ts
@@ -18,7 +18,7 @@ import { RefObject, useMemo } from 'react';
 
 import { BlockType, FormattingFunctions } from './types';
 import { sendWysiwygInputEvent } from './useListeners';
-import { LinkEvent } from './useListeners/types';
+import { LinkEvent, SuggestionEvent } from './useListeners/types';
 import { ComposerModel } from '../generated/wysiwyg';
 
 export function useFormattingFunctions(
@@ -32,7 +32,7 @@ export function useFormattingFunctions(
         // and we do not use the browser input event handling
         const sendEvent = (
             blockType: BlockType,
-            data?: string | LinkEvent['data'],
+            data?: string | LinkEvent['data'] | SuggestionEvent['data'],
         ) =>
             editorRef.current &&
             sendWysiwygInputEvent(
@@ -63,8 +63,11 @@ export function useFormattingFunctions(
             quote: () => sendEvent('insertQuote'),
             indent: () => sendEvent('formatIndent'),
             unindent: () => sendEvent('formatOutdent'),
-            mention: (link: string, text: string) =>
-                sendEvent('insertSuggestion', { link, text }),
+            mention: (
+                link: string,
+                text: string,
+                attributes: Record<string, string>,
+            ) => sendEvent('insertSuggestion', { link, text, attributes }),
             command: (text: string) => sendEvent('insertCommand', text),
         };
     }, [editorRef, composerModel]);

--- a/platforms/web/lib/useListeners/types.ts
+++ b/platforms/web/lib/useListeners/types.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { HTMLAttributes } from 'react';
+
 import { BlockType } from '../types';
 
 export type FormatBlockEvent = CustomEvent<{

--- a/platforms/web/lib/useListeners/types.ts
+++ b/platforms/web/lib/useListeners/types.ts
@@ -26,7 +26,9 @@ export type LinkEvent = Omit<InputEvent, 'data'> & {
     data: { link: string; text?: string };
 };
 
+export type Attributes = Record<string, string>;
+
 export type SuggestionEvent = Omit<InputEvent, 'data'> & {
     inputType: 'insertSuggestion';
-    data: { link: string; text: string; attributes?: Record<string, string> };
+    data: { link: string; text: string; attributes: Attributes };
 };

--- a/platforms/web/lib/useListeners/types.ts
+++ b/platforms/web/lib/useListeners/types.ts
@@ -28,5 +28,5 @@ export type LinkEvent = Omit<InputEvent, 'data'> & {
 
 export type SuggestionEvent = Omit<InputEvent, 'data'> & {
     inputType: 'insertSuggestion';
-    data: { link: string; text: string };
+    data: { link: string; text: string; attributes?: Record<string, string> };
 };

--- a/platforms/web/lib/useListeners/types.ts
+++ b/platforms/web/lib/useListeners/types.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { HTMLAttributes } from 'react';
 import { BlockType } from '../types';
 
 export type FormatBlockEvent = CustomEvent<{
@@ -26,7 +27,11 @@ export type LinkEvent = Omit<InputEvent, 'data'> & {
     data: { link: string; text?: string };
 };
 
-export type Attributes = Record<string, string>;
+type AnchorHTMLAttribute<T> = T extends keyof HTMLAttributes<HTMLAnchorElement>
+    ? T
+    : never;
+
+export type Attributes = Record<AnchorHTMLAttribute<string>, string>;
 
 export type SuggestionEvent = Omit<InputEvent, 'data'> & {
     inputType: 'insertSuggestion';

--- a/platforms/web/lib/useListeners/types.ts
+++ b/platforms/web/lib/useListeners/types.ts
@@ -27,11 +27,13 @@ export type LinkEvent = Omit<InputEvent, 'data'> & {
     data: { link: string; text?: string };
 };
 
-type AnchorHTMLAttribute<T> = T extends keyof HTMLAttributes<HTMLAnchorElement>
-    ? T
-    : never;
+type AnchorElementAttributes =
+    | keyof HTMLAttributes<HTMLAnchorElement>
+    | `data-${string}`;
 
-export type Attributes = Record<AnchorHTMLAttribute<string>, string>;
+export type Attributes = {
+    [K in AnchorElementAttributes]?: string;
+};
 
 export type SuggestionEvent = Omit<InputEvent, 'data'> & {
     inputType: 'insertSuggestion';

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -194,7 +194,7 @@ function App() {
                                     wysiwyg.mention(
                                         'https://matrix.to/#/@alice_user:element.io',
                                         'Alice',
-                                        { something: 'funny' },
+                                        { 'data-something': 'hello' },
                                     )
                                 }
                             >

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -195,6 +195,7 @@ function App() {
                                         'https://matrix.to/#/@alice_user:element.io',
                                         'Alice',
                                         {
+                                            'contentEditable': 'false',
                                             'data-mention-type':
                                                 suggestion.keyChar === '@'
                                                     ? 'user'

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -194,7 +194,12 @@ function App() {
                                     wysiwyg.mention(
                                         'https://matrix.to/#/@alice_user:element.io',
                                         'Alice',
-                                        { 'data-something': 'hello' },
+                                        {
+                                            'data-mention-type':
+                                                suggestion.keyChar === '@'
+                                                    ? 'user'
+                                                    : 'room',
+                                        },
                                     )
                                 }
                             >

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -194,6 +194,7 @@ function App() {
                                     wysiwyg.mention(
                                         'https://matrix.to/#/@alice_user:element.io',
                                         'Alice',
+                                        { something: 'funny' },
                                     )
                                 }
                             >


### PR DESCRIPTION
This PR:

- allows us to pass in attributes that get applied to the mentions
- relies on the client passing in `contenteditable=false` 
- changes the web and mobile bindings
- updates the iOS and web code to accommodate the binding changes (Android is not currently using this functionality so does not require change)