### PR TITLE
Fix failure on autocorrection tests if the keyboard is hidden on the simulator

### DIFF
--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Autocorrection.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Autocorrection.swift
@@ -20,8 +20,7 @@ extension WysiwygUITests {
     func testRichTextModeAutocorrection() throws {
         textView.typeTextCharByChar("/")
         XCTAssertFalse(image(.autocorrectionIndicator).exists)
-        let deleteKey = app.keys["delete"]
-        deleteKey.tap()
+        textView.typeText(XCUIKeyboardKey.delete.rawValue)
         XCTAssertTrue(image(.autocorrectionIndicator).exists)
         textView.typeTextCharByChar("/join")
         XCTAssertFalse(image(.autocorrectionIndicator).exists)
@@ -34,8 +33,7 @@ extension WysiwygUITests {
         waitForButtonToExistAndTap(.plainRichButton)
         textView.typeTextCharByChar("/")
         XCTAssertFalse(image(.autocorrectionIndicator).exists)
-        let deleteKey = app.keys["delete"]
-        deleteKey.tap()
+        textView.typeText(XCUIKeyboardKey.delete.rawValue)
         XCTAssertTrue(image(.autocorrectionIndicator).exists)
         textView.typeTextCharByChar("/join")
         XCTAssertFalse(image(.autocorrectionIndicator).exists)


### PR DESCRIPTION
Autocorrection tests that use the delete key can sometimes fail if the simulator is not showing the keyboard. 
This fixes it by using the rawValue instead of looking for the keyboard button.