### PR TITLE
Amend mention message html output

### DIFF
--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -77,7 +77,13 @@ where
         let (start, end) = self.safe_selection();
         let range = self.state.dom.find_range(start, end);
 
-        let new_node = DomNode::new_mention(url, text, attributes);
+        // use the display text to determine if it's an at-room or regular mention
+        let new_node = if text == "@room".into() {
+            DomNode::new_at_room_mention(attributes)
+        } else {
+            DomNode::new_mention(url, text, attributes)
+        };
+
         let new_cursor_index = start + new_node.text_len();
 
         let handle = self.state.dom.insert_node_at_cursor(&range, new_node);

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -129,12 +129,16 @@ impl<S: UnicodeString> MentionNode<S> {
         let cur_pos = formatter.len();
         match self.kind() {
             MentionNodeKind::MatrixUrl { display_text, url } => {
-                let mut attributes = self.attributes.clone();
+                let mut attributes = if as_message {
+                    vec![]
+                } else {
+                    self.attributes.clone()
+                };
+
                 attributes.push(("href".into(), url.clone()));
 
                 if !as_message {
                     attributes.push(("contenteditable".into(), "false".into()))
-                    // TODO: data-mention-type = "user" | "room"
                 }
 
                 self.fmt_tag_open(tag, formatter, &Some(attributes));
@@ -144,7 +148,18 @@ impl<S: UnicodeString> MentionNode<S> {
                 self.fmt_tag_close(tag, formatter);
             }
             MentionNodeKind::AtRoom => {
-                formatter.push(self.display_text());
+                if as_message {
+                    formatter.push(self.display_text())
+                } else {
+                    let mut attributes = self.attributes.clone();
+                    attributes.push(("href".into(), "#".into()));
+                    attributes.push(("contenteditable".into(), "false".into()));
+                    self.fmt_tag_open(tag, formatter, &Some(attributes));
+
+                    formatter.push("@room");
+
+                    self.fmt_tag_close(tag, formatter);
+                };
             }
         }
 

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -129,35 +129,32 @@ impl<S: UnicodeString> MentionNode<S> {
         let cur_pos = formatter.len();
         match self.kind() {
             MentionNodeKind::MatrixUrl { display_text, url } => {
-                let mut attributes = if as_message {
-                    vec![]
+                // if formatting as a message, only include the href attribute
+                let attributes = if as_message {
+                    vec![("href".into(), url.clone())]
                 } else {
-                    self.attributes.clone()
+                    let mut attributes_for_composer = self.attributes.clone();
+                    attributes_for_composer.push(("href".into(), url.clone()));
+                    attributes_for_composer
+                        .push(("contenteditable".into(), "false".into()));
+                    attributes_for_composer
                 };
 
-                attributes.push(("href".into(), url.clone()));
-
-                if !as_message {
-                    attributes.push(("contenteditable".into(), "false".into()))
-                }
-
                 self.fmt_tag_open(tag, formatter, &Some(attributes));
-
                 formatter.push(display_text.clone());
-
                 self.fmt_tag_close(tag, formatter);
             }
             MentionNodeKind::AtRoom => {
+                // if formatting as a message, simply use the display text (@room)
                 if as_message {
                     formatter.push(self.display_text())
                 } else {
                     let mut attributes = self.attributes.clone();
                     attributes.push(("href".into(), "#".into()));
                     attributes.push(("contenteditable".into(), "false".into()));
+
                     self.fmt_tag_open(tag, formatter, &Some(attributes));
-
-                    formatter.push("@room");
-
+                    formatter.push(self.display_text());
                     self.fmt_tag_close(tag, formatter);
                 };
             }

--- a/crates/wysiwyg/src/tests.rs
+++ b/crates/wysiwyg/src/tests.rs
@@ -30,6 +30,7 @@ pub mod test_selection;
 pub mod test_set_content;
 pub mod test_suggestions;
 pub mod test_to_markdown;
+pub mod test_to_message_html;
 pub mod test_to_plain_text;
 pub mod test_to_raw_text;
 pub mod test_to_tree;

--- a/crates/wysiwyg/src/tests/test_to_message_html.rs
+++ b/crates/wysiwyg/src/tests/test_to_message_html.rs
@@ -58,7 +58,7 @@ fn only_outputs_href_attribute_on_room_mention() {
 fn only_outputs_href_inner_text_for_at_room_mention() {
     let mut model = cm("|");
     model.insert_mention(
-        "anything".into(),
+        "anything".into(), // this should be ignored in favour of a # placeholder
         "@room".into(),
         vec![
             ("data-mention-type".into(), "at-room".into()),

--- a/crates/wysiwyg/src/tests/test_to_message_html.rs
+++ b/crates/wysiwyg/src/tests/test_to_message_html.rs
@@ -1,0 +1,72 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tests::testutils_composer_model::{cm, tx};
+
+#[test]
+fn only_outputs_href_attribute_on_user_mention() {
+    let mut model = cm("|");
+    model.insert_mention(
+        "www.url.com".into(),
+        "inner text".into(),
+        vec![
+            ("data-mention-type".into(), "user".into()),
+            ("style".into(), "some css".into()),
+        ],
+    );
+    assert_eq!(tx(&model), "<a data-mention-type=\"user\" style=\"some css\" href=\"www.url.com\" contenteditable=\"false\">inner text</a>&nbsp;|");
+
+    let message_output = model.get_content_as_message_html();
+    assert_eq!(
+        message_output,
+        "<a href=\"www.url.com\">inner text</a>\u{a0}"
+    );
+}
+
+#[test]
+fn only_outputs_href_attribute_on_room_mention() {
+    let mut model = cm("|");
+    model.insert_mention(
+        "www.url.com".into(),
+        "inner text".into(),
+        vec![
+            ("data-mention-type".into(), "room".into()),
+            ("style".into(), "some css".into()),
+        ],
+    );
+    assert_eq!(tx(&model), "<a data-mention-type=\"room\" style=\"some css\" href=\"www.url.com\" contenteditable=\"false\">inner text</a>&nbsp;|");
+
+    let message_output = model.get_content_as_message_html();
+    assert_eq!(
+        message_output,
+        "<a href=\"www.url.com\">inner text</a>\u{a0}"
+    );
+}
+
+#[test]
+fn only_outputs_href_inner_text_for_at_room_mention() {
+    let mut model = cm("|");
+    model.insert_mention(
+        "anything".into(),
+        "@room".into(),
+        vec![
+            ("data-mention-type".into(), "at-room".into()),
+            ("style".into(), "some css".into()),
+        ],
+    );
+    assert_eq!(tx(&model), "<a data-mention-type=\"at-room\" style=\"some css\" href=\"#\" contenteditable=\"false\">@room</a>&nbsp;|");
+
+    let message_output = model.get_content_as_message_html();
+    assert_eq!(message_output, "@room\u{a0}");
+}

--- a/crates/wysiwyg/src/tests/test_to_message_html.rs
+++ b/crates/wysiwyg/src/tests/test_to_message_html.rs
@@ -15,6 +15,23 @@
 use crate::tests::testutils_composer_model::{cm, tx};
 
 #[test]
+fn replaces_empty_paragraphs_with_newline_characters() {
+    let mut model = cm("|");
+    model.replace_text("hello".into());
+    model.enter();
+    model.enter();
+    model.enter();
+    model.enter();
+    model.replace_text("Alice".into());
+
+    assert_eq!(
+        tx(&model),
+        "<p>hello</p><p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p><p>Alice|</p>"
+    );
+    let message_output = model.get_content_as_message_html();
+    assert_eq!(message_output, "<p>hello</p>\n\n\n<p>Alice</p>");
+}
+#[test]
 fn only_outputs_href_attribute_on_user_mention() {
     let mut model = cm("|");
     model.insert_mention(

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -56,6 +56,7 @@ export function processInput(
         {
             actions: formattingFunctions,
             content: () => composerModel.get_content_as_html(),
+            messageContent: () => composerModel.get_content_as_message_html(),
         },
         editor,
         inputEventProcessor,

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -50,6 +50,7 @@ export type FormattingFunctions = Record<
 export type Wysiwyg = {
     actions: FormattingFunctions;
     content: () => string;
+    messageContent: () => string;
 };
 
 export type InputEventProcessor = (

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -106,6 +106,7 @@ function getInputFromKeyDown(
         {
             actions: formattingFunctions,
             content: () => composerModel.get_content_as_html(),
+            messageContent: () => composerModel.get_content_as_message_html(),
         },
         editor,
         inputEventProcessor,

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -108,5 +108,7 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
             traceAction: testUtilities.traceAction,
         },
         suggestion: memoisedMappedSuggestion,
+        getMessageContent: () =>
+            composerModel?.get_content_as_message_html() ?? null,
     };
 }

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -216,12 +216,12 @@ function App() {
                                 <button
                                     type="button"
                                     onClick={(_e) =>
-                                        wysiwyg.mention('#', 'Alice', {
+                                        wysiwyg.mention('#', '@room', {
                                             'data-mention-type': 'at-room',
                                         })
                                     }
                                 >
-                                    Add {suggestion.keyChar}mention
+                                    Add at-room mention
                                 </button>
                             )}
                         {suggestion && suggestion.type === 'command' && (

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -75,7 +75,7 @@ function App() {
             if (debug.testRef.current) {
                 debug.traceAction(null, 'send', `${wysiwyg.content()}`);
             }
-            console.log(`SENDING: ${wysiwyg.content()}`);
+            console.log(`SENDING: ${wysiwyg.messageContent()}`);
             wysiwyg.actions.clear();
             return null;
         }
@@ -203,9 +203,27 @@ function App() {
                                     )
                                 }
                             >
-                                Add {suggestion.keyChar}mention
+                                Add
+                                {suggestion.keyChar === '@'
+                                    ? ' user '
+                                    : ' room '}
+                                mention
                             </button>
                         )}
+                        {suggestion &&
+                            suggestion.type === 'mention' &&
+                            suggestion.keyChar === '@' && (
+                                <button
+                                    type="button"
+                                    onClick={(_e) =>
+                                        wysiwyg.mention('#', 'Alice', {
+                                            'data-mention-type': 'at-room',
+                                        })
+                                    }
+                                >
+                                    Add {suggestion.keyChar}mention
+                                </button>
+                            )}
                         {suggestion && suggestion.type === 'command' && (
                             <button
                                 type="button"


### PR DESCRIPTION
This PR:

- makes it so that when you translate a mention to "message format" html then the following rules are applied:
    - if it's an at-room mention, only output the raw text `@room`
    - if it's a room or user mention, output the mention as `<a href="...">display_text</a>`
