### PR TITLE
[CI] Cancel previous workflows on update

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,10 @@ env:
   ARCH: x86_64
   DEVICE: Nexus 5X
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     if: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -10,6 +10,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: |

--- a/.github/workflows/react-build.yml
+++ b/.github/workflows/react-build.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -9,6 +9,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   build:
 


### PR DESCRIPTION
Allows for only one concurrent build per GH Actions/ branch.

It does seem that the build on labelling thing sometimes triggers multiple builds for some reason too, so it will help not overflow the runners if that keeps happening. 