### PR TITLE
Draft: idea for selection decoupling

### DIFF
--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -100,6 +100,8 @@ pub struct ComposerModel {
 
 #[wasm_bindgen]
 impl ComposerModel {
+    // TODO implement once types figured out
+    // pub fn get_web_selection(&self) -> WebSelection {}
     pub fn new() -> Self {
         Self {
             inner: wysiwyg::ComposerModel::new(),
@@ -619,6 +621,29 @@ impl From<&ComposerAction> for wysiwyg::ComposerAction {
         }
     }
 }
+
+// TODO implement once types figured out
+// #[derive(Clone)]
+// #[wasm_bindgen(getter_with_clone)]
+// pub struct WebSelection {
+//     pub anchor_node: js_sys::Array,
+//     pub anchor_offset: u32,
+//     pub focus_node: js_sys::Array,
+//     pub focus_offset: u32,
+//     pub is_collapsed: bool,
+// }
+
+// impl From<wysiwyg::WebSelection> for WebSelection {
+//     fn from(inner: wysiwyg::WebSelection) -> Self {
+//         Self {
+//             anchor_node: js_sys::Array::from(vec![1, 2, 3]).unwrap(),
+//             anchor_offset: u32::try_from(inner.anchor_offset).unwrap(),
+//             focus_node: js_sys::Array::from(vec![3, 2, 1]).unwrap(),
+//             focus_offset: u32::try_from(inner.focus_offset).unwrap(),
+//             is_collapsed: bool::try_from(inner.is_collapsed).unwrap(),
+//         }
+//     }
+// }
 
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Clone)]

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -29,6 +29,7 @@ mod pattern_key;
 mod suggestion_pattern;
 mod tests;
 mod text_update;
+mod web_selection;
 
 pub use crate::action_state::ActionState;
 pub use crate::composer_action::ComposerAction;
@@ -59,3 +60,4 @@ pub use crate::suggestion_pattern::SuggestionPattern;
 pub use crate::text_update::ReplaceAll;
 pub use crate::text_update::Selection;
 pub use crate::text_update::TextUpdate;
+pub use crate::web_selection::WebSelection;

--- a/crates/wysiwyg/src/web_selection.rs
+++ b/crates/wysiwyg/src/web_selection.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::DomHandle;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebSelection {
+    pub anchor_node: DomHandle,
+    pub anchor_offset: usize,
+    pub focus_node: DomHandle,
+    pub focus_offset: usize,
+    pub is_collapsed: bool,
+}


### PR DESCRIPTION
Opening as an idea for giving us a way to decouple selection logic from Rust and client.

Adds a `WebSelection` type that simulates what you'd get back from doing `window.getSelection()` in web.