### PR TITLE
Amend web bindings for slash commands

### DIFF
--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -159,11 +159,11 @@ impl ComposerModel {
     pub fn replace_text_suggestion(
         &mut self,
         new_text: &str,
-        suggestion: SuggestionPattern,
+        suggestion: &SuggestionPattern,
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.replace_text_suggestion(
             Utf16String::from_str(new_text),
-            wysiwyg::SuggestionPattern::from(suggestion),
+            wysiwyg::SuggestionPattern::from(suggestion.clone()),
         ))
     }
 

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -203,7 +203,7 @@ function App() {
                         {suggestion && suggestion.type === 'command' && (
                             <button
                                 type="button"
-                                onClick={(_e) => wysiwyg.command('/spoiler ')}
+                                onClick={(_e) => wysiwyg.command('/spoiler')}
                             >
                                 Add /spoiler command
                             </button>


### PR DESCRIPTION
Previously, the implementation of mentions in element web caused issues with the React SDK CI tests due to a memory issue.

The fix was to amend how we use the `SuggestionPattern` argument in the bindings. This issue would be present in commands as well, so this PR addresses that issue before we start using commands in element web.