### PR TITLE
Fix concurrency cancelling unrelated builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ env:
   DEVICE: Nexus 5X
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.ref == 'refs/heads/main' && format('android-build-main-{0}', github.sha) || format('android-build-pr-{0}', github.ref)  }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,7 +11,7 @@ env:
   CARGO_TERM_COLOR: always
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.ref == 'refs/heads/main' && format('ios-build-main-{0}', github.sha) || format('ios-build-pr-{0}', github.ref)  }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/react-build.yml
+++ b/.github/workflows/react-build.yml
@@ -10,7 +10,7 @@ on:
     branches: ["main"]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.ref == 'refs/heads/main' && format('react-build-main-{0}', github.sha) || format('react-build-pr-{0}', github.ref)  }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.ref == 'refs/heads/main' && format('rust-build-main-{0}', github.sha) || format('rust-build-pr-{0}', github.ref)  }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.ref == 'refs/heads/main' && format('sonarqube-main-{0}', github.sha) || format('sonarqube-pr-{0}', github.ref)  }}
   cancel-in-progress: true
 jobs:
   sonarqube:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.ref == 'refs/heads/main' && format('wasm-build-main-{0}', github.sha) || format('wasm-build-pr-{0}', github.ref)  }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Change concurrency to avoid issue with current setup cancelling unrelated content. 
Concurrency should now allow to run all `main` builds and allow only a single build on each PR