### PR TITLE
Add basic mentions to Android sample app

### DIFF
--- a/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/Mention.kt
+++ b/platforms/android/example/src/main/java/io/element/android/wysiwyg/poc/Mention.kt
@@ -1,0 +1,29 @@
+package io.element.android.wysiwyg.poc
+
+import io.element.android.wysiwyg.suggestions.MentionType
+
+/**
+ * Utility model class for the sample app to represent a mention to a
+ * matrix.org user or room
+ */
+sealed class Mention(
+    val display: String,
+) {
+    abstract val key: String
+    abstract val mentionType: MentionType
+    val link get() = "https://matrix.to/#/$key$display:matrix.org"
+
+    class Room(
+        display: String
+    ): Mention(display) {
+        override val mentionType: MentionType = MentionType.Room
+        override val key: String = "#"
+    }
+
+    class User(
+        display: String
+    ): Mention(display) {
+        override val mentionType: MentionType = MentionType.User
+        override val key: String = "@"
+    }
+}

--- a/platforms/android/example/src/main/res/layout/view_rich_text_editor.xml
+++ b/platforms/android/example/src/main/res/layout/view_rich_text_editor.xml
@@ -44,6 +44,11 @@
             android:singleLine="false" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <ListView
+        android:id="@+id/menuSuggestion"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <LinearLayout
         android:id="@+id/menu"
         android:layout_width="match_parent"

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -12,7 +12,7 @@ import io.element.android.wysiwyg.utils.AndroidHtmlConverter
 import io.element.android.wysiwyg.utils.AndroidResourcesHelper
 import io.element.android.wysiwyg.utils.HtmlToSpansParser
 import io.element.android.wysiwyg.utils.NBSP
-import io.element.android.wysiwyg.viewmodel.EditorViewModel
+import io.element.android.wysiwyg.internal.viewmodel.EditorViewModel
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -15,7 +15,7 @@ import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
 import io.element.android.wysiwyg.inputhandlers.models.ReplaceTextResult
 import io.element.android.wysiwyg.utils.EditorIndexMapper
 import io.element.android.wysiwyg.utils.HtmlToSpansParser.FormattingSpans.removeFormattingSpans
-import io.element.android.wysiwyg.viewmodel.EditorViewModel
+import io.element.android.wysiwyg.internal.viewmodel.EditorViewModel
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/EditorInputAction.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/models/EditorInputAction.kt
@@ -1,5 +1,6 @@
 package io.element.android.wysiwyg.inputhandlers.models
 
+import io.element.android.wysiwyg.suggestions.MentionType
 import uniffi.wysiwyg_composer.ComposerModel
 
 /**
@@ -89,4 +90,10 @@ internal sealed interface EditorInputAction {
     object Indent: EditorInputAction
 
     object Unindent: EditorInputAction
+
+    data class SetMention(
+        val link: String,
+        val name: String,
+        val type: MentionType,
+    ): EditorInputAction
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/suggestions/MentionTypeExt.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/suggestions/MentionTypeExt.kt
@@ -1,0 +1,9 @@
+package io.element.android.wysiwyg.internal.suggestions
+
+import io.element.android.wysiwyg.suggestions.MentionType
+import uniffi.wysiwyg_composer.PatternKey
+
+internal fun MentionType.toInternalPatternKey(): PatternKey = when(this) {
+    MentionType.User -> PatternKey.AT
+    MentionType.Room -> PatternKey.HASH
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/suggestions/PatternKeyExt.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/suggestions/PatternKeyExt.kt
@@ -1,0 +1,9 @@
+package io.element.android.wysiwyg.internal.suggestions
+
+import uniffi.wysiwyg_composer.PatternKey
+
+internal fun PatternKey.toSymbol() = when(this) {
+    PatternKey.AT -> "@"
+    PatternKey.HASH -> "#"
+    PatternKey.SLASH -> "/"
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/suggestions/MentionType.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/suggestions/MentionType.kt
@@ -1,0 +1,5 @@
+package io.element.android.wysiwyg.suggestions
+
+enum class  MentionType {
+    User, Room
+}

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
@@ -4,6 +4,7 @@ import io.element.android.wysiwyg.inputhandlers.models.EditorInputAction
 import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import io.element.android.wysiwyg.inputhandlers.models.LinkAction
 import io.element.android.wysiwyg.inputhandlers.models.ReplaceTextResult
+import io.element.android.wysiwyg.internal.viewmodel.EditorViewModel
 import io.element.android.wysiwyg.mocks.MockComposer
 import io.element.android.wysiwyg.mocks.MockComposerUpdateFactory
 import io.element.android.wysiwyg.mocks.MockTextUpdateFactory


### PR DESCRIPTION
# What?
- Expose `setMention()` API in Android library
- Display basic, text based (i.e. not pills) mentions in the editor
- Add user (@) and room (#) mentions to sample app

[mentions.webm](https://user-images.githubusercontent.com/4940864/235156914-d8366015-78d9-44c0-a5e3-f5affa5139a2.webm)

# Why?
Closes vector-im/verticals-internal#77