### PR TITLE
Disable autocorrection if input is a command

### DIFF
--- a/platforms/ios/example/Shared/View+Accessibility.swift
+++ b/platforms/ios/example/Shared/View+Accessibility.swift
@@ -48,6 +48,7 @@ public enum WysiwygSharedAccessibilityIdentifier: String {
     case forceCrashButton = "WysiwygForceCrashButton"
     case setHtmlButton = "WysiwygSetHtmlButton"
     case setHtmlField = "WysiwygSetHtmlField"
+    case autocorrectionIndicator = "WysiwygAutocorrectionIndicator"
 
     // Mock buttons for menu
     case aliceButton = "WysiwygMenuAliceButton"

--- a/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
+++ b/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		A68E7140291D40710023CC04 /* WysiwygSharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68E713F291D40710023CC04 /* WysiwygSharedConstants.swift */; };
 		A68E7141291D40710023CC04 /* WysiwygSharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68E713F291D40710023CC04 /* WysiwygSharedConstants.swift */; };
 		A69356B229BB71F700A81F71 /* WysiwygUITests+PlainTextMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69356B129BB71F700A81F71 /* WysiwygUITests+PlainTextMode.swift */; };
+		A6BB18D729F9191C00EB6366 /* WysiwygUITests+Autocorrection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BB18D629F9191C00EB6366 /* WysiwygUITests+Autocorrection.swift */; };
 		A6C2157528C0E95C00C8E727 /* View+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C2157428C0E95C00C8E727 /* View+Accessibility.swift */; };
 		A6C2157928C0F62000C8E727 /* WysiwygActionToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C2157828C0F62000C8E727 /* WysiwygActionToolbar.swift */; };
 		A6C2157C28C0FAAD00C8E727 /* WysiwygAction+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C2157B28C0FAAD00C8E727 /* WysiwygAction+Utils.swift */; };
@@ -76,6 +77,7 @@
 		A6852F042981661000632252 /* WysiwygUITests+Indent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WysiwygUITests+Indent.swift"; sourceTree = "<group>"; };
 		A68E713F291D40710023CC04 /* WysiwygSharedConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygSharedConstants.swift; sourceTree = "<group>"; };
 		A69356B129BB71F700A81F71 /* WysiwygUITests+PlainTextMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WysiwygUITests+PlainTextMode.swift"; sourceTree = "<group>"; };
+		A6BB18D629F9191C00EB6366 /* WysiwygUITests+Autocorrection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WysiwygUITests+Autocorrection.swift"; sourceTree = "<group>"; };
 		A6C2157428C0E95C00C8E727 /* View+Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Accessibility.swift"; sourceTree = "<group>"; };
 		A6C2157828C0F62000C8E727 /* WysiwygActionToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WysiwygActionToolbar.swift; sourceTree = "<group>"; };
 		A6C2157B28C0FAAD00C8E727 /* WysiwygAction+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WysiwygAction+Utils.swift"; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				A6472CC52886CF840021A0E8 /* WysiwygUITests.swift */,
+				A6BB18D629F9191C00EB6366 /* WysiwygUITests+Autocorrection.swift */,
 				A64AB147296C769000F08494 /* WysiwygUITests+CodeBlocks.swift */,
 				A64AB143296C747C00F08494 /* WysiwygUITests+Format.swift */,
 				A6852F042981661000632252 /* WysiwygUITests+Indent.swift */,
@@ -426,6 +429,7 @@
 			files = (
 				A6852F052981661000632252 /* WysiwygUITests+Indent.swift in Sources */,
 				A64AB13E296C732500F08494 /* WysiwygUITests+Typing.swift in Sources */,
+				A6BB18D729F9191C00EB6366 /* WysiwygUITests+Autocorrection.swift in Sources */,
 				A6472CC62886CF840021A0E8 /* WysiwygUITests.swift in Sources */,
 				A64AB140296C73CE00F08494 /* WysiwygUITests+Links.swift in Sources */,
 				A661FDA729B0ACB400E799A6 /* WysiwygUITests+Suggestions.swift in Sources */,

--- a/platforms/ios/example/Wysiwyg/Views/Composer.swift
+++ b/platforms/ios/example/Wysiwyg/Views/Composer.swift
@@ -51,6 +51,12 @@ struct Composer: View {
             .onTapGesture {
                 focused = true
             }
+            if viewModel.textView.autocorrectionType == .yes {
+                Image(systemName: "text.badge.checkmark")
+                    .foregroundColor(.green)
+                    .padding(.horizontal, 16)
+                    .accessibilityIdentifier(.autocorrectionIndicator)
+            }
             if let suggestion = viewModel.suggestionPattern {
                 WysiwygSuggestionList(suggestion: suggestion)
                     .environmentObject(viewModel)

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Autocorrection.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Autocorrection.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+extension WysiwygUITests {
+    func testRichTextModeAutocorrection() throws {
+        textView.typeTextCharByChar("/")
+        XCTAssertFalse(image(.autocorrectionIndicator).exists)
+        let deleteKey = app.keys["delete"]
+        deleteKey.tap()
+        XCTAssertTrue(image(.autocorrectionIndicator).exists)
+        textView.typeTextCharByChar("/join")
+        XCTAssertFalse(image(.autocorrectionIndicator).exists)
+        // Send message
+        button(.sendButton).tap()
+        XCTAssertTrue(image(.autocorrectionIndicator).exists)
+    }
+
+    func testPlainTextModeAutocorrection() throws {
+        waitForButtonToExistAndTap(.plainRichButton)
+        textView.typeTextCharByChar("/")
+        XCTAssertFalse(image(.autocorrectionIndicator).exists)
+        let deleteKey = app.keys["delete"]
+        deleteKey.tap()
+        XCTAssertTrue(image(.autocorrectionIndicator).exists)
+        textView.typeTextCharByChar("/join")
+        XCTAssertFalse(image(.autocorrectionIndicator).exists)
+        // Send message
+        button(.sendButton).tap()
+        XCTAssertTrue(image(.autocorrectionIndicator).exists)
+    }
+
+    func testRichTextModeNonLeadingCommand() throws {
+        textView.typeTextCharByChar("text /not_a_command")
+        XCTAssertTrue(image(.autocorrectionIndicator).exists)
+    }
+
+    func testPlainTextModeNonLeadingCommand() throws {
+        waitForButtonToExistAndTap(.plainRichButton)
+        textView.typeTextCharByChar("text /not_a_command")
+        XCTAssertTrue(image(.autocorrectionIndicator).exists)
+    }
+}

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -73,9 +73,35 @@ internal extension WysiwygUITests {
     func button(_ id: WysiwygSharedAccessibilityIdentifier) -> XCUIElement {
         app.buttons[rawIdentifier(id)]
     }
-    
+
+    /// Get the text field with given id
+    ///
+    /// - Parameter id: Accessibility identifier
+    /// - Returns: Associated text field, if it exists
     func textField(_ id: WysiwygSharedAccessibilityIdentifier) -> XCUIElement {
-        app.textFields[id.rawValue]
+        app.textFields[rawIdentifier(id)]
+    }
+
+    /// Get the image with given id
+    ///
+    /// - Parameter id: Accessibility identifier
+    /// - Returns: Associated image, if it exists
+    func image(_ id: WysiwygSharedAccessibilityIdentifier) -> XCUIElement {
+        app.images[rawIdentifier(id)]
+    }
+
+    /// Wait for buton with given id to exist, then tap it.
+    ///
+    /// - Parameter id: Accessibility identifier
+    func waitForButtonToExistAndTap(_ id: WysiwygSharedAccessibilityIdentifier) {
+        let expectation = expectation(
+            for: NSPredicate(format: "exists == true"),
+            evaluatedWith: button(id),
+            handler: .none
+        )
+        let result = XCTWaiter.wait(for: [expectation], timeout: 30.0)
+        XCTAssertEqual(result, .completed)
+        button(id).tap()
     }
 
     /// Get the static text with given id

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/String+Character.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/String+Character.swift
@@ -25,9 +25,12 @@ public extension String {
     static let carriageReturn = "\r"
     /// String containing a single line feed character (`\n`)
     static let lineFeed = "\n"
+    /// String containing a single slash character(`/`)
+    static let slash = "/"
 }
 
 public extension Character {
     static let nbsp = Character(.nbsp)
     static let zwsp = Character(.zwsp)
+    static let slash = Character(.slash)
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -110,6 +110,7 @@ public struct WysiwygComposerView: UIViewRepresentable {
                 functionName: #function
             )
             didUpdateText()
+            textView.toggleAutocorrectionIfNeeded()
         }
 
         public func textViewDidChangeSelection(_ textView: UITextView) {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -89,6 +89,7 @@ public class WysiwygTextView: UITextView {
             flusher.flush()
         }
         didSet {
+            toggleAutocorrectionIfNeeded()
             delegate?.textViewDidChange?(self)
         }
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
@@ -20,10 +20,10 @@ extension UITextView {
     /// Toggles  autocorrection if needed. It should always be enabled,
     /// unless current text starts with exactly one slash.
     func toggleAutocorrectionIfNeeded() {
-        if attributedText.string.prefix(while: { $0 == .slash }).count == 1 {
-            autocorrectionType = .no
-        } else {
-            autocorrectionType = .yes
+        let newValue: UITextAutocorrectionType = attributedText.string.prefix(while: { $0 == .slash }).count == 1 ? .no : .yes
+        if newValue != autocorrectionType {
+            autocorrectionType = newValue
+            reloadInputViews()
         }
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/UITextView.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+extension UITextView {
+    /// Toggles  autocorrection if needed. It should always be enabled,
+    /// unless current text starts with exactly one slash.
+    func toggleAutocorrectionIfNeeded() {
+        if attributedText.string.prefix(while: { $0 == .slash }).count == 1 {
+            autocorrectionType = .no
+        } else {
+            autocorrectionType = .yes
+        }
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Autocorrection.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Autocorrection.swift
@@ -1,0 +1,106 @@
+//
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import WysiwygComposer
+import XCTest
+
+extension WysiwygComposerViewModelTests {
+    func testAutocorrectionIsDisabled() throws {
+        mockTrailingTyping("/")
+        assertAutocorrectDisabled()
+
+        mockTrailingTyping("join")
+        assertAutocorrectDisabled()
+
+        mockTrailingTyping(" #some_room:matrix.org")
+        assertAutocorrectDisabled()
+    }
+
+    func testAutocorrectionIsEnabled() throws {
+        mockTrailingTyping("Just some text")
+        assertAutoCorrectEnabled()
+
+        mockTrailingTyping(" /not_a_command")
+        assertAutoCorrectEnabled()
+    }
+
+    func testDoubleSlashKeepAutocorrectionEnabled() throws {
+        mockTrailingTyping("//")
+        assertAutoCorrectEnabled()
+    }
+
+    func testAutocorrectionIsReEnabled() throws {
+        mockTrailingTyping("/")
+        assertAutocorrectDisabled()
+
+        mockTrailingBackspace()
+        assertAutoCorrectEnabled()
+
+        mockTrailingTyping("/join")
+        assertAutocorrectDisabled()
+
+        for _ in 0...4 {
+            mockTrailingBackspace()
+        }
+        assertAutoCorrectEnabled()
+    }
+
+    func testAutocorrectionAfterSetHtmlContent() {
+        viewModel.setHtmlContent("/join #some_room:matrix.org")
+        assertAutocorrectDisabled()
+
+        viewModel.setHtmlContent("<strong>some text</strong>")
+        assertAutoCorrectEnabled()
+    }
+
+    func testAutocorrectionAfterSetHtmlContentInPlainTextMode() {
+        viewModel.plainTextMode = true
+
+        viewModel.setHtmlContent("/join #some_room:matrix.org")
+        assertAutocorrectDisabled()
+
+        viewModel.setHtmlContent("<strong>some text</strong>")
+        assertAutoCorrectEnabled()
+    }
+
+    func testAutocorrectionAfterSetMarkdownContent() {
+        viewModel.setMarkdownContent("/join #some_room:matrix.org")
+        assertAutocorrectDisabled()
+
+        viewModel.setMarkdownContent("__some text__")
+        assertAutoCorrectEnabled()
+    }
+
+    func testAutocorrectionAfterSetMarkdownContentInPlainTextMode() {
+        viewModel.plainTextMode = true
+
+        viewModel.setMarkdownContent("/join #some_room:matrix.org")
+        assertAutocorrectDisabled()
+
+        viewModel.setMarkdownContent("__some text__")
+        assertAutoCorrectEnabled()
+    }
+}
+
+private extension WysiwygComposerViewModelTests {
+    func assertAutoCorrectEnabled() {
+        XCTAssertEqual(viewModel.textView.autocorrectionType, .yes)
+    }
+
+    func assertAutocorrectDisabled() {
+        XCTAssertEqual(viewModel.textView.autocorrectionType, .no)
+    }
+}


### PR DESCRIPTION
* Disable autocorrection when message starts with one slash
* Add unit tests
* Add UI tests for potential cases not covered by unit tests