### PR TITLE
Move translating mention type to attributes from wrapper to view model

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
@@ -32,7 +32,7 @@ protocol ComposerModelWrapperProtocol {
     func enter() -> ComposerUpdate
     func setLink(url: String, attributes: [Attribute]) -> ComposerUpdate
     func setLinkWithText(url: String, text: String, attributes: [Attribute]) -> ComposerUpdate
-    func setLinkSuggestion(url: String, text: String, suggestion: SuggestionPattern, mentionType: WysiwygMentionType) -> ComposerUpdate
+    func setLinkSuggestion(url: String, text: String, suggestion: SuggestionPattern, attributes: [Attribute]) -> ComposerUpdate
     func removeLinks() -> ComposerUpdate
     func toTree() -> String
     func getCurrentDomState() -> ComposerState
@@ -121,11 +121,8 @@ final class ComposerModelWrapper: ComposerModelWrapperProtocol {
         execute { try $0.setLinkWithText(url: url, text: text, attributes: attributes) }
     }
 
-    func setLinkSuggestion(url: String, text: String, suggestion: SuggestionPattern, mentionType: WysiwygMentionType) -> ComposerUpdate {
-        let attributes = [
-            Attribute(key: "data-mention-type", value: mentionType.rawValue),
-            Attribute(key: "contenteditable", value: "false"),
-        ]
+    func setLinkSuggestion(url: String, text: String, suggestion: SuggestionPattern, attributes: [Attribute]) -> ComposerUpdate {
+        let attributes = suggestion.key.mentionType?.attributes ?? []
         return execute { try $0.setLinkSuggestion(url: url, text: text, suggestion: suggestion, attributes: attributes) }
     }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -242,10 +242,12 @@ public extension WysiwygComposerViewModel {
     func setMention(url: String, name: String, mentionType: WysiwygMentionType) {
         let update: ComposerUpdate
         if let suggestionPattern, suggestionPattern.key == mentionType.patternKey {
-            update = model.setLinkSuggestion(url: url, text: name, suggestion: suggestionPattern, mentionType: mentionType)
+            update = model.setLinkSuggestion(url: url,
+                                             text: name,
+                                             suggestion: suggestionPattern,
+                                             attributes: mentionType.attributes)
         } else {
-            // FIXME: update when merged with https://github.com/matrix-org/matrix-rich-text-editor/pull/653
-            _ = model.setLinkWithText(url: url, text: name, attributes: [])
+            _ = model.setLinkWithText(url: url, text: name, attributes: mentionType.attributes)
             update = model.replaceText(newText: " ")
         }
         applyUpdate(update)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/PatternKey.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/PatternKey.swift
@@ -14,36 +14,16 @@
 // limitations under the License.
 //
 
-import Foundation
-
-// MARK: - Public
-
-/// Defines a mention type available in the Rich Text Editor.
-public enum WysiwygMentionType: String {
-    case user
-    case room
-}
-
-public extension WysiwygMentionType {
-    /// Associated pattern key.
-    var patternKey: PatternKey {
+public extension PatternKey {
+    /// Associated mention type, if any.
+    var mentionType: WysiwygMentionType? {
         switch self {
-        case .user:
-            return .at
-        case .room:
-            return .hash
+        case .at:
+            return .user
+        case .hash:
+            return .room
+        case .slash:
+            return nil
         }
-    }
-}
-
-// MARK: - Internal
-
-extension WysiwygMentionType {
-    /// Default attributes.
-    var attributes: [Attribute] {
-        [
-            Attribute(key: "data-mention-type", value: rawValue),
-            Attribute(key: "contenteditable", value: "false"),
-        ]
     }
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
@@ -68,7 +68,7 @@ extension WysiwygComposerViewModelTests {
         XCTAssertEqual(
             viewModel.content.html,
             """
-            Text<a href="https://matrix.to/#/@alice:matrix.org">Alice</a>\u{00A0}
+            Text<a data-mention-type="user" contenteditable="false" href="https://matrix.to/#/@alice:matrix.org">Alice</a>\u{00A0}
             """
         )
     }
@@ -81,7 +81,7 @@ extension WysiwygComposerViewModelTests {
         XCTAssertEqual(
             viewModel.content.html,
             """
-            <a href="https://matrix.to/#/@alice:matrix.org">Alice</a> Text
+            <a data-mention-type="user" contenteditable="false" href="https://matrix.to/#/@alice:matrix.org">Alice</a> Text
             """
         )
     }
@@ -104,7 +104,7 @@ extension WysiwygComposerViewModelTests {
         XCTAssertEqual(
             viewModel.content.html,
             """
-            Text<a href="https://matrix.to/#/#room1:matrix.org">Room 1</a>\u{00A0}
+            Text<a data-mention-type="room" contenteditable="false" href="https://matrix.to/#/#room1:matrix.org">Room 1</a>\u{00A0}
             """
         )
     }
@@ -116,7 +116,7 @@ extension WysiwygComposerViewModelTests {
         XCTAssertEqual(
             viewModel.content.html,
             """
-            <a href="https://matrix.to/#/#room1:matrix.org">Room 1</a> Text
+            <a data-mention-type="room" contenteditable="false" href="https://matrix.to/#/#room1:matrix.org">Room 1</a> Text
             """
         )
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
@@ -22,8 +22,10 @@ extension WysiwygComposerTests {
         let model = ComposerModelWrapper()
         let update = model.replaceText(newText: "@alic")
 
-        guard case .suggestion(suggestionPattern: let suggestionPattern) = update.menuAction() else {
-            XCTFail("No suggestion found")
+        guard case .suggestion(suggestionPattern: let suggestionPattern) = update.menuAction(),
+              let attributes = suggestionPattern.key.mentionType?.attributes
+        else {
+            XCTFail("No user suggestion found")
             return
         }
 
@@ -33,7 +35,7 @@ extension WysiwygComposerTests {
                     url: "https://matrix.to/#/@alice:matrix.org",
                     text: "Alice",
                     suggestion: suggestionPattern,
-                    mentionType: .user
+                    attributes: attributes
                 )
             }
             .assertHtml(
@@ -47,8 +49,10 @@ extension WysiwygComposerTests {
         let model = ComposerModelWrapper()
         let update = model.replaceText(newText: "#roo")
 
-        guard case .suggestion(suggestionPattern: let suggestionPattern) = update.menuAction() else {
-            XCTFail("No suggestion found")
+        guard case .suggestion(suggestionPattern: let suggestionPattern) = update.menuAction(),
+              let attributes = suggestionPattern.key.mentionType?.attributes
+        else {
+            XCTFail("No room suggestion found")
             return
         }
 
@@ -58,7 +62,7 @@ extension WysiwygComposerTests {
                     url: "https://matrix.to/#/#room1:matrix.org",
                     text: "Room 1",
                     suggestion: suggestionPattern,
-                    mentionType: .room
+                    attributes: attributes
                 )
             }
             .assertHtml(


### PR DESCRIPTION
Minor code move as `ComposerModelWrapper` shouldn't host any logic other than the panic recovery mechanism (plan is to be able to remove it if possible, and just use the bindings-built `ComposerModel` - e.g. if Rust code manages to be 100% reliable).