### PR TITLE
Add Matrix mentions utils [wip]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,7 +36,7 @@ checksum = "87bf87e6e8b47264efa9bde63d6225c6276a52e05e91bf37eaa8afd0032d6b71"
 dependencies = [
  "askama_shared",
  "proc-macro2",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -49,8 +58,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
- "toml",
+ "syn 1.0.103",
+ "toml 0.5.9",
 ]
 
 [[package]]
@@ -69,6 +78,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "base64"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
 
 [[package]]
 name = "bincode"
@@ -161,7 +176,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -297,7 +312,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -318,6 +333,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -340,6 +356,46 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "js_int"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d937f95470b270ce8b8950207715d71aa8e153c0d44c6684d59397ed4949160a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "js_option"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68421373957a1593a767013698dbf206e2b221eefe97a44d98d18672ff38423c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330f0e13e6483b8c34885f7e6c9f19b1a7bd449c673fbb948a51c99d66ef74f4"
+dependencies = [
+ "konst_macro_rules",
+ "konst_proc_macros",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984e109462d46ad18314f10e392c286c3d47bce203088a09012de1015b45b737"
 
 [[package]]
 name = "lazy_static"
@@ -390,6 +446,13 @@ dependencies = [
  "string_cache",
  "string_cache_codegen",
  "tendril",
+]
+
+[[package]]
+name = "matrix_mentions"
+version = "0.1.0"
+dependencies = [
+ "ruma-common",
 ]
 
 [[package]]
@@ -619,6 +682,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +706,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,7 +724,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -662,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -682,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -817,6 +896,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
+name = "ruma-common"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b4ec3f70ea9afeae96a6c1e5eb86ed02760d5c28a167b5d9a433cefaaf815c"
+dependencies = [
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "indexmap",
+ "js_int",
+ "js_option",
+ "konst",
+ "percent-encoding",
+ "regex",
+ "ruma-identifiers-validation",
+ "ruma-macros",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "wildmatch",
+]
+
+[[package]]
+name = "ruma-identifiers-validation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebefdab34311af44d07cd2cd91c36cfe6a8c770647c6b00f6ab47f1186b2bb72"
+dependencies = [
+ "js_int",
+ "thiserror",
+]
+
+[[package]]
+name = "ruma-macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e883799456b6213da90fe065d4234f282b89afe161af3e5fcc854e44e8f582"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "ruma-identifiers-validation",
+ "serde",
+ "syn 1.0.103",
+ "toml 0.7.4",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,7 +1011,7 @@ checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -892,7 +1040,20 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53192e38d5c88564b924dbe9b60865ecbb71b81d38c4e61c817cffd3e36ef696"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -903,6 +1064,15 @@ checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
  "serde",
 ]
 
@@ -981,7 +1151,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -989,6 +1159,17 @@ name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1022,6 +1203,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 
 [[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1244,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1127,7 +1394,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.9",
  "uniffi_meta",
  "weedle2",
 ]
@@ -1156,8 +1423,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
- "toml",
+ "syn 1.0.103",
+ "toml 0.5.9",
  "uniffi_build",
  "uniffi_meta",
 ]
@@ -1233,7 +1500,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -1267,7 +1534,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1326,6 +1593,12 @@ name = "widestring"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
+
+[[package]]
+name = "wildmatch"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee583bdc5ff1cf9db20e9db5bb3ff4c3089a8f6b8b31aff265c9aba85812db86"
 
 [[package]]
 name = "winapi"
@@ -1416,6 +1689,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wysiwyg"
 version = "2.2.1"
 dependencies = [
@@ -1424,6 +1706,7 @@ dependencies = [
  "html-escape",
  "html5ever",
  "indoc",
+ "matrix_mentions",
  "once_cell",
  "pulldown-cmark",
  "speculoos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "bindings/wysiwyg-ffi",
     "bindings/wysiwyg-wasm",
     "crates/wysiwyg",
+    "crates/matrix_mentions",
 ]
 resolver = "2"
 

--- a/crates/matrix_mentions/Cargo.toml
+++ b/crates/matrix_mentions/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["Jonny Andrew <jonnya@element.io>"]
+homepage = "https://github.com/matrix-org/matrix-rich-text-editor"
+repository = "https://github.com/matrix-org/matrix-rich-text-editor"
+description = "Utilities for Matrix mentions"
+keywords = ["matrix", "chat", "messaging"]
+license = "Apache-2.0"
+name = "matrix_mentions"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+ruma-common = "0.11.3"

--- a/crates/matrix_mentions/src/lib.rs
+++ b/crates/matrix_mentions/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod mention;
+
+pub use crate::mention::Mention;

--- a/crates/matrix_mentions/src/mention.rs
+++ b/crates/matrix_mentions/src/mention.rs
@@ -1,0 +1,253 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ruma_common::{matrix_uri::MatrixId, MatrixToUri, MatrixUri};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Mention {
+    uri: String,
+    text: String,
+}
+
+impl Mention {
+    fn new(uri: String, text: String) -> Self {
+        Mention { uri, text }
+    }
+
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Create a mention from a URI
+    ///
+    /// If the URI is a valid room or user, it creates a mention using the
+    /// default text.
+    pub fn from_uri(uri: &str) -> Option<Mention> {
+        match parse_matrix_id(uri)? {
+            MatrixId::Room(_) | MatrixId::RoomAlias(_) => {
+                Mention::from_room(uri)
+            }
+            MatrixId::User(_) => Mention::from_user(uri, None),
+            _ => None,
+        }
+    }
+
+    /// Create a mention from a link
+    ///
+    /// If the URI is a valid room, it constructs a room mention, ignoring the
+    /// provided `anchor_text` and using the room Itext
+    ///
+    /// If the URI is a valid user, it constructs a valid room mention, and
+    /// assumes the provided `anchor_text` is the user's display name.
+    pub fn from_link(href: &str, anchor_text: &str) -> Option<Mention> {
+        match parse_matrix_id(href)? {
+            MatrixId::Room(_) | MatrixId::RoomAlias(_) => {
+                Mention::from_room(href)
+            }
+            MatrixId::User(_) => Mention::from_user(href, Some(anchor_text)),
+            _ => None,
+        }
+    }
+
+    /// Create a mention from a user URI and an optional display name
+    ///
+    /// If the URI is not a valid user, it returns None.
+    /// If the display name is not given, it falls back to the user's ID.
+    fn from_user(
+        user_uri: &str,
+        display_name: Option<&str>,
+    ) -> Option<Mention> {
+        match parse_matrix_id(user_uri)? {
+            MatrixId::User(user_id) => {
+                // Use the user’s potentially ambiguous display name for the
+                // anchor’s text.
+                let text = display_name
+                    // If the user does not have a display name,
+                    // use the user’s ID.
+                    .unwrap_or(user_id.as_str());
+
+                Some(Mention::new(user_uri.to_string(), text.to_string()))
+            }
+            _ => None,
+        }
+    }
+
+    /// Create a mention from a room URI and an optional display name
+    ///
+    /// If the URI is not a valid room, it returns None.
+    fn from_room(room_uri: &str) -> Option<Mention> {
+        // In all cases, use the alias/room ID being linked to as the
+        // anchor’s text.
+        let text = match parse_matrix_id(room_uri)? {
+            MatrixId::Room(room_id) => room_id.to_string(),
+            MatrixId::RoomAlias(room_alias) => room_alias.to_string(),
+            _ => return None,
+        };
+
+        Some(Mention::new(room_uri.to_string(), text))
+    }
+}
+
+fn parse_matrix_id(uri: &str) -> Option<MatrixId> {
+    if let Ok(matrix_uri) = MatrixUri::parse(uri) {
+        Some(matrix_uri.id().to_owned())
+    } else if let Ok(matrix_to_uri) = MatrixToUri::parse(uri) {
+        Some(matrix_to_uri.id().to_owned())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ruma_common::{MatrixToUri, MatrixUri};
+
+    use crate::mention::Mention;
+
+    #[test]
+    fn parse_uri_matrix_to_valid_user() {
+        let parsed = Mention::from_uri(matrix_to(
+            "https://matrix.to/#/@alice:example.org",
+        ))
+        .unwrap();
+        assert!(parsed.text() == "@alice:example.org");
+    }
+
+    #[test]
+    fn parse_uri_matrix_uri_valid_user() {
+        let parsed =
+            Mention::from_uri(matrix_uri("matrix:u/alice:example.org"))
+                .unwrap();
+        assert!(parsed.text() == "@alice:example.org");
+    }
+
+    #[test]
+    fn parse_uri_matrix_to_valid_room() {
+        let parsed = Mention::from_uri(matrix_to(
+            "https://matrix.to/#/!roomid:example.org",
+        ))
+        .unwrap();
+        assert!(parsed.text() == "!roomid:example.org");
+    }
+
+    #[test]
+    fn parse_uri_matrix_uri_valid_room() {
+        let parsed =
+            Mention::from_uri(matrix_uri("matrix:roomid/roomid:example.org"))
+                .unwrap();
+        assert!(parsed.text() == "!roomid:example.org");
+    }
+
+    #[test]
+    fn parse_uri_matrix_to_valid_room_alias() {
+        let parsed = Mention::from_uri(matrix_to(
+            "https://matrix.to/#/#room:example.org",
+        ))
+        .unwrap();
+        assert!(parsed.text() == "#room:example.org");
+    }
+
+    #[test]
+    fn parse_uri_matrix_uri_valid_room_alias() {
+        let parsed =
+            Mention::from_uri(matrix_uri("matrix:r/room:example.org")).unwrap();
+        assert!(parsed.text() == "#room:example.org");
+    }
+
+    #[test]
+    fn parse_uri_matrix_to_valid_event() {
+        let parsed = Mention::from_uri(matrix_to(
+            "https://matrix.to/#/#room:example.org/$eventid",
+        ));
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn parse_uri_matrix_uri_valid_event() {
+        let parsed = Mention::from_uri(matrix_uri(
+            "matrix:r/room:example.org/e/eventid",
+        ));
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn parse_uri_matrix_to_invalid() {
+        assert!(Mention::from_uri("https://matrix.to/#/invalid").is_none());
+    }
+
+    #[test]
+    fn parse_uri_matrix_uri_invalid() {
+        assert!(Mention::from_uri("matrix:u/invalid").is_none());
+    }
+
+    #[test]
+    fn parse_uri_not_uri() {
+        assert!(Mention::from_uri("hello").is_none());
+    }
+
+    #[test]
+    fn parse_link_user_text() {
+        let parsed = Mention::from_link(
+            matrix_to("https://matrix.to/#/@alice:example.org"),
+            "Alice",
+        )
+        .unwrap();
+        assert!(parsed.text() == "Alice");
+    }
+
+    #[test]
+    fn parse_link_room_text() {
+        let parsed = Mention::from_link(
+            matrix_to("https://matrix.to/#/!room:example.org"),
+            "My room",
+        )
+        .unwrap();
+        assert!(parsed.text() == "!room:example.org");
+    }
+
+    #[test]
+    fn parse_link_room_alias_text() {
+        let parsed = Mention::from_link(
+            matrix_to("https://matrix.to/#/#room:example.org"),
+            "My room",
+        )
+        .unwrap();
+        assert!(parsed.text() == "#room:example.org");
+    }
+
+    #[test]
+    fn parse_link_event_text() {
+        let parsed = Mention::from_link(
+            matrix_to("https://matrix.to/#/#room:example.org/$eventid"),
+            "My event",
+        );
+        assert!(parsed.is_none());
+    }
+
+    fn matrix_to(uri: &str) -> &str {
+        let parsed = MatrixToUri::parse(uri);
+        assert!(parsed.is_ok());
+        uri
+    }
+
+    fn matrix_uri(uri: &str) -> &str {
+        let parsed = MatrixUri::parse(uri);
+        assert!(parsed.is_ok());
+        uri
+    }
+}

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -31,6 +31,7 @@ widestring = "1.0.2"
 indoc = "1.0"
 url="2.3.1"
 email_address="0.2.4"
+matrix_mentions = { path = "../matrix_mentions" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 speculoos = "0.9"


### PR DESCRIPTION
This PR should add utilities to help with creating Matrix spec compliant mention HTML.

- Part of https://github.com/matrix-org/matrix-rich-text-editor/issues/692

As input, functions might accept:
- a Matrix mention URL
- a potentially ambiguous display name
- any room aliases that are available

As output, functions should return:
- a valid mention URL and anchor/body text combination
- any other useful information required by the library (e.g. the mention type required by matrix-org/matrix-rich-text-editor#709)

### Reference

Valid mention URL and anchor/body text combinations according to the Matrix spec:

> * When mentioning users, use the user’s potentially ambiguous display name for the anchor’s text. If the user does not have a display name, use the user’s ID.
> * When mentioning rooms, use the canonical alias [fallling back to alias then room ID] for the room. In all cases, use the alias/room ID being linked to as the anchor’s text.

> The text component of the anchor should be used in the event’s `body` where the mention would normally be represented, as shown in the example above.


