### PR TITLE
Add ContainerNodeKind::Mention

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -205,23 +205,10 @@ impl ComposerModel {
         Arc::new(ComposerUpdate::from(self.inner.lock().unwrap().redo()))
     }
 
-    pub fn set_link(
-        self: &Arc<Self>,
-        url: String,
-        attributes: Vec<Attribute>,
-    ) -> Arc<ComposerUpdate> {
+    pub fn set_link(self: &Arc<Self>, url: String) -> Arc<ComposerUpdate> {
         let url = Utf16String::from_str(&url);
-        let attrs = attributes
-            .iter()
-            .map(|attr| {
-                (
-                    Utf16String::from_str(&attr.key),
-                    Utf16String::from_str(&attr.value),
-                )
-            })
-            .collect();
         Arc::new(ComposerUpdate::from(
-            self.inner.lock().unwrap().set_link(url, attrs),
+            self.inner.lock().unwrap().set_link(url),
         ))
     }
 
@@ -229,24 +216,11 @@ impl ComposerModel {
         self: &Arc<Self>,
         url: String,
         text: String,
-        attributes: Vec<Attribute>,
     ) -> Arc<ComposerUpdate> {
         let url = Utf16String::from_str(&url);
         let text = Utf16String::from_str(&text);
-        let attrs = attributes
-            .iter()
-            .map(|attr| {
-                (
-                    Utf16String::from_str(&attr.key),
-                    Utf16String::from_str(&attr.value),
-                )
-            })
-            .collect();
         Arc::new(ComposerUpdate::from(
-            self.inner
-                .lock()
-                .unwrap()
-                .set_link_with_text(url, text, attrs),
+            self.inner.lock().unwrap().set_link_with_text(url, text),
         ))
     }
 
@@ -276,7 +250,7 @@ impl ComposerModel {
             self.inner
                 .lock()
                 .unwrap()
-                .set_link_suggestion(url, text, suggestion, attrs),
+                .set_mention_from_suggestion(url, text, suggestion, attrs),
         ))
     }
 

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -135,20 +135,14 @@ mod test {
             "https://matrix.to/#/@alice:matrix.org".into(),
             "Alice".into(),
             suggestion_pattern,
-            vec![
-                Attribute {
-                    key: "contenteditable".into(),
-                    value: "false".into(),
-                },
-                Attribute {
-                    key: "data-mention-type".into(),
-                    value: "user".into(),
-                },
-            ],
+            vec![Attribute {
+                key: "data-mention-type".into(),
+                value: "user".into(),
+            }],
         );
         assert_eq!(
             model.get_content_as_html(),
-            "<a contenteditable=\"false\" data-mention-type=\"user\" href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>\u{a0}",
+            "<a data-mention-type=\"user\" href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\">Alice</a>\u{a0}",
         )
     }
 

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -44,8 +44,8 @@ interface ComposerModel {
     ComposerUpdate redo();
     ComposerUpdate indent();
     ComposerUpdate unindent();
-    ComposerUpdate set_link(string url, sequence<Attribute> attributes);
-    ComposerUpdate set_link_with_text(string url, string text, sequence<Attribute> attributes);
+    ComposerUpdate set_link(string url);
+    ComposerUpdate set_link_with_text(string url, string text);
     ComposerUpdate set_link_suggestion(string url, string text, SuggestionPattern suggestion, sequence<Attribute> attributes);
     ComposerUpdate remove_links();
     ComposerUpdate code_block();

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -284,33 +284,26 @@ impl ComposerModel {
         self.inner.get_link_action().into()
     }
 
-    pub fn set_link(
-        &mut self,
-        url: &str,
-        attributes: js_sys::Map,
-    ) -> ComposerUpdate {
-        ComposerUpdate::from(
-            self.inner
-                .set_link(Utf16String::from_str(url), attributes.into_vec()),
-        )
+    pub fn set_link(&mut self, url: &str) -> ComposerUpdate {
+        ComposerUpdate::from(self.inner.set_link(Utf16String::from_str(url)))
     }
 
     pub fn set_link_with_text(
         &mut self,
         url: &str,
         text: &str,
-        attributes: js_sys::Map,
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.set_link_with_text(
             Utf16String::from_str(url),
             Utf16String::from_str(text),
-            attributes.into_vec(),
         ))
     }
 
     /// This function creates a link with the first argument being the href, the second being the
     /// display text, the third being the (rust model) suggestion that is being replaced and the
-    /// final argument being a map of html attributes that will be added to the Link.
+    /// final argument being a map of html attributes that will be added to the mention.
+
+    // TODO should this be renamed? We're now creating a mention container, but that is still a link node
     pub fn set_link_suggestion(
         &mut self,
         url: &str,
@@ -318,7 +311,7 @@ impl ComposerModel {
         suggestion: &SuggestionPattern,
         attributes: js_sys::Map,
     ) -> ComposerUpdate {
-        ComposerUpdate::from(self.inner.set_link_suggestion(
+        ComposerUpdate::from(self.inner.set_mention_from_suggestion(
             Utf16String::from_str(url),
             Utf16String::from_str(text),
             wysiwyg::SuggestionPattern::from(suggestion.clone()),

--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -132,7 +132,7 @@ where
                     .state
                     .dom
                     .lookup_container(&link.node_handle)
-                    .is_immutable_link_or_mention()
+                    .is_mention()
                 {
                     self.select(
                         Location::from(link.position),

--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -132,7 +132,7 @@ where
                     .state
                     .dom
                     .lookup_container(&link.node_handle)
-                    .is_immutable_link()
+                    .is_immutable_link_or_mention()
                 {
                     self.select(
                         Location::from(link.position),

--- a/crates/wysiwyg/src/composer_model/hyperlinks.rs
+++ b/crates/wysiwyg/src/composer_model/hyperlinks.rs
@@ -254,7 +254,7 @@ where
 
         node.iter_containers()
             .filter_map(|c| {
-                if c.is_link() && c.handle() != *node_handle {
+                if c.is_link_or_mention() && c.handle() != *node_handle {
                     Some(c.handle())
                 } else {
                     None
@@ -277,7 +277,9 @@ where
                 DomNode::Container(container) => container,
                 _ => continue,
             };
-            if matches!(container.kind(), ContainerNodeKind::Link(_)) {
+            if matches!(container.kind(), ContainerNodeKind::Link(_))
+                || matches!(container.kind(), ContainerNodeKind::Mention(_))
+            {
                 return Some(node.handle());
             }
             parent_handle = parent_handle.parent_handle();

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -174,7 +174,9 @@ where
                     Some(ComposerAction::InlineCode)
                 }
             },
-            ContainerNodeKind::Link(_) => Some(ComposerAction::Link),
+            ContainerNodeKind::Link(_) | ContainerNodeKind::Mention(_) => {
+                Some(ComposerAction::Link)
+            }
             ContainerNodeKind::List(list_type) => match list_type {
                 ListType::Ordered => Some(ComposerAction::OrderedList),
                 ListType::Unordered => Some(ComposerAction::UnorderedList),

--- a/crates/wysiwyg/src/composer_model/menu_state.rs
+++ b/crates/wysiwyg/src/composer_model/menu_state.rs
@@ -174,9 +174,7 @@ where
                     Some(ComposerAction::InlineCode)
                 }
             },
-            ContainerNodeKind::Link(_) | ContainerNodeKind::Mention(_) => {
-                Some(ComposerAction::Link)
-            }
+            ContainerNodeKind::Link(_) => Some(ComposerAction::Link),
             ContainerNodeKind::List(list_type) => match list_type {
                 ListType::Ordered => Some(ComposerAction::OrderedList),
                 ListType::Unordered => Some(ComposerAction::UnorderedList),

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -311,7 +311,7 @@ where
         {
             match node {
                 DomNode::Container(c) => {
-                    if c.is_link() {
+                    if c.is_link_or_mention() {
                         None
                     } else if let Some(last_child) = c.last_child_mut() {
                         last_text_node_in(last_child)
@@ -366,7 +366,7 @@ where
         {
             match node {
                 DomNode::Container(c) => {
-                    if c.is_link() {
+                    if c.is_link_or_mention() {
                         None
                     } else if let Some(first_child) = c.first_child_mut() {
                         first_text_node_in(first_child)

--- a/crates/wysiwyg/src/dom/insert_parent.rs
+++ b/crates/wysiwyg/src/dom/insert_parent.rs
@@ -129,10 +129,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(model.state.dom.to_html(), r#"A<a href="link">B</a>C"#)
     }
@@ -143,10 +143,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(model.state.dom.to_html(), r#"<a href="link">AB</a>C"#)
     }
@@ -157,10 +157,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(model.state.dom.to_html(), r#"A<a href="link">BC</a>"#)
     }
@@ -171,10 +171,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(model.state.dom.to_html(), r#"<a href="link">ABC</a>"#)
     }
@@ -185,10 +185,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -202,10 +202,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -219,10 +219,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -236,10 +236,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -253,10 +253,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -270,10 +270,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -288,10 +288,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(
             model.state.dom.to_html(),
@@ -305,10 +305,10 @@ mod test {
         let (start, end) = model.safe_selection();
         let range = model.state.dom.find_range(start, end);
 
-        model.state.dom.insert_parent(
-            &range,
-            DomNode::new_link(utf16("link"), vec![], vec![]),
-        );
+        model
+            .state
+            .dom
+            .insert_parent(&range, DomNode::new_link(utf16("link"), vec![]));
 
         assert_eq!(
             model.state.dom.to_html(),

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -872,10 +872,10 @@ where
 {
     fn to_tree_display(&self, continuous_positions: Vec<usize>) -> S {
         let mut description = self.name.clone();
-        // TODO need to handle mentions in the tree display
-        if let ContainerNodeKind::Link(url) = self.kind() {
+
+        if let Some(url) = self.get_link_url() {
             description.push(" \"");
-            description.push(url.clone());
+            description.push(url);
             description.push("\"");
         }
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -382,19 +382,36 @@ where
         children_len + block_nodes_extra
     }
 
-    pub fn new_link(
-        url: S,
-        children: Vec<DomNode<S>>,
-        mut attributes: Vec<(S, S)>,
-    ) -> Self {
-        // Hosting application may provide attributes but always provides url, this
-        // allows the Rust code to stay as generic as possible, since it should only care about
-        // `contenteditable="false"` to implement custom behaviours for immutable links.
-        attributes.push(("href".into(), url.clone()));
+    // links only ever have hrefs
+    pub fn new_link(url: S, children: Vec<DomNode<S>>) -> Self {
+        let attributes = vec![("href".into(), url.clone())];
 
         Self {
             name: "a".into(),
             kind: ContainerNodeKind::Link(url),
+            attrs: Some(attributes),
+            children,
+            handle: DomHandle::new_unset(),
+        }
+    }
+
+    // mentions can have custom attributes
+    pub fn new_mention(
+        url: S,
+        children: Vec<DomNode<S>>,
+        mut attributes: Vec<(S, S)>,
+    ) -> Self {
+        // In order to display correctly in the composer for web, the client must pass in:
+        // - style attribute containing the required CSS variable
+        // - data-mention-type giving the type of the mention as "user" | "room" | "at-room"
+
+        // We then add the href and contenteditable attributes to make sure they are present
+        attributes.push(("href".into(), url.clone()));
+        attributes.push(("contenteditable".into(), "false".into()));
+
+        Self {
+            name: "a".into(),
+            kind: ContainerNodeKind::Mention(url),
             attrs: Some(attributes),
             children,
             handle: DomHandle::new_unset(),

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -322,15 +322,14 @@ where
             || matches!(self.kind, ContainerNodeKind::Mention(_))
     }
 
+    // we have gone away from non-editable links so now, the only immutable container
+    // node is the Mention type
     pub fn is_immutable(&self) -> bool {
-        self.attributes()
-            .unwrap_or(&vec![])
-            .contains(&("contenteditable".into(), "false".into()))
+        matches!(self.kind, ContainerNodeKind::Mention(_))
     }
 
-    pub fn is_immutable_link_or_mention(&self) -> bool {
-        matches!(self.kind, ContainerNodeKind::Link(_) if self.is_immutable())
-            || matches!(self.kind, ContainerNodeKind::Mention(_))
+    pub fn is_mention(&self) -> bool {
+        matches!(self.kind, ContainerNodeKind::Mention(_))
     }
 
     pub fn is_list_item(&self) -> bool {

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -961,7 +961,7 @@ where
             }
 
             Mention(url) => {
-                fmt_mention(self, buffer, &options, url)?;
+                fmt_mention(buffer, url)?;
             }
         };
 
@@ -1331,17 +1331,13 @@ where
 
         #[inline(always)]
         fn fmt_mention<S>(
-            this: &ContainerNode<S>,
             buffer: &mut S,
-            options: &MarkdownOptions,
-            _url: &S,
+            _url: S,
         ) -> Result<(), MarkdownError<S>>
         where
             S: UnicodeString,
         {
-            fmt_children(this, buffer, options)?;
-
-            // TODO extract mxId from the url instead of hardcoding this
+            // TODO extract mxId from the _url instead of hardcoding this
 
             buffer.push("@mxId");
 

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -1332,7 +1332,7 @@ where
         #[inline(always)]
         fn fmt_mention<S>(
             buffer: &mut S,
-            _url: S,
+            _url: &S,
         ) -> Result<(), MarkdownError<S>>
         where
             S: UnicodeString,

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -418,28 +418,6 @@ where
         }
     }
 
-    pub fn new_mention(
-        url: S,
-        children: Vec<DomNode<S>>,
-        mut attributes: Vec<(S, S)>,
-    ) -> Self {
-        // In order to display correctly in the composer for web, the client must pass in:
-        // - style attribute containing the required CSS variable
-        // - data-mention-type giving the type of the mention as "user" | "room" | "at-room"
-
-        // We then add the href and contenteditable attributes to make sure they are present
-        attributes.push(("href".into(), url.clone()));
-        attributes.push(("contenteditable".into(), "false".into()));
-
-        Self {
-            name: "a".into(),
-            kind: ContainerNodeKind::Mention(url),
-            attrs: Some(attributes),
-            children,
-            handle: DomHandle::new_unset(),
-        }
-    }
-
     pub(crate) fn get_list_type(&self) -> Option<&ListType> {
         match &self.kind {
             ContainerNodeKind::List(t) => Some(t),

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -1334,7 +1334,7 @@ where
             this: &ContainerNode<S>,
             buffer: &mut S,
             options: &MarkdownOptions,
-            url: &S,
+            _url: &S,
         ) -> Result<(), MarkdownError<S>>
         where
             S: UnicodeString,

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -1344,19 +1344,9 @@ where
 
             fmt_children(this, buffer, options)?;
 
-            // TODO add some logic here to determine if it's a mention or a link
-            // For the time being, treat this as a link - will need to manipulate the url to get the mxId
+            // TODO extract mxId from the url instead of hardcoding this
 
-            buffer.push("](<");
-            buffer.push(
-                url.to_string()
-                    .replace('<', "\\<")
-                    .replace('>', "\\>")
-                    .replace('(', "\\(")
-                    .replace(')', "\\)")
-                    .as_str(),
-            );
-            buffer.push(">)");
+            buffer.push("@mxId");
 
             Ok(())
         }

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -1339,8 +1339,6 @@ where
         where
             S: UnicodeString,
         {
-            buffer.push('[');
-
             fmt_children(this, buffer, options)?;
 
             // TODO extract mxId from the url instead of hardcoding this

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -132,6 +132,16 @@ where
         DomNode::Container(ContainerNode::new_link(url, children, attributes))
     }
 
+    pub fn new_mention(
+        url: S,
+        children: Vec<DomNode<S>>,
+        attributes: Vec<(S, S)>,
+    ) -> DomNode<S> {
+        DomNode::Container(ContainerNode::new_mention(
+            url, children, attributes,
+        ))
+    }
+
     pub fn is_container_node(&self) -> bool {
         matches!(self, DomNode::Container(_))
     }
@@ -465,6 +475,7 @@ impl DomNodeKind {
             ContainerNodeKind::CodeBlock => DomNodeKind::CodeBlock,
             ContainerNodeKind::Quote => DomNodeKind::Quote,
             ContainerNodeKind::Paragraph => DomNodeKind::Paragraph,
+            ContainerNodeKind::Mention(_) => DomNodeKind::Link,
         }
     }
 

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -124,12 +124,18 @@ where
         }
     }
 
-    pub fn new_link(
+    pub fn new_link(url: S, children: Vec<DomNode<S>>) -> DomNode<S> {
+        DomNode::Container(ContainerNode::new_link(url, children))
+    }
+
+    pub fn new_mention(
         url: S,
         children: Vec<DomNode<S>>,
         attributes: Vec<(S, S)>,
     ) -> DomNode<S> {
-        DomNode::Container(ContainerNode::new_link(url, children, attributes))
+        DomNode::Container(ContainerNode::new_mention(
+            url, children, attributes,
+        ))
     }
 
     pub fn new_mention(

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -138,16 +138,6 @@ where
         ))
     }
 
-    pub fn new_mention(
-        url: S,
-        children: Vec<DomNode<S>>,
-        attributes: Vec<(S, S)>,
-    ) -> DomNode<S> {
-        DomNode::Container(ContainerNode::new_mention(
-            url, children, attributes,
-        ))
-    }
-
     pub fn is_container_node(&self) -> bool {
         matches!(self, DomNode::Container(_))
     }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -269,7 +269,6 @@ mod sys {
         where
             S: UnicodeString,
         {
-
             // initial implementation, firstly check if we have either `contenteditable=false` or `data-mention-type=`
             // attributes, if so then we're going to add a mention instead of a link
             // TODO should this just use `data-mention-type` to simulate a mention? Would need to change some tests
@@ -303,7 +302,6 @@ mod sys {
                     Vec::new(),
                 ))
             }
-
         }
 
         /// Create a list node
@@ -988,7 +986,7 @@ mod js {
         #[wasm_bindgen_test]
         fn a_with_attributes() {
             roundtrip(
-                r#"<a contenteditable="false" data-mention-type="user" style="something" href="http://example.com">a user mention</a>"#,
+                r#"<a data-mention-type="user" style="something" href="http://example.com" contenteditable="false">a user mention</a>"#,
             );
         }
 

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -177,7 +177,6 @@ mod sys {
                     self.current_path.remove(cur_path_idx);
                 }
                 "a" => {
-                    // TODO add some logic here to determine if it's a mention or a link
                     self.current_path.push(DomNodeKind::Link);
                     node.append_child(Self::new_link(child));
                     self.convert_children(

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -270,8 +270,7 @@ mod sys {
         {
             // initial implementation, firstly check if we have either `contenteditable=false` or `data-mention-type=`
             // attributes, if so then we're going to add a mention instead of a link
-            // TODO should this just use `data-mention-type` to simulate a mention? Would need to change some tests
-            // if so
+            // TODO we should make this just check the href but we need to update all the tests to account for this
             let is_mention = child.attrs.iter().any(|(k, v)| {
                 k == &String::from("contenteditable")
                     && v == &String::from("false")

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -270,7 +270,7 @@ mod sys {
         {
             // initial implementation, firstly check if we have either `contenteditable=false` or `data-mention-type=`
             // attributes, if so then we're going to add a mention instead of a link
-            // TODO we should make this just check the href but we need to update all the tests to account for this
+            // TODO move to inferring link or mention from href when utils exist
             let is_mention = child.attrs.iter().any(|(k, v)| {
                 k == &String::from("contenteditable")
                     && v == &String::from("false")
@@ -749,7 +749,7 @@ mod js {
                     "A" => {
                         self.current_path.push(DomNodeKind::Link);
 
-                        // TODO add some logic here to determine if it's a mention or a link
+                        // TODO move to inferring link or mention from href when utils exist
                         let is_mention = node
                             .unchecked_ref::<Element>()
                             .has_attribute("data-mention-type");

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -269,19 +269,39 @@ mod sys {
         where
             S: UnicodeString,
         {
-            // TODO add some logic here to determine if it's a mention or a link
-            let attributes = child
-                .attrs
-                .iter()
-                .filter(|(k, _)| k != &String::from("href"))
-                .map(|(k, v)| (k.as_str().into(), v.as_str().into()))
-                .collect();
 
-            DomNode::Container(ContainerNode::new_link(
-                child.get_attr("href").unwrap_or("").into(),
-                Vec::new(),
-                attributes,
-            ))
+            // initial implementation, firstly check if we have either `contenteditable=false` or `data-mention-type=`
+            // attributes, if so then we're going to add a mention instead of a link
+            let is_mention = child.attrs.iter().any(|(k, v)| {
+                k == &String::from("contenteditable")
+                    && v == &String::from("false")
+                    || k == &String::from("data-mention-type")
+            });
+
+            if is_mention {
+                // if we have a mention, filtering out the href and contenteditable attributes because
+                // we add these attributes when creating the mention and don't want repetition
+                let attributes = child
+                    .attrs
+                    .iter()
+                    .filter(|(k, _)| {
+                        k != &String::from("href")
+                            && k != &String::from("contenteditable")
+                    })
+                    .map(|(k, v)| (k.as_str().into(), v.as_str().into()))
+                    .collect();
+                DomNode::Container(ContainerNode::new_mention(
+                    child.get_attr("href").unwrap_or("").into(),
+                    Vec::new(),
+                    attributes,
+                ))
+            } else {
+                DomNode::Container(ContainerNode::new_link(
+                    child.get_attr("href").unwrap_or("").into(),
+                    Vec::new(),
+                ))
+            }
+
         }
 
         /// Create a list node

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -177,6 +177,7 @@ mod sys {
                     self.current_path.remove(cur_path_idx);
                 }
                 "a" => {
+                    // TODO add some logic here to determine if it's a mention or a link
                     self.current_path.push(DomNodeKind::Link);
                     node.append_child(Self::new_link(child));
                     self.convert_children(
@@ -268,6 +269,7 @@ mod sys {
         where
             S: UnicodeString,
         {
+            // TODO add some logic here to determine if it's a mention or a link
             let attributes = child
                 .attrs
                 .iter()
@@ -727,6 +729,7 @@ mod js {
                     },
 
                     "A" => {
+                        // TODO add some logic here to determine if it's a mention or a link
                         self.current_path.push(DomNodeKind::Link);
                         let mut attributes = vec![];
                         let valid_attributes =

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -887,7 +887,7 @@ fn backspace_mention_multiple() {
     model.backspace();
     assert_eq!(
         restore_whitespace(&tx(&model)),
-        "<a contenteditable=\"false\" href=\"https://matrix.org\">first|</a>"
+        "<a href=\"https://matrix.org\" contenteditable=\"false\">first|</a>"
     );
     model.backspace();
     assert_eq!(restore_whitespace(&tx(&model)), "|");
@@ -928,7 +928,7 @@ fn delete_first_mention_of_multiple() {
     model.delete();
     assert_eq!(
         restore_whitespace(&tx(&model)),
-        "<a contenteditable=\"false\" href=\"https://matrix.org\">|second</a>"
+        "<a href=\"https://matrix.org\" contenteditable=\"false\">|second</a>"
     );
     model.delete();
     assert_eq!(restore_whitespace(&tx(&model)), "|");
@@ -942,7 +942,7 @@ fn delete_second_mention_of_multiple() {
     model.delete();
     assert_eq!(
         restore_whitespace(&tx(&model)),
-        "<a contenteditable=\"false\" href=\"https://matrix.org\">first</a> |"
+        "<a href=\"https://matrix.org\" contenteditable=\"false\">first</a> |"
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -18,21 +18,21 @@ use crate::tests::testutils_conversion::utf16;
 #[test]
 fn set_link_to_empty_selection_at_end_of_alink() {
     let mut model = cm("<a href=\"https://matrix.org\">test_link</a>|");
-    model.set_link(utf16("https://element.io"), vec![]);
+    model.set_link(utf16("https://element.io"));
     assert_eq!(tx(&model), "<a href=\"https://element.io\">test_link|</a>");
 }
 
 #[test]
 fn set_link_to_empty_selection_within_a_link() {
     let mut model = cm("<a href=\"https://matrix.org\">test_|link</a>");
-    model.set_link(utf16("https://element.io"), vec![]);
+    model.set_link(utf16("https://element.io"));
     assert_eq!(tx(&model), "<a href=\"https://element.io\">test_|link</a>");
 }
 
 #[test]
 fn set_link_to_empty_selection_at_start_of_a_link() {
     let mut model = cm("<a href=\"https://matrix.org\">|test_link</a>");
-    model.set_link(utf16("https://element.io"), vec![]);
+    model.set_link(utf16("https://element.io"));
     assert_eq!(tx(&model), "<a href=\"https://element.io\">|test_link</a>");
 }
 
@@ -40,14 +40,14 @@ fn set_link_to_empty_selection_at_start_of_a_link() {
 fn set_link_to_empty_selection() {
     // This use case should never happen but in case it would...
     let mut model = cm("test|");
-    model.set_link(utf16("https://element.io"), vec![]);
+    model.set_link(utf16("https://element.io"));
     assert_eq!(tx(&model), "test|");
 }
 
 #[test]
 fn set_link_wraps_selection_in_link_tag() {
     let mut model = cm("{hello}| world");
-    model.set_link(utf16("https://element.io"), vec![]);
+    model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
         "<a href=\"https://element.io\">hello</a> world"
@@ -57,7 +57,7 @@ fn set_link_wraps_selection_in_link_tag() {
 #[test]
 fn set_link_in_multiple_leaves_of_formatted_text() {
     let mut model = cm("{<i>test_italic<b>test_italic_bold</b></i>}|");
-    model.set_link(utf16("https://element.io"), vec![]);
+    model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
         "<a href=\"https://element.io\"><i>test_italic<b>test_italic_bold</b></i></a>"
@@ -67,7 +67,7 @@ fn set_link_in_multiple_leaves_of_formatted_text() {
 #[test]
 fn set_link_in_multiple_leaves_of_formatted_text_partially_covered() {
     let mut model = cm("<i>test_it{alic<b>test_ital}|ic_bold</b></i>");
-    model.set_link(utf16("https://element.io"), vec![]);
+    model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
         "<i>test_it<a href=\"https://element.io\">alic<b>test_ital</b></a><b>ic_bold</b></i>"
@@ -77,7 +77,7 @@ fn set_link_in_multiple_leaves_of_formatted_text_partially_covered() {
 #[test]
 fn set_link_in_multiple_leaves_of_formatted_text_partially_covered_2() {
     let mut model = cm("<i><u>test_it{alic_underline</u>test_italic<b>test_ital}|ic_bold</b></i>");
-    model.set_link(utf16("https://element.io"), vec![]);
+    model.set_link(utf16("https://element.io"));
     assert_eq!(
         model.state.dom.to_string(),
         "<i><u>test_it</u><a href=\"https://element.io\"><u>alic_underline</u>test_italic<b>test_ital</b></a><b>ic_bold</b></i>"
@@ -87,7 +87,7 @@ fn set_link_in_multiple_leaves_of_formatted_text_partially_covered_2() {
 #[test]
 fn set_link_in_already_linked_text() {
     let mut model = cm("{<a href=\"https://element.io\">link_text</a>}|");
-    model.set_link(utf16("https://matrix.org"), vec![]);
+    model.set_link(utf16("https://matrix.org"));
     assert_eq!(
         model.state.dom.to_string(),
         "<a href=\"https://matrix.org\">link_text</a>"
@@ -97,7 +97,7 @@ fn set_link_in_already_linked_text() {
 #[test]
 fn set_link_in_already_linked_text_with_partial_selection() {
     let mut model = cm("<a href=\"https://element.io\">link_{text}|</a>");
-    model.set_link(utf16("https://matrix.org"), vec![]);
+    model.set_link(utf16("https://matrix.org"));
     assert_eq!(
         model.state.dom.to_string(),
         "<a href=\"https://matrix.org\">link_text</a>"
@@ -108,7 +108,7 @@ fn set_link_in_already_linked_text_with_partial_selection() {
 fn set_link_in_text_and_already_linked_text() {
     let mut model =
         cm("{non_link_text<a href=\"https://element.io\">link_text</a>}|");
-    model.set_link(utf16("https://matrix.org"), vec![]);
+    model.set_link(utf16("https://matrix.org"));
     assert_eq!(
         model.state.dom.to_string(),
         "<a href=\"https://matrix.org\">non_link_textlink_text</a>"
@@ -118,7 +118,7 @@ fn set_link_in_text_and_already_linked_text() {
 #[test]
 fn set_link_in_multiple_leaves_of_formatted_text_with_link() {
     let mut model = cm("{<i><a href=\"https://element.io\">test_italic</a><b><a href=\"https://element.io\">test_italic_bold</a></b></i>}|");
-    model.set_link(utf16("https://matrix.org"), vec![]);
+    model.set_link(utf16("https://matrix.org"));
     assert_eq!(
         model.state.dom.to_string(),
         "<a href=\"https://matrix.org\"><i>test_italic<b>test_italic_bold</b></i></a>"
@@ -128,7 +128,7 @@ fn set_link_in_multiple_leaves_of_formatted_text_with_link() {
 #[test]
 fn set_link_partially_highlighted_inside_a_link_and_starting_inside() {
     let mut model = cm("<a href=\"https://element.io\">test_{link</a> test}|");
-    model.set_link(utf16("https://matrix.org"), vec![]);
+    model.set_link(utf16("https://matrix.org"));
     assert_eq!(
         tx(&model),
         "<a href=\"https://matrix.org\">test_{link test}|</a>"
@@ -138,7 +138,7 @@ fn set_link_partially_highlighted_inside_a_link_and_starting_inside() {
 #[test]
 fn set_link_partially_highlighted_inside_a_link_and_starting_before() {
     let mut model = cm("{test <a href=\"https://element.io\">test}|_link</a>");
-    model.set_link(utf16("https://matrix.org"), vec![]);
+    model.set_link(utf16("https://matrix.org"));
     assert_eq!(
         tx(&model),
         "<a href=\"https://matrix.org\">{test test}|_link</a>"
@@ -148,7 +148,7 @@ fn set_link_partially_highlighted_inside_a_link_and_starting_before() {
 #[test]
 fn set_link_highlighted_inside_a_link() {
     let mut model = cm("<a href=\"https://element.io\">test {test}| test</a>");
-    model.set_link(utf16("https://matrix.org"), vec![]);
+    model.set_link(utf16("https://matrix.org"));
     assert_eq!(
         tx(&model),
         r#"<a href="https://matrix.org">test {test}| test</a>"#
@@ -158,7 +158,7 @@ fn set_link_highlighted_inside_a_link() {
 #[test]
 fn set_link_around_links() {
     let mut model = cm(r#"{X <a href="linkA">A</a> <a href="linkB">B</a> Y}|"#);
-    model.set_link(utf16("https://matrix.org"), vec![]);
+    model.set_link(utf16("https://matrix.org"));
     assert_eq!(tx(&model), r#"<a href="https://matrix.org">{X A B Y}|</a>"#);
 }
 
@@ -384,11 +384,7 @@ fn replace_text_in_a_link_inside_a_list_partially_selected_starting_inside_endin
 #[test]
 fn set_link_with_text() {
     let mut model = cm("test|");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>"
@@ -398,11 +394,7 @@ fn set_link_with_text() {
 #[test]
 fn set_link_with_text_and_undo() {
     let mut model = cm("test|");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>"
@@ -414,11 +406,7 @@ fn set_link_with_text_and_undo() {
 #[test]
 fn set_link_with_text_in_container() {
     let mut model = cm("<b>test_bold|</b> test");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "<b>test_bold<a href=\"https://element.io\">added_link|</a></b> test"
@@ -428,22 +416,14 @@ fn set_link_with_text_in_container() {
 #[test]
 fn set_link_with_text_on_blank_selection() {
     let mut model = cm("{   }|");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
 }
 
 #[test]
 fn set_link_with_text_on_blank_selection_after_text() {
     let mut model = cm("test{   }|");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>"
@@ -453,11 +433,7 @@ fn set_link_with_text_on_blank_selection_after_text() {
 #[test]
 fn set_link_with_text_on_blank_selection_before_text() {
     let mut model = cm("{   }|test");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "<a href=\"https://element.io\">added_link|</a>test"
@@ -467,11 +443,7 @@ fn set_link_with_text_on_blank_selection_before_text() {
 #[test]
 fn set_link_with_text_on_blank_selection_between_texts() {
     let mut model = cm("test{   }|test");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>test"
@@ -481,11 +453,7 @@ fn set_link_with_text_on_blank_selection_between_texts() {
 #[test]
 fn set_link_with_text_on_blank_selection_in_container() {
     let mut model = cm("<b>test{   }| test</b>");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "<b>test<a href=\"https://element.io\">added_link|</a> test</b>"
@@ -495,11 +463,7 @@ fn set_link_with_text_on_blank_selection_in_container() {
 #[test]
 fn set_link_with_text_on_blank_selection_with_line_break() {
     let mut model = cm("test{  <br> }|test");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "test<a href=\"https://element.io\">added_link|</a>test"
@@ -509,11 +473,7 @@ fn set_link_with_text_on_blank_selection_with_line_break() {
 #[test]
 fn set_link_with_text_on_blank_selection_with_different_containers() {
     let mut model = cm("<b>test_bold{ </b><br>  ~ <i> }|test_italic</i>");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(tx(&model), "<b>test_bold<a href=\"https://element.io\">added_link|</a></b><i>test_italic</i>");
 }
 
@@ -524,11 +484,7 @@ fn set_link_with_text_at_end_of_a_link() {
     // This fails returning <a href=\"https://element.io\">test_linkadded_link|</a>
     // Since it considers the added_link part as part of the first link itself
     let mut model = cm("<a href=\"https://matrix.org\">test_link|</a>");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(tx(&model), "<a href=\"https://matrix.org\">test_link</a><a href=\"https://element.io\">added_link|</a>");
 }
 
@@ -536,11 +492,7 @@ fn set_link_with_text_at_end_of_a_link() {
 fn set_link_with_text_within_a_link() {
     // This use case should never happen, but just in case it would...
     let mut model = cm("<a href=\"https://matrix.org\">test|_link</a>");
-    model.set_link_with_text(
-        utf16("https://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("https://element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "<a href=\"https://element.io\">testadded_link|_link</a>"
@@ -550,18 +502,14 @@ fn set_link_with_text_within_a_link() {
 #[test]
 fn set_link_without_http_scheme_and_www() {
     let mut model = cm("|");
-    model.set_link_with_text(utf16("element.io"), utf16("added_link"), vec![]);
+    model.set_link_with_text(utf16("element.io"), utf16("added_link"));
     assert_eq!(tx(&model), "<a href=\"https://element.io\">added_link|</a>");
 }
 
 #[test]
 fn set_link_without_http_scheme() {
     let mut model = cm("|");
-    model.set_link_with_text(
-        utf16("www.element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("www.element.io"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "<a href=\"https://www.element.io\">added_link|</a>"
@@ -574,7 +522,6 @@ fn set_link_do_not_change_scheme_for_http() {
     model.set_link_with_text(
         utf16("https://www.element.io"),
         utf16("added_link"),
-        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -585,11 +532,7 @@ fn set_link_do_not_change_scheme_for_http() {
 #[test]
 fn set_link_do_not_change_scheme_for_udp() {
     let mut model = cm("|");
-    model.set_link_with_text(
-        utf16("udp://element.io"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("udp://element.io"), utf16("added_link"));
     assert_eq!(tx(&model), "<a href=\"udp://element.io\">added_link|</a>");
 }
 
@@ -599,7 +542,6 @@ fn set_link_do_not_change_scheme_for_mail() {
     model.set_link_with_text(
         utf16("mailto:mymail@mail.com"),
         utf16("added_link"),
-        vec![],
     );
     assert_eq!(
         tx(&model),
@@ -610,11 +552,7 @@ fn set_link_do_not_change_scheme_for_mail() {
 #[test]
 fn set_link_add_mail_scheme() {
     let mut model = cm("|");
-    model.set_link_with_text(
-        utf16("mymail@mail.com"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("mymail@mail.com"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "<a href=\"mailto:mymail@mail.com\">added_link|</a>"
@@ -624,11 +562,7 @@ fn set_link_add_mail_scheme() {
 #[test]
 fn set_link_add_mail_scheme_with_plus() {
     let mut model = cm("|");
-    model.set_link_with_text(
-        utf16("mymail+01@mail.com"),
-        utf16("added_link"),
-        vec![],
-    );
+    model.set_link_with_text(utf16("mymail+01@mail.com"), utf16("added_link"));
     assert_eq!(
         tx(&model),
         "<a href=\"mailto:mymail+01@mail.com\">added_link|</a>"
@@ -638,14 +572,14 @@ fn set_link_add_mail_scheme_with_plus() {
 #[test]
 fn set_link_with_selection_add_http_scheme() {
     let mut model = cm("<a href=\"https://matrix.org\">test_link</a>|");
-    model.set_link(utf16("element.io"), vec![]);
+    model.set_link(utf16("element.io"));
     assert_eq!(tx(&model), "<a href=\"https://element.io\">test_link|</a>");
 }
 
 #[test]
 fn set_link_accross_list_items() {
     let mut model = cm("<ul><li>Te{st</li><li>Bo}|ld</li></ul>");
-    model.set_link("https://element.io".into(), vec![]);
+    model.set_link("https://element.io".into());
     assert_eq!(
         tx(&model),
         "<ul>\
@@ -658,7 +592,7 @@ fn set_link_accross_list_items() {
 #[test]
 fn set_link_accross_list_items_with_container() {
     let mut model = cm("<ul><li><b>Te{st</b></li><li><b>Bo}|ld</b></li></ul>");
-    model.set_link("https://element.io".into(), vec![]);
+    model.set_link("https://element.io".into());
     assert_eq!(
         tx(&model),
         "<ul>\
@@ -677,7 +611,7 @@ fn set_link_across_list_items_with_multiple_inline_formattings_selected() {
     let mut model = cm(
         "<ul><li>tes{t<b>test_bold</b></li><li><i>test_}|italic</i></li></ul>",
     );
-    model.set_link("https://element.io".into(), vec![]);
+    model.set_link("https://element.io".into());
     assert_eq!(
         tx(&model),
         "<ul>\
@@ -696,7 +630,7 @@ fn set_link_across_list_items_including_an_entire_item() {
     // panicked at 'All child nodes of handle DomHandle { path: Some([0]) } must be either inline nodes or block nodes
     let mut model =
         cm("<ul><li>te{st1</li><li>test2</li><li>te}|st3</li></ul>");
-    model.set_link("https://element.io".into(), vec![]);
+    model.set_link("https://element.io".into());
     assert_eq!(
         tx(&model),
         "<ul>\
@@ -717,7 +651,7 @@ fn set_link_across_list_items_including_an_entire_item() {
 fn set_link_accross_quote() {
     let mut model =
         cm("<blockquote>test_{block_quote</blockquote><p> test}|</p>");
-    model.set_link("https://element.io".into(), vec![]);
+    model.set_link("https://element.io".into());
     assert_eq!(
         tx(&model),
         "<blockquote>\
@@ -732,7 +666,7 @@ fn set_link_accross_quote() {
 #[test]
 fn set_link_across_multiple_paragraphs() {
     let mut model = cm("<p>te{st1</p><p>te}|st2</p>");
-    model.set_link("https://element.io".into(), vec![]);
+    model.set_link("https://element.io".into());
     assert_eq!(
         tx(&model),
         "<p>te<a href=\"https://element.io\">{st1</a></p><p><a href=\"https://element.io\">te}|</a>st2</p>"
@@ -743,7 +677,7 @@ fn set_link_across_multiple_paragraphs() {
 fn set_link_across_multiple_paragraphs_containing_an_entire_pagraph() {
     // This panics saying 'All child nodes of handle DomHandle { path: Some([0]) } must be either inline nodes or block nodes'
     let mut model = cm("<p>te{st1</p><p>test2</p><p>tes}|t3</p>");
-    model.set_link("https://element.io".into(), vec![]);
+    model.set_link("https://element.io".into());
     assert_eq!(
         tx(&model),
         "<p>\
@@ -765,11 +699,7 @@ fn create_link_after_enter_with_formatting_applied() {
     model.bold();
     model.replace_text("test".into());
     model.enter();
-    model.set_link_with_text(
-        "https://matrix.org".into(),
-        "test".into(),
-        vec![],
-    );
+    model.set_link_with_text("https://matrix.org".into(), "test".into());
     assert_eq!(
         tx(&model),
         "<p>test <strong>test</strong></p><p><a href=\"https://matrix.org\"><strong>test|</strong></a></p>",
@@ -780,11 +710,7 @@ fn create_link_after_enter_with_formatting_applied() {
 fn create_link_after_enter_with_no_formatting_applied() {
     let mut model = cm("|");
     model.enter();
-    model.set_link_with_text(
-        "https://matrix.org".into(),
-        "test".into(),
-        vec![],
-    );
+    model.set_link_with_text("https://matrix.org".into(), "test".into());
     assert_eq!(
         tx(&model),
         "<p>&nbsp;</p><p><a href=\"https://matrix.org\">test|</a></p>"
@@ -844,32 +770,5 @@ fn replace_text_right_after_link_with_next_formatted_text() {
     assert_eq!(
         tx(&model),
         "<a href=\"https://matrix.org\">Matrix</a><strong>text|text</strong>",
-    )
-}
-
-#[test]
-fn set_link_with_custom_attributes() {
-    let mut model = cm("{hello}| world");
-    model.set_link(
-        "https://matrix.org".into(),
-        vec![("customattribute".into(), "customvalue".into())],
-    );
-    assert_eq!(
-        tx(&model),
-        "<a customattribute=\"customvalue\" href=\"https://matrix.org\">{hello}|</a> world"
-    )
-}
-
-#[test]
-fn set_link_with_text_and_custom_attributes() {
-    let mut model = cm("|");
-    model.set_link_with_text(
-        "https://matrix.org".into(),
-        "link".into(),
-        vec![("customattribute".into(), "customvalue".into())],
-    );
-    assert_eq!(
-        tx(&model),
-        "<a customattribute=\"customvalue\" href=\"https://matrix.org\">link|</a>"
     )
 }

--- a/crates/wysiwyg/src/tests/test_suggestions.rs
+++ b/crates/wysiwyg/src/tests/test_suggestions.rs
@@ -34,7 +34,7 @@ fn test_set_link_suggestion_no_attributes() {
     let MenuAction::Suggestion(suggestion) = update.menu_action else {
         panic!("No suggestion pattern found")
     };
-    model.set_link_suggestion(
+    model.set_mention_from_suggestion(
         "https://matrix.to/#/@alice:matrix.org".into(),
         "Alice".into(),
         suggestion,
@@ -42,7 +42,7 @@ fn test_set_link_suggestion_no_attributes() {
     );
     assert_eq!(
         tx(&model),
-        "<a href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>&nbsp;|",
+        "<a href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\">Alice</a>&nbsp;|",
     );
 }
 
@@ -53,17 +53,14 @@ fn test_set_link_suggestion_with_attributes() {
     let MenuAction::Suggestion(suggestion) = update.menu_action else {
         panic!("No suggestion pattern found")
     };
-    model.set_link_suggestion(
+    model.set_mention_from_suggestion(
         "https://matrix.to/#/@alice:matrix.org".into(),
         "Alice".into(),
         suggestion,
-        vec![
-            ("contenteditable".into(), "false".into()),
-            ("data-mention-type".into(), "user".into()),
-        ],
+        vec![("data-mention-type".into(), "user".into())],
     );
     assert_eq!(
         tx(&model),
-        "<a contenteditable=\"false\" data-mention-type=\"user\" href=\"https://matrix.to/#/@alice:matrix.org\">Alice</a>&nbsp;|",
+        "<a data-mention-type=\"user\" href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\">Alice</a>&nbsp;|",
     );
 }

--- a/crates/wysiwyg/src/tests/testutils_dom.rs
+++ b/crates/wysiwyg/src/tests/testutils_dom.rs
@@ -29,11 +29,7 @@ pub fn dom<'a>(
 pub fn a<'a>(
     children: impl IntoIterator<Item = &'a DomNode<Utf16String>>,
 ) -> DomNode<Utf16String> {
-    DomNode::new_link(
-        utf16("https://element.io"),
-        clone_children(children),
-        vec![],
-    )
+    DomNode::new_link(utf16("https://element.io"), clone_children(children))
 }
 
 pub fn b<'a>(

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -73,17 +73,14 @@ export function processInput(
         case 'insertSuggestion': {
             if (suggestion && isSuggestionEvent(event)) {
                 const { text, url, attributes } = event.data;
-                const defaultMap = new Map();
-                defaultMap.set('contenteditable', 'false');
-                Object.entries(attributes).forEach(([key, value]) => {
-                    defaultMap.set(key, value);
-                });
+                const attributesMap = new Map(Object.entries(attributes));
+
                 return action(
                     composerModel.set_link_suggestion(
                         url,
                         text,
                         suggestion,
-                        defaultMap,
+                        attributesMap,
                     ),
                     'set_link_suggestion',
                 );
@@ -181,8 +178,8 @@ export function processInput(
                 const { text, url } = event.data;
                 return action(
                     text
-                        ? composerModel.set_link_with_text(url, text, new Map())
-                        : composerModel.set_link(url, new Map()),
+                        ? composerModel.set_link_with_text(url, text)
+                        : composerModel.set_link(url),
                     'insertLink',
                 );
             }

--- a/platforms/web/lib/testUtils/Editor.tsx
+++ b/platforms/web/lib/testUtils/Editor.tsx
@@ -122,7 +122,6 @@ export const Editor = forwardRef<HTMLDivElement, EditorProps>(function Editor(
                         'https://matrix.to/#/@test_user:element.io',
                         'test user',
                         {
-                            'contentEditable': 'false',
                             'data-mention-type': 'user',
                         },
                     );

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -195,7 +195,6 @@ function App() {
                                         'https://matrix.to/#/@alice_user:element.io',
                                         'Alice',
                                         {
-                                            'contentEditable': 'false',
                                             'data-mention-type':
                                                 suggestion.keyChar === '@'
                                                     ? 'user'


### PR DESCRIPTION
This PR adds a mention type so that we can differentiate between links and mentions. Opening for CI checks.

This PR:
- amends `set_link` and `set_link_with_text` so that these functions no longer need to be passed an `attributes` argument (and updates the binding functions for web and mobile to account for this change of signature)
- renames `set_link_suggestion` to `set_mention_from_suggestion`
- makes it so that creating a mention automatically adds a `contenteditable=false` attribute to the mention and adjusts the test cases as required

Recommend to look at this commit by commit.
