### PR TITLE
[Android] Change HTML output to use message format

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
@@ -478,19 +478,19 @@ class EditorEditTextInputTests {
             val editor = activity.findViewById<EditorEditText>(R.id.rich_text_edit_text)
             editor.setMarkdown("__Test__")
             ViewMatchers.assertThat(
-                editor.getHtmlOutput(),
+                editor.getContentAsMessageHtml(),
                 CoreMatchers.equalTo("<strong>Test</strong>")
             )
             editor.setMarkdown("**Test**")
             ViewMatchers.assertThat(
-                editor.getHtmlOutput(),
+                editor.getContentAsMessageHtml(),
                 CoreMatchers.equalTo("<strong>Test</strong>")
             )
             editor.setMarkdown("**Test*")
-            ViewMatchers.assertThat(editor.getHtmlOutput(), CoreMatchers.equalTo("*<em>Test</em>"))
+            ViewMatchers.assertThat(editor.getContentAsMessageHtml(), CoreMatchers.equalTo("*<em>Test</em>"))
             editor.setMarkdown("<u>*Test*</u>")
             ViewMatchers.assertThat(
-                editor.getHtmlOutput(),
+                editor.getContentAsMessageHtml(),
                 CoreMatchers.equalTo("<u><em>Test</em></u>")
             )
         }

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -503,7 +503,7 @@ class InterceptInputConnectionIntegrationTest {
         inputConnection.setComposingRegion(0, 4)
         inputConnection.commitText("testing", 1)
 
-        assertThat(viewModel.getHtml(), equalTo("<strong>test</strong>ing"))
+        assertThat(viewModel.getContentAsMessageHtml(), equalTo("<strong>test</strong>ing"))
     }
 
     @Test
@@ -519,7 +519,7 @@ class InterceptInputConnectionIntegrationTest {
         // Add some extra text
         inputConnection.setComposingText("whitespaces", 1)
 
-        assertThat(viewModel.getHtml(), equalTo("<strong>test</strong> whitespaces"))
+        assertThat(viewModel.getContentAsMessageHtml(), equalTo("<strong>test</strong> whitespaces"))
     }
 
     private fun simulateInput(editorInputAction: EditorInputAction) =

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -403,8 +403,11 @@ class EditorEditText : TextInputEditText {
         setSelectionFromComposerUpdate(result.selection.last)
     }
 
-    fun getHtmlOutput(): String {
-        return viewModel.getHtml()
+    /**
+     * Get the editor content as clean HTML suitable for sending as a message
+     */
+    fun getContentAsMessageHtml(): String {
+        return viewModel.getContentAsMessageHtml()
     }
 
     /**

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
@@ -130,15 +130,15 @@ internal class EditorViewModel(
         }
     }
 
-    fun getHtml(): String {
-        return composer?.getContentAsHtml().orEmpty()
+    fun getContentAsMessageHtml(): String {
+        return composer?.getContentAsMessageHtml().orEmpty()
     }
 
     fun getMarkdown(): String =
         composer?.getContentAsMarkdown().orEmpty()
 
     fun getCurrentFormattedText(): CharSequence {
-        return stringToSpans(getHtml())
+        return stringToSpans(getContentAsMessageHtml())
     }
 
     fun actionStates(): Map<ComposerAction, ActionState>? {

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
@@ -131,9 +131,9 @@ class MockComposer {
         throwable: Throwable = IllegalStateException("Invalid selection range"),
     ) = every { instance.select(any(), any()) } throws throwable
 
-    fun givenGetContentAsHtml(
+    fun givenGetContentAsMessageHtml(
         html: String = ""
-    ) = every { instance.getContentAsHtml() } returns html
+    ) = every { instance.getContentAsMessageHtml() } returns html
 
     fun givenGetContentAsMarkdown(
         markdown: String = ""

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
@@ -417,8 +417,8 @@ internal class EditorViewModelTest {
     }
 
     @Test
-    fun `given formatted text, getHtml function returns formatted HTML`() {
-        composer.givenGetContentAsHtml(htmlParagraphs)
+    fun `given formatted text, getContentAsMessageHtml function returns formatted HTML`() {
+        composer.givenGetContentAsMessageHtml(htmlParagraphs)
 
         val html = viewModel.getContentAsMessageHtml()
 

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
@@ -420,7 +420,7 @@ internal class EditorViewModelTest {
     fun `given formatted text, getHtml function returns formatted HTML`() {
         composer.givenGetContentAsHtml(htmlParagraphs)
 
-        val html = viewModel.getHtml()
+        val html = viewModel.getContentAsMessageHtml()
 
         assertThat(html, equalTo(htmlParagraphs))
     }


### PR DESCRIPTION
## Changes

- Expose new `getContentAsMessageHtml()` from Android platform library.
- **[API breaking change]** Remove the ambiguous `getHtml()` function

## Context

- https://github.com/matrix-org/matrix-rich-text-editor/pull/686
- https://github.com/matrix-org/matrix-rich-text-editor/issues/679