### PR TITLE
Android: Allow pasting of non text content

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
@@ -1,7 +1,9 @@
 package io.element.android.wysiwyg.test.utils
 
+import android.net.Uri
 import android.text.Editable
 import android.view.View
+import androidx.core.view.ViewCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
@@ -10,6 +12,7 @@ import io.element.android.wysiwyg.EditorEditText
 import io.element.android.wysiwyg.display.KeywordDisplayHandler
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.display.LinkDisplayHandler
+import io.element.android.wysiwyg.inputhandlers.UriContentListener
 import io.element.android.wysiwyg.utils.RustErrorCollector
 import org.hamcrest.Matcher
 
@@ -201,6 +204,27 @@ object Editor {
         }
     }
 
+    class AddContentWatcher(
+        private val contentTypes: Array<String>,
+        private val contentWatcher: (Uri) -> Unit,
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Add a content watcher"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val editor = view as? EditorEditText ?: return
+
+            ViewCompat.setOnReceiveContentListener(
+                editor,
+                contentTypes,
+                UriContentListener{
+                    contentWatcher(it)
+                }
+            )
+        }
+    }
+
     class TestCrash(
         private val errorCollector: RustErrorCollector?
     ) : ViewAction {
@@ -232,7 +256,8 @@ object EditorActions {
     fun undo() = Editor.Undo
     fun redo() = Editor.Redo
     fun toggleFormat(format: InlineFormat) = Editor.ToggleFormat(format)
-    fun addTextWatcher(watcher : (Editable?) -> Unit) = Editor.AddTextWatcher(watcher)
+    fun addTextWatcher(watcher: (Editable?) -> Unit) = Editor.AddTextWatcher(watcher)
+    fun addContentWatcher(contentTypes: Array<String>, watcher: (Uri) -> Unit) = Editor.AddContentWatcher(contentTypes, watcher)
     fun testCrash(
         errorCollector: RustErrorCollector? = null
     ) = Editor.TestCrash(errorCollector)

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
@@ -12,7 +12,6 @@ import io.element.android.wysiwyg.EditorEditText
 import io.element.android.wysiwyg.display.KeywordDisplayHandler
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.display.LinkDisplayHandler
-import io.element.android.wysiwyg.inputhandlers.UriContentListener
 import io.element.android.wysiwyg.utils.RustErrorCollector
 import org.hamcrest.Matcher
 

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/UriContentListener.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/UriContentListener.kt
@@ -1,4 +1,4 @@
-package io.element.android.wysiwyg.inputhandlers
+package io.element.android.wysiwyg.test.utils
 
 import android.content.ClipData
 import android.net.Uri

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -219,7 +219,9 @@ class EditorEditText : TextInputEditText {
             android.R.id.paste, android.R.id.pasteAsPlainText -> {
                 val clipBoardManager =
                     context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
-                val copiedString = clipBoardManager.primaryClip?.getItemAt(0)?.text ?: return false
+                // Only special-case paste behaviour if it is text content, otherwise default to EditText implementation
+                // which calls ViewCompat.performReceiveContent and fires the expected listeners.
+                val copiedString = clipBoardManager.primaryClip?.getItemAt(0)?.text ?: return super.onTextContextMenuItem(id)
                 val result = viewModel.processInput(EditorInputAction.ReplaceText(copiedString))
 
                 if (result != null) {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/UriContentListener.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/UriContentListener.kt
@@ -1,0 +1,29 @@
+package io.element.android.wysiwyg.inputhandlers
+
+import android.content.ClipData
+import android.net.Uri
+import android.view.View
+import androidx.core.view.ContentInfoCompat
+import androidx.core.view.OnReceiveContentListener
+
+class UriContentListener(
+    private val onContent: (uri: Uri) -> Unit
+) : OnReceiveContentListener {
+    override fun onReceiveContent(view: View, payload: ContentInfoCompat): ContentInfoCompat? {
+        val split = payload.partition { item -> item.uri != null }
+        val uriContent = split.first
+        val remaining = split.second
+
+        if (uriContent != null) {
+            val clip: ClipData = uriContent.clip
+            for (i in 0 until clip.itemCount) {
+                val uri = clip.getItemAt(i).uri
+                // ... app-specific logic to handle the URI ...
+                onContent(uri)
+            }
+        }
+        // Return anything that we didn't handle ourselves. This preserves the default platform
+        // behavior for text and anything else for which we are not implementing custom handling.
+        return remaining
+    }
+}


### PR DESCRIPTION
- Only special-case onTextContextMenuItem paste behaviour if it is text that is pasted, otherwise default to EditText implementation.
- Add tests for pasting of images, plain text and html