### PR TITLE
Disable invariant assertions by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Format
       run: cargo fmt -- --check
     - name: Clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --all-features -- -D warnings
     - name: Build
       run: cargo build --verbose
     - name: Install cargo-llvm-cov

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -11,7 +11,7 @@ version = "2.2.0"
 rust-version = "1.65"
 
 [features]
-default = ["assert-invariants", "sys"]
+default = ["sys"]
 js = ["dep:wasm-bindgen", "dep:web-sys"]
 sys = ["dep:html5ever"]
 assert-invariants = []

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -109,6 +109,11 @@ afterEvaluate {
     def isReleaseBuild = taskName.containsIgnoreCase("release") || taskName.containsIgnoreCase("publish")
     if (isReleaseBuild) {
         cargo.profile = "release"
+    } else {
+        cargo.profile = "debug"
+        cargo.features {
+            defaultAnd("assert-invariants")
+        }
     }
 }
 


### PR DESCRIPTION
Disable invariant assertions by default so that they are not run in release builds.

Note
- The invariant assertions will still be run in tests.
- After this change, the invariant assertions will no longer run in iOS and web example apps so follow-up work is needed to fix that.