### PR TITLE
Upload rust coverage to codecov

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,5 +30,13 @@ jobs:
       run: cargo clippy -- -D warnings
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Generate code coverage
+      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: lcov.info
+        fail_ci_if_error: true
+        flags: unittests-rust, unittests


### PR DESCRIPTION
Use `cargo-llvm-cov` for coverage and upload to codecov.

Added a couple of flags so we can easily see all unit tests together and platforms separately.