### PR TITLE
Add functions to get content in clean message format

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -48,6 +48,14 @@ impl ComposerModel {
         self.inner.lock().unwrap().get_content_as_html().to_string()
     }
 
+    pub fn get_content_as_message_html(self: &Arc<Self>) -> String {
+        self.inner
+            .lock()
+            .unwrap()
+            .get_content_as_message_html()
+            .to_string()
+    }
+
     pub fn get_content_as_markdown(self: &Arc<Self>) -> String {
         self.inner
             .lock()

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -22,6 +22,7 @@ interface ComposerModel {
     [Throws=DomCreationError]
     ComposerUpdate set_content_from_markdown(string markdown);
     string get_content_as_html();
+    string get_content_as_message_html();
     string get_content_as_markdown();
     string get_content_as_plain_text();
     ComposerUpdate clear();

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -120,6 +120,10 @@ impl ComposerModel {
         self.inner.get_content_as_html().to_string()
     }
 
+    pub fn get_content_as_message_html(&self) -> String {
+        self.inner.get_content_as_message_html().to_string()
+    }
+
     pub fn get_content_as_markdown(&self) -> String {
         self.inner.get_content_as_markdown().to_string()
     }

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -195,6 +195,10 @@ where
         self.state.dom.to_html()
     }
 
+    pub fn get_content_as_message_html(&self) -> S {
+        self.state.dom.to_message_html()
+    }
+
     pub fn get_content_as_markdown(&self) -> S {
         self.state.dom.to_markdown().unwrap()
     }

--- a/crates/wysiwyg/src/composer_model/example_format.rs
+++ b/crates/wysiwyg/src/composer_model/example_format.rs
@@ -253,6 +253,7 @@ impl ComposerModel<Utf16String> {
             &mut buf,
             Some(&mut selection_writer),
             ToHtmlState::default(),
+            false,
         );
         if range.is_empty().not() {
             // we should always have written at least the start of the selection

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -618,8 +618,10 @@ where
         buf: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        as_message: bool,
     ) {
-        self.document.fmt_html(buf, selection_writer, state)
+        self.document
+            .fmt_html(buf, selection_writer, state, as_message)
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -709,7 +709,7 @@ impl<S: UnicodeString> ContainerNode<S> {
         let name = self.name();
 
         if self.is_empty() {
-            self.fmt_tag_empty(&S::from("br"), formatter, &self.attrs);
+            formatter.push('\n');
         } else {
             self.fmt_tag_open(name, formatter, &self.attrs);
             self.fmt_children_html(
@@ -813,27 +813,6 @@ impl<S: UnicodeString> ContainerNode<S> {
         formatter.push("</");
         formatter.push(name);
         formatter.push('>');
-    }
-
-    fn fmt_tag_empty(
-        &self,
-        name: &S::Str,
-        formatter: &mut S,
-        attrs: &Option<Vec<(S, S)>>,
-    ) {
-        formatter.push('<');
-        formatter.push(name);
-        if let Some(attrs) = attrs {
-            for attr in attrs {
-                let (attr_name, value) = attr;
-                formatter.push(' ');
-                formatter.push(&**attr_name);
-                formatter.push("=\"");
-                formatter.push(&**value);
-                formatter.push('"');
-            }
-        }
-        formatter.push(" />");
     }
 
     fn updated_state(
@@ -1599,10 +1578,7 @@ mod test {
     #[test]
     fn paragraph_to_message_html() {
         let model = cm("<p>&nbsp;</p><p>&nbsp;</p><p>Hello!</p><p>&nbsp;</p>|");
-        assert_eq!(
-            &model.state.dom.to_message_html(),
-            "<br /><br /><p>Hello!</p><br />"
-        );
+        assert_eq!(&model.state.dom.to_message_html(), "\n\n<p>Hello!</p>\n");
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -608,15 +608,27 @@ where
         formatter: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        as_message: bool,
     ) {
         match self.kind() {
-            ContainerNodeKind::Paragraph => {
-                self.fmt_paragraph_html(formatter, selection_writer, state)
-            }
-            ContainerNodeKind::CodeBlock => {
-                self.fmt_code_block_html(formatter, selection_writer, state)
-            }
-            _ => self.fmt_default_html(formatter, selection_writer, state),
+            ContainerNodeKind::Paragraph => self.fmt_paragraph_html(
+                formatter,
+                selection_writer,
+                state,
+                as_message,
+            ),
+            ContainerNodeKind::CodeBlock => self.fmt_code_block_html(
+                formatter,
+                selection_writer,
+                state,
+                as_message,
+            ),
+            _ => self.fmt_default_html(
+                formatter,
+                selection_writer,
+                state,
+                as_message,
+            ),
         };
     }
 }
@@ -628,13 +640,14 @@ impl<S: UnicodeString> ContainerNode<S> {
         formatter: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        as_message: bool,
     ) {
         let name = self.name();
         if !name.is_empty() {
             self.fmt_tag_open(name, formatter, &self.attrs);
         }
 
-        self.fmt_children_html(formatter, selection_writer, state);
+        self.fmt_children_html(formatter, selection_writer, state, as_message);
 
         if !name.is_empty() {
             self.fmt_tag_close(name, formatter);
@@ -646,10 +659,22 @@ impl<S: UnicodeString> ContainerNode<S> {
         formatter: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        as_message: bool,
     ) {
         assert!(matches!(self.kind, ContainerNodeKind::Paragraph));
         if state.is_inside_code_block {
-            self.fmt_code_paragraph_html(formatter, selection_writer, state)
+            self.fmt_code_paragraph_html(
+                formatter,
+                selection_writer,
+                state,
+                as_message,
+            )
+        } else if as_message {
+            self.fmt_paragraph_as_message_html(
+                formatter,
+                selection_writer,
+                state,
+            )
         } else {
             self.fmt_default_paragraph_html(formatter, selection_writer, state)
         }
@@ -661,6 +686,7 @@ impl<S: UnicodeString> ContainerNode<S> {
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
     ) {
+        let as_message = false;
         assert!(matches!(self.kind, ContainerNodeKind::Paragraph));
         let name = self.name();
 
@@ -668,8 +694,32 @@ impl<S: UnicodeString> ContainerNode<S> {
         if self.is_empty() {
             formatter.push(char::nbsp());
         }
-        self.fmt_children_html(formatter, selection_writer, state);
+        self.fmt_children_html(formatter, selection_writer, state, as_message);
         self.fmt_tag_close(name, formatter);
+    }
+
+    fn fmt_paragraph_as_message_html(
+        &self,
+        formatter: &mut S,
+        selection_writer: Option<&mut SelectionWriter>,
+        state: ToHtmlState,
+    ) {
+        let as_message = true;
+        assert!(matches!(self.kind, ContainerNodeKind::Paragraph));
+        let name = self.name();
+
+        if self.is_empty() {
+            self.fmt_tag_empty(&S::from("br"), formatter, &self.attrs);
+        } else {
+            self.fmt_tag_open(name, formatter, &self.attrs);
+            self.fmt_children_html(
+                formatter,
+                selection_writer,
+                state,
+                as_message,
+            );
+            self.fmt_tag_close(name, formatter);
+        }
     }
 
     fn fmt_code_paragraph_html(
@@ -677,6 +727,7 @@ impl<S: UnicodeString> ContainerNode<S> {
         formatter: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        as_message: bool,
     ) {
         assert!(matches!(self.kind, ContainerNodeKind::Paragraph));
         if self.is_empty()
@@ -684,7 +735,7 @@ impl<S: UnicodeString> ContainerNode<S> {
         {
             formatter.push(char::nbsp());
         }
-        self.fmt_children_html(formatter, selection_writer, state);
+        self.fmt_children_html(formatter, selection_writer, state, as_message);
         if !state.is_last_node_in_parent {
             formatter.push('\n');
         }
@@ -695,6 +746,7 @@ impl<S: UnicodeString> ContainerNode<S> {
         formatter: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        as_message: bool,
     ) {
         assert!(matches!(self.kind, ContainerNodeKind::CodeBlock));
         self.fmt_tag_open(&S::from("pre"), formatter, &self.attrs);
@@ -703,7 +755,7 @@ impl<S: UnicodeString> ContainerNode<S> {
 
         self.fmt_tag_open(&S::from("code"), formatter, &None::<Vec<(S, S)>>);
 
-        self.fmt_children_html(formatter, selection_writer, state);
+        self.fmt_children_html(formatter, selection_writer, state, as_message);
 
         self.fmt_tag_close(&S::from("code"), formatter);
         self.fmt_tag_close(&S::from("pre"), formatter);
@@ -714,11 +766,12 @@ impl<S: UnicodeString> ContainerNode<S> {
         formatter: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        as_message: bool,
     ) {
         if let Some(w) = selection_writer {
             for (i, child) in self.children.iter().enumerate() {
                 let state = self.updated_state(state, i);
-                child.fmt_html(formatter, Some(w), state);
+                child.fmt_html(formatter, Some(w), state, as_message);
             }
             if self.is_empty() {
                 w.write_selection_empty_container(
@@ -730,7 +783,7 @@ impl<S: UnicodeString> ContainerNode<S> {
         } else {
             for (i, child) in self.children.iter().enumerate() {
                 let state = self.updated_state(state, i);
-                child.fmt_html(formatter, None, state);
+                child.fmt_html(formatter, None, state, as_message);
             }
         }
     }
@@ -760,6 +813,27 @@ impl<S: UnicodeString> ContainerNode<S> {
         formatter.push("</");
         formatter.push(name);
         formatter.push('>');
+    }
+
+    fn fmt_tag_empty(
+        &self,
+        name: &S::Str,
+        formatter: &mut S,
+        attrs: &Option<Vec<(S, S)>>,
+    ) {
+        formatter.push('<');
+        formatter.push(name);
+        if let Some(attrs) = attrs {
+            for attr in attrs {
+                let (attr_name, value) = attr;
+                formatter.push(' ');
+                formatter.push(&**attr_name);
+                formatter.push("=\"");
+                formatter.push(&**value);
+                formatter.push('"');
+            }
+        }
+        formatter.push(" />");
     }
 
     fn updated_state(
@@ -1309,7 +1383,9 @@ where
 mod test {
     use widestring::Utf16String;
 
-    use crate::tests::testutils_conversion::utf16;
+    use crate::tests::{
+        testutils_composer_model::cm, testutils_conversion::utf16,
+    };
 
     use super::*;
 
@@ -1518,6 +1594,24 @@ mod test {
     fn slicing_after_edge_panics() {
         let mut container = create_container_with_nested_children();
         container.slice_after(42);
+    }
+
+    #[test]
+    fn paragraph_to_message_html() {
+        let model = cm("<p>&nbsp;</p><p>&nbsp;</p><p>Hello!</p><p>&nbsp;</p>|");
+        assert_eq!(
+            &model.state.dom.to_message_html(),
+            "<br /><br /><p>Hello!</p><br />"
+        );
+    }
+
+    #[test]
+    fn paragraph_to_html() {
+        let model = cm("<p>&nbsp;</p><p>&nbsp;</p><p>Hello!</p><p>&nbsp;</p>|");
+        assert_eq!(
+            &model.state.dom.to_html(),
+            "<p>\u{a0}</p><p>\u{a0}</p><p>Hello!</p><p>\u{a0}</p>"
+        );
     }
 
     /// Result HTML is "<strong><em>abc</em>def</strong>".

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -369,11 +369,18 @@ where
         buf: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        as_message: bool,
     ) {
         match self {
-            DomNode::Container(s) => s.fmt_html(buf, selection_writer, state),
-            DomNode::LineBreak(s) => s.fmt_html(buf, selection_writer, state),
-            DomNode::Text(s) => s.fmt_html(buf, selection_writer, state),
+            DomNode::Container(s) => {
+                s.fmt_html(buf, selection_writer, state, as_message)
+            }
+            DomNode::LineBreak(s) => {
+                s.fmt_html(buf, selection_writer, state, as_message)
+            }
+            DomNode::Text(s) => {
+                s.fmt_html(buf, selection_writer, state, as_message)
+            }
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -79,6 +79,7 @@ where
         buf: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         _: ToHtmlState,
+        _as_message: bool,
     ) {
         let cur_pos = buf.len();
         buf.push(S::from("<br />"));

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -216,6 +216,7 @@ where
         buf: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        _as_message: bool,
     ) {
         let cur_pos = buf.len();
         let string = self.data.to_string();

--- a/crates/wysiwyg/src/dom/to_html.rs
+++ b/crates/wysiwyg/src/dom/to_html.rs
@@ -20,16 +20,30 @@ pub trait ToHtml<S>
 where
     S: UnicodeString,
 {
+    /// Convert to HTML
+    ///
+    /// When `is_message` is true, it outputs a clean representation of the
+    /// source object, suitable for sending as a message.
     fn fmt_html(
         &self,
         buf: &mut S,
         selection_writer: Option<&mut SelectionWriter>,
         state: ToHtmlState,
+        as_message: bool,
     );
 
+    /// Convert to a clean HTML represention of the source object, suitable
+    /// for sending as a message
+    fn to_message_html(&self) -> S {
+        let mut buf = S::default();
+        self.fmt_html(&mut buf, None, ToHtmlState::default(), true);
+        buf
+    }
+
+    /// Convert to a literal HTML represention of the source object
     fn to_html(&self) -> S {
         let mut buf = S::default();
-        self.fmt_html(&mut buf, None, ToHtmlState::default());
+        self.fmt_html(&mut buf, None, ToHtmlState::default(), false);
         buf
     }
 }


### PR DESCRIPTION
## Changes
- Add `to_message_html()`/`get_content_as_message_html()` functions which render HTML in a format that is suitable for sending as a message.
  - Output empty `<p>` tags as a newline `\n` when asking for message HTML. This behaviour is consistent with the legacy Element message editor.
- _Note: keep `to_html()`/`get_content_as_html()` functions which render HTML in a format that preserves structures and attributes needed during editing._

## Context
- matrix-org/matrix-rich-text-editor#679