### PR TITLE
[Android] Fix display of multiple identical custom link replacements

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
@@ -3,6 +3,7 @@ package io.element.android.wysiwyg
 import android.graphics.Typeface
 import android.text.Editable
 import android.text.style.BulletSpan
+import android.text.style.ReplacementSpan
 import android.text.style.StyleSpan
 import android.view.KeyEvent
 import android.view.View
@@ -265,6 +266,22 @@ class EditorEditTextInputTests {
             .perform(EditorActions.setLinkSuggestion("jonny", "https://matrix.to/#/@test:matrix.org"))
             .check(matches(TextViewMatcher {
                 it.editableText.getSpans<PillSpan>().isNotEmpty()
+            }))
+    }
+
+    @Test
+    fun testSettingMultipleLinkSuggestionWithCustomReplacements() {
+        onView(withId(R.id.rich_text_edit_text))
+            .perform(ImeActions.setComposingText("@jonny"))
+            .perform(EditorActions.setLinkDisplayHandler { _, _ -> LinkDisplay.Custom(PillSpan(
+                R.color.fake_color
+            )) })
+            .perform(EditorActions.setLinkSuggestion("jonny", "https://matrix.to/#/@test:matrix.org"))
+            .perform(typeText(" "))
+            .perform(ImeActions.setComposingText("@jonny"))
+            .perform(EditorActions.setLinkSuggestion("jonny", "https://matrix.to/#/@test:matrix.org"))
+            .check(matches(TextViewMatcher {
+                it.editableText.getSpans<ReplacementSpan>().count() == 2
             }))
     }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/links/LinkDisplayHandler.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/links/LinkDisplayHandler.kt
@@ -1,5 +1,7 @@
 package io.element.android.wysiwyg.links
 
+import android.text.style.ReplacementSpan
+
 /**
  * Clients can implement a link display handler to let the editor
  * know how to display URLs.
@@ -18,7 +20,7 @@ sealed class LinkDisplay {
     /**
      * Display the link using a custom span
      */
-    data class Custom(val customSpan: Any): LinkDisplay()
+    data class Custom(val customSpan: ReplacementSpan): LinkDisplay()
 
     /**
      * Display the link using a default pill shape

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -16,6 +16,7 @@ import io.element.android.wysiwyg.view.StyleConfig
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.spans.BlockSpan
 import io.element.android.wysiwyg.view.spans.CodeBlockSpan
+import io.element.android.wysiwyg.view.spans.CustomReplacementSpan
 import io.element.android.wysiwyg.view.spans.ExtraCharacterSpan
 import io.element.android.wysiwyg.view.spans.InlineCodeSpan
 import io.element.android.wysiwyg.view.spans.LinkSpan
@@ -314,11 +315,11 @@ internal class HtmlToSpansParser(
             ?: LinkDisplay.Plain
         when(linkDisplay) {
             is LinkDisplay.Custom -> {
-                val span = linkDisplay.customSpan
+                val span = CustomReplacementSpan(linkDisplay.customSpan)
                 replacePlaceholderWithPendingSpan(last.span, span, last.start, text.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
             LinkDisplay.Pill -> {
-                val span = PillSpan((last.span).link, resourcesHelper.getColor(styleConfig.pill.backgroundColor))
+                val span = PillSpan(resourcesHelper.getColor(styleConfig.pill.backgroundColor))
                 replacePlaceholderWithPendingSpan(last.span, span, last.start, text.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
             LinkDisplay.Plain -> {
@@ -490,6 +491,7 @@ internal class HtmlToSpansParser(
             // Links
             LinkSpan::class.java,
             PillSpan::class.java,
+            CustomReplacementSpan::class.java,
 
             // Lists
             UnorderedListSpan::class.java,

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/CustomReplacementSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/CustomReplacementSpan.kt
@@ -1,0 +1,39 @@
+package io.element.android.wysiwyg.view.spans
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.text.style.ReplacementSpan
+
+/**
+ * Wrapper for a [ReplacementSpan] which does nothing except delegate to an
+ * underlying span.
+ * It is used to allow reuse of the same underlying span across multiple ranges
+ * of a spanned text.
+ */
+internal class CustomReplacementSpan(
+    private val providedSpan: ReplacementSpan
+) : ReplacementSpan() {
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence?,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        y: Int,
+        bottom: Int,
+        paint: Paint
+    ) = providedSpan.draw(
+        canvas, text, start, end, x, top, y, bottom, paint
+    )
+
+    override fun getSize(
+        paint: Paint,
+        text: CharSequence?,
+        start: Int,
+        end: Int,
+        fm: Paint.FontMetricsInt?
+    ): Int = providedSpan.getSize(
+        paint, text, start, end, fm
+    )
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/PillSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/PillSpan.kt
@@ -8,7 +8,6 @@ import androidx.annotation.ColorInt
 import kotlin.math.roundToInt
 
 internal class PillSpan(
-    val url: String,
     @ColorInt
     val backgroundColor: Int,
 ) : ReplacementSpan() {


### PR DESCRIPTION
Fix display of multiple identical custom link replacements.

Previously, when a second link replacement was added, the first disappeared. After the fix, both are displayed as expected.

### Screenshots
| Before | After |
|-|-|
|![pill-before](https://github.com/matrix-org/matrix-rich-text-editor/assets/4940864/20f3f565-52bb-4c8a-861f-eab7f2fc01d4)|![pill-after](https://github.com/matrix-org/matrix-rich-text-editor/assets/4940864/f54fe0f7-8e3d-40f7-9623-30a672d68d86)|