### PR TITLE
Integrate mention parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
 name = "matrix_mentions"
 version = "0.1.0"
 dependencies = [
+ "cfg-if",
  "ruma-common",
 ]
 

--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -260,7 +260,7 @@ impl ComposerModel {
 
     /// Creates an at-room mention node and inserts it into the composer at the current selection
     pub fn insert_at_room_mention(
-        &mut self,
+        self: &Arc<Self>,
         attributes: Vec<Attribute>,
     ) -> Arc<ComposerUpdate> {
         let attrs = attributes
@@ -303,7 +303,7 @@ impl ComposerModel {
     /// Creates an at-room mention node and inserts it into the composer, replacing the
     /// text content defined by the suggestion
     pub fn insert_at_room_mention_at_suggestion(
-        &mut self,
+        self: &Arc<Self>,
         suggestion: SuggestionPattern,
         attributes: Vec<Attribute>,
     ) -> Arc<ComposerUpdate> {

--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -258,6 +258,25 @@ impl ComposerModel {
         ))
     }
 
+    /// Creates an at-room mention node and inserts it into the composer at the current selection
+    pub fn insert_at_room_mention(
+        &mut self,
+        attributes: Vec<Attribute>,
+    ) -> Arc<ComposerUpdate> {
+        let attrs = attributes
+            .iter()
+            .map(|attr| {
+                (
+                    Utf16String::from_str(&attr.key),
+                    Utf16String::from_str(&attr.value),
+                )
+            })
+            .collect();
+        Arc::new(ComposerUpdate::from(
+            self.inner.lock().unwrap().insert_at_room_mention(attrs),
+        ))
+    }
+
     /// Creates a mention node and inserts it into the composer at the current selection
     pub fn insert_mention(
         self: &Arc<Self>,
@@ -278,6 +297,31 @@ impl ComposerModel {
             .collect();
         Arc::new(ComposerUpdate::from(
             self.inner.lock().unwrap().insert_mention(url, text, attrs),
+        ))
+    }
+
+    /// Creates an at-room mention node and inserts it into the composer, replacing the
+    /// text content defined by the suggestion
+    pub fn insert_at_room_mention_at_suggestion(
+        &mut self,
+        suggestion: SuggestionPattern,
+        attributes: Vec<Attribute>,
+    ) -> Arc<ComposerUpdate> {
+        let suggestion = wysiwyg::SuggestionPattern::from(suggestion);
+        let attrs = attributes
+            .iter()
+            .map(|attr| {
+                (
+                    Utf16String::from_str(&attr.key),
+                    Utf16String::from_str(&attr.value),
+                )
+            })
+            .collect();
+        Arc::new(ComposerUpdate::from(
+            self.inner
+                .lock()
+                .unwrap()
+                .insert_at_room_mention_at_suggestion(suggestion, attrs),
         ))
     }
 

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -48,7 +48,9 @@ interface ComposerModel {
     ComposerUpdate set_link(string url, sequence<Attribute> attributes);
     ComposerUpdate set_link_with_text(string url, string text, sequence<Attribute> attributes);
     ComposerUpdate remove_links();
+    ComposerUpdate insert_at_room_mention(sequence<Attribute> attributes);
     ComposerUpdate insert_mention(string url, string text, sequence<Attribute> attributes);
+    ComposerUpdate insert_at_room_mention_at_suggestion(SuggestionPattern suggestion, sequence<Attribute> attributes);
     ComposerUpdate insert_mention_at_suggestion(string url, string text, SuggestionPattern suggestion, sequence<Attribute> attributes);
     ComposerUpdate code_block();
     ComposerUpdate quote();

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -312,6 +312,16 @@ impl ComposerModel {
         ))
     }
 
+    /// Creates an at-room mention node and inserts it into the composer at the current selection
+    pub fn insert_at_room(
+        &mut self,
+        attributes: js_sys::Map,
+    ) -> ComposerUpdate {
+        ComposerUpdate::from(
+            self.inner.insert_at_room_mention(attributes.into_vec()),
+        )
+    }
+
     /// Creates a mention node and inserts it into the composer at the current selection
     pub fn insert_mention(
         &mut self,
@@ -322,6 +332,19 @@ impl ComposerModel {
         ComposerUpdate::from(self.inner.insert_mention(
             Utf16String::from_str(url),
             Utf16String::from_str(text),
+            attributes.into_vec(),
+        ))
+    }
+
+    /// Creates an at-room mention node and inserts it into the composer, replacing the
+    /// text content defined by the suggestion
+    pub fn insert_at_room_at_suggestion(
+        &mut self,
+        suggestion: &SuggestionPattern,
+        attributes: js_sys::Map,
+    ) -> ComposerUpdate {
+        ComposerUpdate::from(self.inner.insert_at_room_mention_at_suggestion(
+            wysiwyg::SuggestionPattern::from(suggestion.clone()),
             attributes.into_vec(),
         ))
     }

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -313,7 +313,7 @@ impl ComposerModel {
     }
 
     /// Creates an at-room mention node and inserts it into the composer at the current selection
-    pub fn insert_at_room(
+    pub fn insert_at_room_mention(
         &mut self,
         attributes: js_sys::Map,
     ) -> ComposerUpdate {
@@ -338,7 +338,7 @@ impl ComposerModel {
 
     /// Creates an at-room mention node and inserts it into the composer, replacing the
     /// text content defined by the suggestion
-    pub fn insert_at_room_at_suggestion(
+    pub fn insert_at_room_mention_at_suggestion(
         &mut self,
         suggestion: &SuggestionPattern,
         attributes: js_sys::Map,

--- a/crates/matrix_mentions/Cargo.toml
+++ b/crates/matrix_mentions/Cargo.toml
@@ -9,6 +9,8 @@ name = "matrix_mentions"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
+[features]
+custom_matrix_urls = []
 
+[dependencies]
 ruma-common = "0.11.3"

--- a/crates/matrix_mentions/Cargo.toml
+++ b/crates/matrix_mentions/Cargo.toml
@@ -10,7 +10,9 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-custom_matrix_urls = []
+default = ["custom-matrix-urls"]
+custom-matrix-urls = []
 
 [dependencies]
+cfg-if = "1.0.0"
 ruma-common = "0.11.3"

--- a/crates/matrix_mentions/src/lib.rs
+++ b/crates/matrix_mentions/src/lib.rs
@@ -14,4 +14,4 @@
 
 mod mention;
 
-pub use crate::mention::{Mention, MentionKind};
+pub use crate::mention::{Mention, MentionKind, AT_ROOM};

--- a/crates/matrix_mentions/src/lib.rs
+++ b/crates/matrix_mentions/src/lib.rs
@@ -14,6 +14,4 @@
 
 mod mention;
 
-pub use crate::mention::{
-    get_at_room_display_text, Mention, MentionKind, AT_ROOM,
-};
+pub use crate::mention::{Mention, MentionKind};

--- a/crates/matrix_mentions/src/lib.rs
+++ b/crates/matrix_mentions/src/lib.rs
@@ -14,4 +14,7 @@
 
 mod mention;
 
-pub use crate::mention::{Mention, MentionKind, AT_ROOM};
+pub use crate::mention::{
+    get_at_room_display_text, is_at_room_display_text, Mention, MentionKind,
+    AT_ROOM,
+};

--- a/crates/matrix_mentions/src/lib.rs
+++ b/crates/matrix_mentions/src/lib.rs
@@ -14,4 +14,4 @@
 
 mod mention;
 
-pub use crate::mention::Mention;
+pub use crate::mention::{Mention, MentionKind};

--- a/crates/matrix_mentions/src/lib.rs
+++ b/crates/matrix_mentions/src/lib.rs
@@ -15,6 +15,5 @@
 mod mention;
 
 pub use crate::mention::{
-    get_at_room_display_text, is_at_room_display_text, Mention, MentionKind,
-    AT_ROOM,
+    get_at_room_display_text, Mention, MentionKind, AT_ROOM,
 };

--- a/crates/matrix_mentions/src/mention.rs
+++ b/crates/matrix_mentions/src/mention.rs
@@ -338,7 +338,7 @@ mod test {
 
         assert_eq!(parsed.uri(), uri);
         assert_eq!(parsed.mx_id(), "!room:example.org");
-        assert_eq!(parsed.display_text(), "!room:example.org");
+        assert_eq!(parsed.display_text(), "!room:example.org"); // note the display_text is overridden
         assert_eq!(parsed.kind(), &MentionKind::Room);
     }
 

--- a/crates/matrix_mentions/src/mention.rs
+++ b/crates/matrix_mentions/src/mention.rs
@@ -15,12 +15,6 @@
 use ruma_common::{matrix_uri::MatrixId, IdParseError, MatrixToUri, MatrixUri};
 
 const MATRIX_TO_BASE_URL: &str = "https://matrix.to/#/";
-pub const AT_ROOM: &str = "@room";
-
-/// Util function to get the display text for an at-room mention
-pub fn get_at_room_display_text() -> &'static str {
-    AT_ROOM
-}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Mention {

--- a/crates/matrix_mentions/src/mention.rs
+++ b/crates/matrix_mentions/src/mention.rs
@@ -17,6 +17,16 @@ use ruma_common::{matrix_uri::MatrixId, IdParseError, MatrixToUri, MatrixUri};
 const MATRIX_TO_BASE_URL: &str = "https://matrix.to/#/";
 pub const AT_ROOM: &str = "@room";
 
+/// Util function to check if the display text is that of an at-room mention
+pub fn is_at_room_display_text(text: &str) -> bool {
+    text == AT_ROOM
+}
+
+/// Util function to get the display text for an at-room mention
+pub fn get_at_room_display_text() -> &'static str {
+    AT_ROOM
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Mention {
     uri: String,

--- a/crates/matrix_mentions/src/mention.rs
+++ b/crates/matrix_mentions/src/mention.rs
@@ -59,6 +59,11 @@ impl Mention {
         &self.kind
     }
 
+    /// Determine if a uri is a valid matrix uri
+    pub fn is_matrix_uri(uri: &str) -> bool {
+        parse_matrix_id(uri).is_some()
+    }
+
     /// Create a mention from a URI
     ///
     /// If the URI is a valid room or user, it creates a mention using the

--- a/crates/matrix_mentions/src/mention.rs
+++ b/crates/matrix_mentions/src/mention.rs
@@ -60,7 +60,7 @@ impl Mention {
     }
 
     /// Determine if a uri is a valid matrix uri
-    pub fn is_matrix_uri(uri: &str) -> bool {
+    pub fn is_valid_uri(uri: &str) -> bool {
         parse_matrix_id(uri).is_some()
     }
 

--- a/crates/matrix_mentions/src/mention.rs
+++ b/crates/matrix_mentions/src/mention.rs
@@ -17,11 +17,6 @@ use ruma_common::{matrix_uri::MatrixId, IdParseError, MatrixToUri, MatrixUri};
 const MATRIX_TO_BASE_URL: &str = "https://matrix.to/#/";
 pub const AT_ROOM: &str = "@room";
 
-/// Util function to check if the display text is that of an at-room mention
-pub fn is_at_room_display_text(text: &str) -> bool {
-    text == AT_ROOM
-}
-
 /// Util function to get the display text for an at-room mention
 pub fn get_at_room_display_text() -> &'static str {
     AT_ROOM

--- a/crates/matrix_mentions/src/mention.rs
+++ b/crates/matrix_mentions/src/mention.rs
@@ -15,6 +15,7 @@
 use ruma_common::{matrix_uri::MatrixId, IdParseError, MatrixToUri, MatrixUri};
 
 const MATRIX_TO_BASE_URL: &str = "https://matrix.to/#/";
+pub const AT_ROOM: &str = "@room";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Mention {

--- a/crates/matrix_mentions/src/mention.rs
+++ b/crates/matrix_mentions/src/mention.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma_common::{
-    matrix_uri::MatrixId, IdParseError, MatrixToUri, MatrixUri, UserId,
-};
+use ruma_common::{matrix_uri::MatrixId, IdParseError, MatrixToUri, MatrixUri};
 
 const MATRIX_TO_BASE_URL: &str = "https://matrix.to/#/";
 

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -23,8 +23,8 @@ where
     S: UnicodeString,
 {
     /// Remove the suggestion text and then insert a mention into the composer, using the following rules
-    /// - Do not insert a mention if the uri is invalid
-    /// - Do not insert a mention if the range includes link or code leaves
+    /// - Do not do anthing if the uri is invalid
+    /// - Do not do anthing if the range includes link or code leaves
     /// - If the composer contains a selection, remove the contents of the selection
     /// prior to inserting a mention at the cursor.
     /// - If the composer contains a cursor, insert a mention at the cursor
@@ -35,7 +35,7 @@ where
         suggestion: SuggestionPattern,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
-        if self.should_not_insert_mention(&url, &text) {
+        if self.should_not_insert_mention(&url) {
             return ComposerUpdate::keep();
         }
 
@@ -46,6 +46,11 @@ where
         self.do_insert_mention(url, text, attributes)
     }
 
+    /// Remove the suggestion text and then insert an at-room mention into the composer, using the following rules
+    /// - Do not do anthing if the range includes link or code leaves
+    /// - If the composer contains a selection, remove the contents of the selection
+    /// prior to inserting a mention at the cursor.
+    /// - If the composer contains a cursor, insert a mention at the cursor
     pub fn insert_at_room_mention_at_suggestion(
         &mut self,
         suggestion: SuggestionPattern,
@@ -74,7 +79,7 @@ where
         text: S,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
-        if self.should_not_insert_mention(&url, &text) {
+        if self.should_not_insert_mention(&url) {
             return ComposerUpdate::keep();
         }
 
@@ -161,41 +166,29 @@ where
         }
     }
 
-    /// Utility function for the insert_mention* methods. It returns false if:
+    /// Utility functions for the insert_mention* methods. It returns false if:
     /// - the range includes any link or code type leaves
-    /// - the url is not a valid matrix uri (with special case for at-room)
+    /// - the url is not a valid matrix uri
     ///
     /// Related issue is here:
     /// https://github.com/matrix-org/matrix-rich-text-editor/issues/702
     /// We do not allow mentions to be inserted into links, the planned behaviour is
     /// detailed in the above issue.
-    fn should_not_insert_mention(&self, url: &S, text: &S) -> bool {
-        let (start, end) = self.safe_selection();
-        let range = self.state.dom.find_range(start, end);
-
-        let invalid_uri = !Mention::is_valid_uri(url.to_string().as_str());
-
-        let range_contains_link_or_code_leaves =
-            range.locations.iter().any(|l: &DomLocation| {
-                l.kind.is_link_kind() || l.kind.is_code_kind()
-            });
-
-        // when we have an at-room mention, it doesn't matter about the url as we do not use
-        // it, rendering the mention as raw text in the html output
-        invalid_uri || range_contains_link_or_code_leaves
+    fn should_not_insert_mention(&self, url: &S) -> bool {
+        !Mention::is_valid_uri(url.to_string().as_str())
+            || self.range_contains_link_or_code_leaves()
     }
 
     fn should_not_insert_at_room_mention(&self) -> bool {
+        self.range_contains_link_or_code_leaves()
+    }
+
+    fn range_contains_link_or_code_leaves(&self) -> bool {
         let (start, end) = self.safe_selection();
         let range = self.state.dom.find_range(start, end);
 
-        let range_contains_link_or_code_leaves =
-            range.locations.iter().any(|l: &DomLocation| {
-                l.kind.is_link_kind() || l.kind.is_code_kind()
-            });
-
-        // when we have an at-room mention, it doesn't matter about the url as we do not use
-        // it, rendering the mention as raw text in the html output
-        range_contains_link_or_code_leaves
+        range.locations.iter().any(|l: &DomLocation| {
+            l.kind.is_link_kind() || l.kind.is_code_kind()
+        })
     }
 }

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -43,7 +43,12 @@ where
         self.do_replace_text_in(S::default(), suggestion.start, suggestion.end);
         self.state.start = Location::from(suggestion.start);
         self.state.end = self.state.start;
-        self.do_insert_mention(url, text, attributes)
+
+        if let Ok(mention_node) = DomNode::new_mention(url, text, attributes) {
+            self.do_insert_mention(mention_node)
+        } else {
+            ComposerUpdate::keep()
+        }
     }
 
     /// Remove the suggestion text and then insert an at-room mention into the composer, using the following rules
@@ -64,7 +69,9 @@ where
         self.do_replace_text_in(S::default(), suggestion.start, suggestion.end);
         self.state.start = Location::from(suggestion.start);
         self.state.end = self.state.start;
-        self.do_insert_at_room_mention(attributes)
+
+        let mention_node = DomNode::new_at_room_mention(attributes);
+        self.do_insert_mention(mention_node)
     }
 
     /// Inserts a mention into the composer. It uses the following rules:
@@ -87,7 +94,12 @@ where
         if self.has_selection() {
             self.do_replace_text(S::default());
         }
-        self.do_insert_mention(url, text, attributes)
+
+        if let Ok(mention_node) = DomNode::new_mention(url, text, attributes) {
+            self.do_insert_mention(mention_node)
+        } else {
+            ComposerUpdate::keep()
+        }
     }
 
     pub fn insert_at_room_mention(
@@ -103,7 +115,8 @@ where
             self.do_replace_text(S::default());
         }
 
-        self.do_insert_at_room_mention(attributes)
+        let mention_node = DomNode::new_at_room_mention(attributes);
+        self.do_insert_mention(mention_node)
     }
 
     /// Creates a new mention node then inserts the node at the cursor position. If creation fails due to
@@ -111,48 +124,18 @@ where
     /// It adds a trailing space when the inserted mention is the last node in it's parent.
     fn do_insert_mention(
         &mut self,
-        url: S,
-        text: S,
-        attributes: Vec<(S, S)>,
+        mention_node: DomNode<S>,
     ) -> ComposerUpdate<S> {
-        let (start, end) = self.safe_selection();
-        let range = self.state.dom.find_range(start, end);
-
-        if let Ok(new_node) = DomNode::new_mention(url, text, attributes) {
-            let new_cursor_index = start + new_node.text_len();
-
-            let handle = self.state.dom.insert_node_at_cursor(&range, new_node);
-
-            // manually move the cursor to the end of the mention
-            self.state.start = Location::from(new_cursor_index);
-            self.state.end = self.state.start;
-
-            // add a trailing space in cases when we do not have a next sibling
-            if self.state.dom.is_last_in_parent(&handle) {
-                self.do_replace_text(" ".into())
-            } else {
-                self.create_update_replace_all()
-            }
-        } else {
-            ComposerUpdate::keep()
+        if !mention_node.is_mention_node() {
+            return ComposerUpdate::keep();
         }
-    }
 
-    /// Creates a new mention node then inserts the node at the cursor position. If creation fails due to
-    /// an invalid uri, it will return `ComposerUpdate::keep()`.
-    /// It adds a trailing space when the inserted mention is the last node in it's parent.
-    fn do_insert_at_room_mention(
-        &mut self,
-        attributes: Vec<(S, S)>,
-    ) -> ComposerUpdate<S> {
         let (start, end) = self.safe_selection();
         let range = self.state.dom.find_range(start, end);
 
-        let new_node = DomNode::new_at_room_mention(attributes);
+        let new_cursor_index = start + mention_node.text_len();
 
-        let new_cursor_index = start + new_node.text_len();
-
-        let handle = self.state.dom.insert_node_at_cursor(&range, new_node);
+        let handle = self.state.dom.insert_node_at_cursor(&range, mention_node);
 
         // manually move the cursor to the end of the mention
         self.state.start = Location::from(new_cursor_index);

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -122,10 +122,20 @@ where
 
         // when we have an at-room mention, it doesn't matter about the url as we do not use
         // it, rendering the mention as raw text in the html output
-        if text == &S::from("@room") {
+        if Self::is_at_room_display_text(text) {
             range_contains_link_or_code_leaves
         } else {
             invalid_uri || range_contains_link_or_code_leaves
         }
+    }
+
+    /// Util function to check if the display text is that of an at-room mention
+    pub fn is_at_room_display_text(text: &S) -> bool {
+        text == &S::from("@room")
+    }
+
+    /// Util function to get the display text for an at-room mention
+    pub fn get_at_room_display_text() -> S {
+        S::from("@room")
     }
 }

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -116,7 +116,7 @@ where
     /// mention is the last node in it's parent.
     fn do_insert_mention(
         &mut self,
-        mention_node: MentionNode<S>, // TODO can we type this as a mention node somehow
+        mention_node: MentionNode<S>,
     ) -> ComposerUpdate<S> {
         let (start, end) = self.safe_selection();
         let range = self.state.dom.find_range(start, end);

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -72,6 +72,7 @@ where
             ComposerUpdate::keep()
         }
     }
+
     /// Checks to see if the at-room mention should be inserted.
     /// If so it will remove the suggestion and then insert an at-room mention.
     pub fn insert_at_room_mention_at_suggestion(

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -14,8 +14,9 @@
 use matrix_mentions::Mention;
 
 use crate::{
-    dom::DomLocation, ComposerModel, ComposerUpdate, DomNode, Location,
-    SuggestionPattern, UnicodeString,
+    dom::{nodes::MentionNode, DomLocation},
+    ComposerModel, ComposerUpdate, DomNode, Location, SuggestionPattern,
+    UnicodeString,
 };
 
 impl<S> ComposerModel<S>
@@ -122,20 +123,10 @@ where
 
         // when we have an at-room mention, it doesn't matter about the url as we do not use
         // it, rendering the mention as raw text in the html output
-        if Self::is_at_room_display_text(text) {
+        if MentionNode::is_at_room_display_text(text) {
             range_contains_link_or_code_leaves
         } else {
             invalid_uri || range_contains_link_or_code_leaves
         }
-    }
-
-    /// Util function to check if the display text is that of an at-room mention
-    pub fn is_at_room_display_text(text: &S) -> bool {
-        text == &S::from("@room")
-    }
-
-    /// Util function to get the display text for an at-room mention
-    pub fn get_at_room_display_text() -> S {
-        S::from("@room")
     }
 }

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -100,7 +100,7 @@ where
 
     /// Utility function for the insert_mention* methods. It returns false if:
     /// - the range includes any link or code type leaves
-    /// - the url is not a valid matrix uri
+    /// - the url is not a valid matrix uri OR the `@room` special case
     ///
     /// Related issue is here:
     /// https://github.com/matrix-org/matrix-rich-text-editor/issues/702

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -103,7 +103,7 @@ where
 
     /// Utility function for the insert_mention* methods. It returns false if:
     /// - the range includes any link or code type leaves
-    /// - the url is not a valid matrix uri OR the `@room` special case
+    /// - the url is not a valid matrix uri (with special case for at-room)
     ///
     /// Related issue is here:
     /// https://github.com/matrix-org/matrix-rich-text-editor/issues/702

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -35,7 +35,8 @@ where
         suggestion: SuggestionPattern,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
-        if self.should_not_insert_mention(&url) {
+        // we _do_ want to insert a room mention, regardss or url
+        if text != "@room".into() && self.should_not_insert_mention(&url) {
             return ComposerUpdate::keep();
         }
 
@@ -58,7 +59,8 @@ where
         text: S,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
-        if self.should_not_insert_mention(&url) {
+        // we _do_ want to insert a room mention, regardss or url
+        if text != "@room".into() && self.should_not_insert_mention(&url) {
             return ComposerUpdate::keep();
         }
 

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use matrix_mentions::Mention;
+use matrix_mentions::{is_at_room_display_text, Mention};
 
 use crate::{
     dom::{nodes::MentionNode, DomLocation},
@@ -123,7 +123,7 @@ where
 
         // when we have an at-room mention, it doesn't matter about the url as we do not use
         // it, rendering the mention as raw text in the html output
-        if MentionNode::is_at_room_display_text(text) {
+        if is_at_room_display_text(text.to_string().as_str()) {
             range_contains_link_or_code_leaves
         } else {
             invalid_uri || range_contains_link_or_code_leaves

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -14,8 +14,9 @@
 use matrix_mentions::Mention;
 
 use crate::{
-    dom::DomLocation, ComposerModel, ComposerUpdate, DomNode, Location,
-    SuggestionPattern, UnicodeString,
+    dom::{nodes::MentionNode, DomLocation},
+    ComposerModel, ComposerUpdate, DomNode, Location, SuggestionPattern,
+    UnicodeString,
 };
 
 impl<S> ComposerModel<S>
@@ -58,6 +59,7 @@ where
         text: S,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
+        // TODO change this as this will now be handled by the if let below
         if self.should_not_insert_mention(&url) {
             return ComposerUpdate::keep();
         }
@@ -116,18 +118,17 @@ where
     /// mention is the last node in it's parent.
     fn do_insert_mention(
         &mut self,
-        mention_node: DomNode<S>,
+        mention_node: MentionNode<S>, // TODO can we type this as a mention node somehow
     ) -> ComposerUpdate<S> {
-        if !mention_node.is_mention_node() {
-            return ComposerUpdate::keep();
-        }
-
         let (start, end) = self.safe_selection();
         let range = self.state.dom.find_range(start, end);
 
         let new_cursor_index = start + mention_node.text_len();
 
-        let handle = self.state.dom.insert_node_at_cursor(&range, mention_node);
+        let handle = self
+            .state
+            .dom
+            .insert_node_at_cursor(&range, DomNode::Mention(mention_node));
 
         // manually move the cursor to the end of the mention
         self.state.start = Location::from(new_cursor_index);

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -80,15 +80,7 @@ where
         let (start, end) = self.safe_selection();
         let range = self.state.dom.find_range(start, end);
 
-        // use the display text decide the mention type
-        // TODO extract this into a util function if it is reused when parsing the html prior to editing a message
-        // TODO decide if this do* function should be separated to handle mention vs at-room mention
-        // TODO handle invalid mention urls after permalink parsing methods have been created
-        let new_node = if text == "@room".into() {
-            DomNode::new_at_room_mention(attributes)
-        } else {
-            DomNode::new_mention(url, text, attributes)
-        };
+        let new_node = DomNode::new_mention(url, text, attributes);
 
         let new_cursor_index = start + new_node.text_len();
 

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use matrix_mentions::Mention;
 
 use crate::{
     dom::{nodes::MentionNode, DomLocation},
@@ -32,7 +31,7 @@ where
         suggestion: SuggestionPattern,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
-        if self.should_not_insert_mention(&url) {
+        if self.range_contains_link_or_code_leaves() {
             return ComposerUpdate::keep();
         }
 
@@ -59,8 +58,7 @@ where
         text: S,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
-        // TODO change this as this will now be handled by the if let below
-        if self.should_not_insert_mention(&url) {
+        if self.range_contains_link_or_code_leaves() {
             return ComposerUpdate::keep();
         }
 
@@ -82,7 +80,7 @@ where
         suggestion: SuggestionPattern,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
-        if self.should_not_insert_at_room_mention() {
+        if self.range_contains_link_or_code_leaves() {
             return ComposerUpdate::keep();
         }
 
@@ -101,7 +99,7 @@ where
         &mut self,
         attributes: Vec<(S, S)>,
     ) -> ComposerUpdate<S> {
-        if self.should_not_insert_at_room_mention() {
+        if self.range_contains_link_or_code_leaves() {
             return ComposerUpdate::keep();
         }
 
@@ -144,17 +142,6 @@ where
 
     /// We should not insert a mention if the uri is invalid or the range contains link
     /// or code leaves. See issue https://github.com/matrix-org/matrix-rich-text-editor/issues/702.
-    fn should_not_insert_mention(&self, url: &S) -> bool {
-        !Mention::is_valid_uri(url.to_string().as_str())
-            || self.range_contains_link_or_code_leaves()
-    }
-
-    /// We should not insert an at-room mention if the range contains link or code leaves.
-    /// See issue https://github.com/matrix-org/matrix-rich-text-editor/issues/702.
-    fn should_not_insert_at_room_mention(&self) -> bool {
-        self.range_contains_link_or_code_leaves()
-    }
-
     fn range_contains_link_or_code_leaves(&self) -> bool {
         let (start, end) = self.safe_selection();
         let range = self.state.dom.find_range(start, end);

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use matrix_mentions::{is_at_room_display_text, Mention};
+use matrix_mentions::Mention;
 
 use crate::{
     dom::DomLocation, ComposerModel, ComposerUpdate, DomNode, Location,
@@ -182,11 +182,7 @@ where
 
         // when we have an at-room mention, it doesn't matter about the url as we do not use
         // it, rendering the mention as raw text in the html output
-        if is_at_room_display_text(text.to_string().as_str()) {
-            range_contains_link_or_code_leaves
-        } else {
-            invalid_uri || range_contains_link_or_code_leaves
-        }
+        invalid_uri || range_contains_link_or_code_leaves
     }
 
     fn should_not_insert_at_room_mention(&self) -> bool {

--- a/crates/wysiwyg/src/composer_model/mentions.rs
+++ b/crates/wysiwyg/src/composer_model/mentions.rs
@@ -113,7 +113,7 @@ where
         let (start, end) = self.safe_selection();
         let range = self.state.dom.find_range(start, end);
 
-        let invalid_uri = !Mention::is_matrix_uri(url.to_string().as_str());
+        let invalid_uri = !Mention::is_valid_uri(url.to_string().as_str());
 
         let range_contains_link_or_code_leaves =
             range.locations.iter().any(|l: &DomLocation| {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -139,10 +139,8 @@ where
         DomNode::Container(ContainerNode::new_link(url, children, attributes))
     }
 
-    /// Create a new mention node. This function will perform a single check of the display
-    /// text and return an at-room mention if that text exactly matches `@room`
-    ///
-    /// Returns a result as creating a mention node can fail with an invalid uri
+    /// Attempts to create a new mention node. Returns a result as creating a
+    /// mention node can fail if attempted with an invalid uri.
     pub fn new_mention(
         url: S,
         display_text: S,

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -26,6 +26,7 @@ use crate::dom::unicode_string::UnicodeStrExt;
 use crate::dom::{self, UnicodeString};
 use crate::{InlineFormatType, ListType};
 
+use super::mention_node::UriParseError;
 use super::MentionNode;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -146,7 +147,7 @@ where
         url: S,
         display_text: S,
         attributes: Vec<(S, S)>,
-    ) -> Result<DomNode<S>, ()> {
+    ) -> Result<DomNode<S>, UriParseError> {
         // special case for at-room
         if display_text == "@room".into() {
             Ok(DomNode::Mention(MentionNode::new_at_room(attributes)))
@@ -155,7 +156,7 @@ where
         {
             Ok(DomNode::Mention(mention_node))
         } else {
-            Err(())
+            Err(UriParseError)
         }
     }
 

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -138,12 +138,18 @@ where
         DomNode::Container(ContainerNode::new_link(url, children, attributes))
     }
 
+    /// Create a new mention node. This function will perform a single check of the display
+    /// text and return an at-room mention if that text exactly matches `@room`
     pub fn new_mention(
         url: S,
         display_text: S,
         attributes: Vec<(S, S)>,
     ) -> DomNode<S> {
-        DomNode::Mention(MentionNode::new(url, display_text, attributes))
+        if display_text == "@room".into() {
+            DomNode::Mention(MentionNode::new_at_room(attributes))
+        } else {
+            DomNode::Mention(MentionNode::new(url, display_text, attributes))
+        }
     }
 
     pub fn new_at_room_mention(attributes: Vec<(S, S)>) -> DomNode<S> {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -145,18 +145,18 @@ where
         url: S,
         display_text: S,
         attributes: Vec<(S, S)>,
-    ) -> Result<DomNode<S>, UriParseError> {
+    ) -> Result<MentionNode<S>, UriParseError> {
         if let Ok(mention_node) =
             MentionNode::new(url, display_text, attributes)
         {
-            Ok(DomNode::Mention(mention_node))
+            Ok(mention_node)
         } else {
             Err(UriParseError)
         }
     }
 
-    pub fn new_at_room_mention(attributes: Vec<(S, S)>) -> DomNode<S> {
-        DomNode::Mention(MentionNode::new_at_room(attributes))
+    pub fn new_at_room_mention(attributes: Vec<(S, S)>) -> MentionNode<S> {
+        MentionNode::new_at_room(attributes)
     }
 
     pub fn is_container_node(&self) -> bool {

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -149,10 +149,8 @@ where
     ) -> Result<DomNode<S>, ()> {
         // special case for at-room
         if display_text == "@room".into() {
-            return Ok(DomNode::Mention(MentionNode::new_at_room(attributes)));
-        }
-
-        if let Ok(mention_node) =
+            Ok(DomNode::Mention(MentionNode::new_at_room(attributes)))
+        } else if let Ok(mention_node) =
             MentionNode::new(url, display_text, attributes)
         {
             Ok(DomNode::Mention(mention_node))

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::{
@@ -149,7 +148,7 @@ where
         attributes: Vec<(S, S)>,
     ) -> Result<DomNode<S>, UriParseError> {
         // special case for at-room
-        if display_text == "@room".into() {
+        if MentionNode::is_at_room_display_text(&display_text) {
             Ok(DomNode::Mention(MentionNode::new_at_room(attributes)))
         } else if let Ok(mention_node) =
             MentionNode::new(url, display_text, attributes)

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -140,15 +140,24 @@ where
 
     /// Create a new mention node. This function will perform a single check of the display
     /// text and return an at-room mention if that text exactly matches `@room`
+    ///
+    /// Returns a result as creating a mention node can fail with an invalid uri
     pub fn new_mention(
         url: S,
         display_text: S,
         attributes: Vec<(S, S)>,
-    ) -> DomNode<S> {
+    ) -> Result<DomNode<S>, ()> {
+        // special case for at-room
         if display_text == "@room".into() {
-            DomNode::Mention(MentionNode::new_at_room(attributes))
+            return Ok(DomNode::Mention(MentionNode::new_at_room(attributes)));
+        }
+
+        if let Ok(mention_node) =
+            MentionNode::new(url, display_text, attributes)
+        {
+            Ok(DomNode::Mention(mention_node))
         } else {
-            DomNode::Mention(MentionNode::new(url, display_text, attributes))
+            Err(())
         }
     }
 

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
 use crate::dom::nodes::{

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -149,10 +149,7 @@ where
         display_text: S,
         attributes: Vec<(S, S)>,
     ) -> Result<DomNode<S>, UriParseError> {
-        // special case for at-room
-        if is_at_room_display_text(display_text.to_string().as_str()) {
-            Ok(DomNode::Mention(MentionNode::new_at_room(attributes)))
-        } else if let Ok(mention_node) =
+        if let Ok(mention_node) =
             MentionNode::new(url, display_text, attributes)
         {
             Ok(DomNode::Mention(mention_node))

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -1,3 +1,5 @@
+use matrix_mentions::is_at_room_display_text;
+
 // Copyright 2022 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -148,7 +150,7 @@ where
         attributes: Vec<(S, S)>,
     ) -> Result<DomNode<S>, UriParseError> {
         // special case for at-room
-        if MentionNode::is_at_room_display_text(&display_text) {
+        if is_at_room_display_text(display_text.to_string().as_str()) {
             Ok(DomNode::Mention(MentionNode::new_at_room(attributes)))
         } else if let Ok(mention_node) =
             MentionNode::new(url, display_text, attributes)

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -1,5 +1,3 @@
-use matrix_mentions::is_at_room_display_text;
-
 // Copyright 2022 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -89,7 +89,7 @@ where
         let handle = DomHandle::new_unset();
 
         Self {
-            display_text: S::from("@room"),
+            display_text: MentionNode::get_at_room_display_text(),
             kind: MentionNodeKind::AtRoom,
             attributes,
             handle,
@@ -105,7 +105,7 @@ where
             MentionNodeKind::User { .. } | MentionNodeKind::Room { .. } => {
                 self.display_text.clone()
             }
-            MentionNodeKind::AtRoom => S::from("@room"),
+            MentionNodeKind::AtRoom => MentionNode::get_at_room_display_text(),
         }
     }
 
@@ -125,6 +125,16 @@ where
 
     pub fn kind(&self) -> &MentionNodeKind {
         &self.kind
+    }
+
+    /// Util function to check if the display text is that of an at-room mention
+    pub fn is_at_room_display_text(text: &S) -> bool {
+        text == &S::from("@room")
+    }
+
+    /// Util function to get the display text for an at-room mention
+    pub fn get_at_room_display_text() -> S {
+        S::from("@room")
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -126,16 +126,6 @@ where
     pub fn kind(&self) -> &MentionNodeKind {
         &self.kind
     }
-
-    // /// Util function to check if the display text is that of an at-room mention
-    // pub fn is_at_room_display_text(text: &S) -> bool {
-    //     text == &S::from(AT_ROOM)
-    // }
-
-    // /// Util function to get the display text for an at-room mention
-    // pub fn get_at_room_display_text() -> S {
-    //     S::from(AT_ROOM)
-    // }
 }
 
 impl<S> ToHtml<S> for MentionNode<S>

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -38,8 +38,8 @@ pub enum MentionNodeKind<S>
 where
     S: UnicodeString,
 {
-    Room { mention: Mention<S> },
-    User { mention: Mention<S> },
+    Room { mention: Mention },
+    User { mention: Mention },
     MatrixUrl { display_text: S, url: S },
     AtRoom,
 }
@@ -81,8 +81,12 @@ where
             MentionNodeKind::MatrixUrl { display_text, .. } => {
                 display_text.clone()
             }
-            MentionNodeKind::User { mention } => mention.display_text().clone(),
-            MentionNodeKind::Room { mention } => mention.display_text().clone(),
+            MentionNodeKind::User { mention } => {
+                S::from(mention.display_text())
+            }
+            MentionNodeKind::Room { mention } => {
+                S::from(mention.display_text())
+            }
             MentionNodeKind::AtRoom => S::from("@room"),
         }
     }
@@ -243,10 +247,10 @@ where
 
         // There are two different functions to allow for fact one will use mxId later on
         match self.kind() {
-            User => {
+            User { .. } => {
                 // TODO do something
             }
-            Room => {
+            Room { .. } => {
                 // TODO do something
             }
             MatrixUrl { .. } => {

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -267,52 +267,25 @@ where
         buffer: &mut S,
         _: &MarkdownOptions,
     ) -> Result<(), MarkdownError<S>> {
-        // There are two different functions to allow for fact one will use mxId later on
-        match self.kind() {
-            MentionNodeKind::User { mention } => {
-                // TODO do something
-                fmt_user_or_room_mention(self, mention, buffer)?;
-            }
-            MentionNodeKind::Room { mention } => {
-                // TODO do something
-                fmt_user_or_room_mention(self, mention, buffer)?;
-            }
-            MentionNodeKind::AtRoom => {
-                fmt_at_room_mention(self, buffer)?;
-            }
-        }
-
+        fmt_mention(self, buffer)?;
         return Ok(());
 
         #[inline(always)]
-        fn fmt_user_or_room_mention<S>(
+        fn fmt_mention<S>(
             this: &MentionNode<S>,
-            mention: &Mention,
             buffer: &mut S,
         ) -> Result<(), MarkdownError<S>>
         where
             S: UnicodeString,
         {
-            // use the mx_id for a room mention, but the display text (name) for a user
             let text = match this.kind() {
-                MentionNodeKind::User { mention } => S::from(mention.mx_id()),
-                MentionNodeKind::Room { mention } => S::from(mention.mx_id()),
-                _ => S::from("catch all"),
+                // for User/Room type, we use the mx_id in the md output
+                MentionNodeKind::User { mention }
+                | MentionNodeKind::Room { mention } => S::from(mention.mx_id()),
+                MentionNodeKind::AtRoom => this.display_text(),
             };
 
-            buffer.push(S::from(text));
-            Ok(())
-        }
-
-        #[inline(always)]
-        fn fmt_at_room_mention<S>(
-            this: &MentionNode<S>,
-            buffer: &mut S,
-        ) -> Result<(), MarkdownError<S>>
-        where
-            S: UnicodeString,
-        {
-            buffer.push(this.display_text());
+            buffer.push(text);
             Ok(())
         }
     }

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -270,25 +270,20 @@ where
         buffer: &mut S,
         _: &MarkdownOptions,
     ) -> Result<(), MarkdownError<S>> {
-        use MentionNodeKind::*;
-
         // There are two different functions to allow for fact one will use mxId later on
         match self.kind() {
-            User { mention } => {
+            MentionNodeKind::User { mention } => {
                 // TODO do something
                 fmt_user_or_room_mention(self, mention, buffer)?;
             }
-            Room { mention } => {
+            MentionNodeKind::Room { mention } => {
                 // TODO do something
                 fmt_user_or_room_mention(self, mention, buffer)?;
             }
-            Failed => {
+            MentionNodeKind::Failed => {
                 // TODO do something
             }
-            // MatrixUrl { .. } => {
-            //     fmt_user_or_room_mention(self, buffer)?;
-            // }
-            AtRoom => {
+            MentionNodeKind::AtRoom => {
                 fmt_at_room_mention(self, buffer)?;
             }
         }
@@ -304,8 +299,14 @@ where
         where
             S: UnicodeString,
         {
-            // TODO make this use mxId, for now we use display_text
-            buffer.push(mention.mx_id());
+            // use the mx_id for a room mention, but the display text (name) for a user
+            let text = match this.kind() {
+                MentionNodeKind::User { .. } => this.display_text(),
+                MentionNodeKind::Room { mention } => S::from(mention.mx_id()),
+                _ => S::from("catch all"),
+            };
+
+            buffer.push(S::from(text));
             Ok(())
         }
 

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -38,8 +38,8 @@ pub enum MentionNodeKind<S>
 where
     S: UnicodeString,
 {
-    Room { mention: Mention },
-    User { mention: Mention },
+    Room { mention: Mention<S> },
+    User { mention: Mention<S> },
     MatrixUrl { display_text: S, url: S },
     AtRoom,
 }
@@ -81,6 +81,8 @@ where
             MentionNodeKind::MatrixUrl { display_text, .. } => {
                 display_text.clone()
             }
+            MentionNodeKind::User { mention } => mention.display_text().clone(),
+            MentionNodeKind::Room { mention } => mention.display_text().clone(),
             MentionNodeKind::AtRoom => S::from("@room"),
         }
     }
@@ -131,6 +133,12 @@ impl<S: UnicodeString> MentionNode<S> {
 
         let cur_pos = formatter.len();
         match self.kind() {
+            MentionNodeKind::User { mention } => {
+                // TODO do something
+            }
+            MentionNodeKind::Room { mention } => {
+                // TODO do something
+            }
             MentionNodeKind::MatrixUrl { display_text, url } => {
                 // if formatting as a message, only include the href attribute
                 let attributes = if as_message {
@@ -199,6 +207,12 @@ where
         description.push("\"");
 
         match self.kind() {
+            MentionNodeKind::User { mention } => {
+                // TODO do something
+            }
+            MentionNodeKind::Room { mention } => {
+                // TODO do something
+            }
             MentionNodeKind::MatrixUrl { url, .. } => {
                 description.push(", ");
                 description.push(url.clone());
@@ -229,6 +243,12 @@ where
 
         // There are two different functions to allow for fact one will use mxId later on
         match self.kind() {
+            User => {
+                // TODO do something
+            }
+            Room => {
+                // TODO do something
+            }
             MatrixUrl { .. } => {
                 fmt_user_or_room_mention(self, buffer)?;
             }

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -156,12 +156,10 @@ impl<S: UnicodeString> MentionNode<S> {
                 let attributes = if as_message {
                     vec![("href".into(), S::from(mention.uri()))]
                 } else {
-                    let mut attributes_for_composer = self.attributes.clone();
-                    attributes_for_composer
-                        .push(("href".into(), S::from(mention.uri())));
-                    attributes_for_composer
-                        .push(("contenteditable".into(), "false".into()));
-                    attributes_for_composer
+                    let mut attrs = self.attributes.clone();
+                    attrs.push(("href".into(), S::from(mention.uri())));
+                    attrs.push(("contenteditable".into(), "false".into()));
+                    attrs
                 };
 
                 self.fmt_tag_open(tag, formatter, &Some(attributes));
@@ -169,20 +167,22 @@ impl<S: UnicodeString> MentionNode<S> {
                 self.fmt_tag_close(tag, formatter);
             }
             MentionNodeKind::Room { mention } => {
-                // if formatting as a message, only include the href attribute
-                let attributes = if as_message {
-                    vec![("href".into(), S::from(mention.uri()))]
+                // if formatting as a message, only include the href attribute and also use the mx_id as
+                // the display text
+                let (attributes, display_text) = if as_message {
+                    (
+                        vec![("href".into(), S::from(mention.uri()))],
+                        S::from(mention.mx_id()),
+                    )
                 } else {
-                    let mut attributes_for_composer = self.attributes.clone();
-                    attributes_for_composer
-                        .push(("href".into(), S::from(mention.uri())));
-                    attributes_for_composer
-                        .push(("contenteditable".into(), "false".into()));
-                    attributes_for_composer
+                    let mut attrs = self.attributes.clone();
+                    attrs.push(("href".into(), S::from(mention.uri())));
+                    attrs.push(("contenteditable".into(), "false".into()));
+                    (attrs, self.display_text())
                 };
 
                 self.fmt_tag_open(tag, formatter, &Some(attributes));
-                formatter.push(self.display_text());
+                formatter.push(display_text);
                 self.fmt_tag_close(tag, formatter);
             }
             MentionNodeKind::AtRoom => {

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use matrix_mentions::Mention;
 
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
@@ -37,6 +38,8 @@ pub enum MentionNodeKind<S>
 where
     S: UnicodeString,
 {
+    Room { mention: Mention },
+    User { mention: Mention },
     MatrixUrl { display_text: S, url: S },
     AtRoom,
 }

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -294,8 +294,8 @@ where
         {
             let text = match this.kind() {
                 // for User/Room type, we use the mx_id in the md output
-                MentionNodeKind::User { mention }
-                | MentionNodeKind::Room { mention } => S::from(mention.mx_id()),
+                MentionNodeKind::User { .. } => this.display_text(),
+                MentionNodeKind::Room { mention } => S::from(mention.mx_id()),
                 MentionNodeKind::AtRoom => this.display_text(),
             };
 

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -55,6 +55,12 @@ where
     pub fn new(url: S, display_text: S, attributes: Vec<(S, S)>) -> Self {
         let handle = DomHandle::new_unset();
 
+        // convert S to whatever is needed by doing S.to_string.as_str()
+        let thing = Mention::from_uri_with_display_text(
+            &url.to_string(),
+            &display_text.to_string(),
+        );
+
         Self {
             kind: MentionNodeKind::MatrixUrl { display_text, url },
             attributes,

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -47,7 +47,7 @@ where
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MentionNodeKind {
-    MatrixURI { mention: Mention },
+    MatrixUri { mention: Mention },
     AtRoom,
 }
 
@@ -71,7 +71,7 @@ where
             &url.to_string(),
             &display_text.to_string(),
         ) {
-            let kind = MentionNodeKind::MatrixURI { mention };
+            let kind = MentionNodeKind::MatrixUri { mention };
             Ok(Self {
                 display_text,
                 kind,
@@ -104,7 +104,7 @@ where
 
     pub fn display_text(&self) -> S {
         match self.kind() {
-            MentionNodeKind::MatrixURI { .. } => self.display_text.clone(),
+            MentionNodeKind::MatrixUri { .. } => self.display_text.clone(),
             MentionNodeKind::AtRoom => S::from(get_at_room_display_text()),
         }
     }
@@ -127,6 +127,8 @@ where
         &self.kind
     }
 }
+
+// TODO implment From trait to convert from MentionNode to DomNode to allow MentionNode.into() usage
 
 impl<S> ToHtml<S> for MentionNode<S>
 where
@@ -155,7 +157,7 @@ impl<S: UnicodeString> MentionNode<S> {
 
         let cur_pos = formatter.len();
         match self.kind() {
-            MentionNodeKind::MatrixURI { mention } => {
+            MentionNodeKind::MatrixUri { mention } => {
                 // if formatting as a message, only include the href attribute
                 let attributes = if as_message {
                     vec![("href".into(), S::from(mention.uri()))]
@@ -229,7 +231,7 @@ where
         description.push("\"");
 
         match self.kind() {
-            MentionNodeKind::MatrixURI { mention } => {
+            MentionNodeKind::MatrixUri { mention } => {
                 description.push(", ");
                 description.push(S::from(mention.uri()));
             }
@@ -268,7 +270,7 @@ where
         {
             let text = match this.kind() {
                 // for User/Room type, we use the mx_id in the md output
-                MentionNodeKind::MatrixURI { mention } => {
+                MentionNodeKind::MatrixUri { mention } => {
                     if mention.kind() == &MentionKind::Room {
                         S::from(mention.mx_id())
                     } else {

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use matrix_mentions::{Mention, MentionKind};
+use matrix_mentions::{Mention, MentionKind, AT_ROOM};
 
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
@@ -129,12 +129,12 @@ where
 
     /// Util function to check if the display text is that of an at-room mention
     pub fn is_at_room_display_text(text: &S) -> bool {
-        text == &S::from("@room")
+        text == &S::from(AT_ROOM)
     }
 
     /// Util function to get the display text for an at-room mention
     pub fn get_at_room_display_text() -> S {
-        S::from("@room")
+        S::from(AT_ROOM)
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -28,6 +28,8 @@ pub struct MentionNode<S>
 where
     S: UnicodeString,
 {
+    // `display_text` refers to that passed by the client which may, in some cases, be different
+    // from the ruma derived `Mention.display_text`
     display_text: S,
     kind: MentionNodeKind,
     attributes: Vec<(S, S)>,
@@ -39,7 +41,6 @@ pub enum MentionNodeKind {
     Room { mention: Mention },
     User { mention: Mention },
     AtRoom,
-    Failed,
 }
 
 impl<S> MentionNode<S>
@@ -101,7 +102,6 @@ where
             MentionNodeKind::User { mention } => self.display_text.clone(),
             MentionNodeKind::Room { mention } => self.display_text.clone(),
             MentionNodeKind::AtRoom => S::from("@room"),
-            MentionNodeKind::Failed => S::from("failed parsing"),
         }
     }
 
@@ -185,9 +185,6 @@ impl<S: UnicodeString> MentionNode<S> {
                 formatter.push(self.display_text());
                 self.fmt_tag_close(tag, formatter);
             }
-            MentionNodeKind::Failed => {
-                // TODO do something
-            }
             MentionNodeKind::AtRoom => {
                 // if formatting as a message, simply use the display text (@room)
                 if as_message {
@@ -248,10 +245,6 @@ where
                 description.push(", ");
                 description.push(mention.uri().clone());
             }
-            MentionNodeKind::Failed => {
-                description.push(", ");
-                description.push("failed parsing");
-            }
             MentionNodeKind::AtRoom => {}
         }
 
@@ -283,9 +276,6 @@ where
             MentionNodeKind::Room { mention } => {
                 // TODO do something
                 fmt_user_or_room_mention(self, mention, buffer)?;
-            }
-            MentionNodeKind::Failed => {
-                // TODO do something
             }
             MentionNodeKind::AtRoom => {
                 fmt_at_room_mention(self, buffer)?;

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use matrix_mentions::{get_at_room_display_text, Mention, MentionKind};
+use matrix_mentions::{Mention, MentionKind};
 
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
@@ -23,6 +23,12 @@ use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
 use crate::dom::UnicodeString;
 
+pub const AT_ROOM: &str = "@room";
+
+/// Util function to get the display text for an at-room mention
+pub fn get_at_room_display_text() -> &'static str {
+    AT_ROOM
+}
 #[derive(Debug)]
 pub struct UriParseError;
 

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -23,6 +23,9 @@ use crate::dom::to_tree::ToTree;
 use crate::dom::unicode_string::{UnicodeStrExt, UnicodeStringExt};
 use crate::dom::UnicodeString;
 
+#[derive(Debug)]
+pub struct UriParseError;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MentionNode<S>
 where
@@ -56,7 +59,7 @@ where
         url: S,
         display_text: S,
         attributes: Vec<(S, S)>,
-    ) -> Result<Self, ()> {
+    ) -> Result<Self, UriParseError> {
         let handle = DomHandle::new_unset();
 
         if let Some(mention) = Mention::from_uri_with_display_text(
@@ -74,7 +77,7 @@ where
                 handle,
             })
         } else {
-            Err(())
+            Err(UriParseError)
         }
     }
 
@@ -99,8 +102,9 @@ where
 
     pub fn display_text(&self) -> S {
         match self.kind() {
-            MentionNodeKind::User { mention }
-            | MentionNodeKind::Room { mention } => self.display_text.clone(),
+            MentionNodeKind::User { .. } | MentionNodeKind::Room { .. } => {
+                self.display_text.clone()
+            }
             MentionNodeKind::AtRoom => S::from("@room"),
         }
     }
@@ -239,11 +243,11 @@ where
         match self.kind() {
             MentionNodeKind::User { mention } => {
                 description.push(", ");
-                description.push(mention.uri().clone());
+                description.push(S::from(mention.uri()));
             }
             MentionNodeKind::Room { mention } => {
                 description.push(", ");
-                description.push(mention.uri().clone());
+                description.push(S::from(mention.uri()));
             }
             MentionNodeKind::AtRoom => {}
         }

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -295,7 +295,7 @@ where
         {
             // use the mx_id for a room mention, but the display text (name) for a user
             let text = match this.kind() {
-                MentionNodeKind::User { .. } => this.display_text(),
+                MentionNodeKind::User { mention } => S::from(mention.mx_id()),
                 MentionNodeKind::Room { mention } => S::from(mention.mx_id()),
                 _ => S::from("catch all"),
             };

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use matrix_mentions::{Mention, MentionKind, AT_ROOM};
+use matrix_mentions::{get_at_room_display_text, Mention, MentionKind};
 
 use crate::composer_model::example_format::SelectionWriter;
 use crate::dom::dom_handle::DomHandle;
@@ -89,7 +89,7 @@ where
         let handle = DomHandle::new_unset();
 
         Self {
-            display_text: MentionNode::get_at_room_display_text(),
+            display_text: S::from(get_at_room_display_text()),
             kind: MentionNodeKind::AtRoom,
             attributes,
             handle,
@@ -105,7 +105,7 @@ where
             MentionNodeKind::User { .. } | MentionNodeKind::Room { .. } => {
                 self.display_text.clone()
             }
-            MentionNodeKind::AtRoom => MentionNode::get_at_room_display_text(),
+            MentionNodeKind::AtRoom => S::from(get_at_room_display_text()),
         }
     }
 
@@ -127,15 +127,15 @@ where
         &self.kind
     }
 
-    /// Util function to check if the display text is that of an at-room mention
-    pub fn is_at_room_display_text(text: &S) -> bool {
-        text == &S::from(AT_ROOM)
-    }
+    // /// Util function to check if the display text is that of an at-room mention
+    // pub fn is_at_room_display_text(text: &S) -> bool {
+    //     text == &S::from(AT_ROOM)
+    // }
 
-    /// Util function to get the display text for an at-room mention
-    pub fn get_at_room_display_text() -> S {
-        S::from(AT_ROOM)
-    }
+    // /// Util function to get the display text for an at-room mention
+    // pub fn get_at_room_display_text() -> S {
+    //     S::from(AT_ROOM)
+    // }
 }
 
 impl<S> ToHtml<S> for MentionNode<S>

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -99,8 +99,8 @@ where
 
     pub fn display_text(&self) -> S {
         match self.kind() {
-            MentionNodeKind::User { mention } => self.display_text.clone(),
-            MentionNodeKind::Room { mention } => self.display_text.clone(),
+            MentionNodeKind::User { mention }
+            | MentionNodeKind::Room { mention } => self.display_text.clone(),
             MentionNodeKind::AtRoom => S::from("@room"),
         }
     }

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -46,11 +46,16 @@ impl<S> MentionNode<S>
 where
     S: UnicodeString,
 {
-    /// Create a new MentionNode
+    /// Create a new MentionNode. This may fail if the uri can not be parsed, so
+    /// it will return `Result<MentionNode>`
     ///
     /// NOTE: Its handle() will be unset until you call set_handle() or
     /// append() it to another node.
-    pub fn new(url: S, display_text: S, attributes: Vec<(S, S)>) -> Self {
+    pub fn new(
+        url: S,
+        display_text: S,
+        attributes: Vec<(S, S)>,
+    ) -> Result<Self, ()> {
         let handle = DomHandle::new_unset();
 
         if let Some(mention) = Mention::from_uri_with_display_text(
@@ -61,22 +66,21 @@ where
                 MentionKind::Room => MentionNodeKind::Room { mention },
                 MentionKind::User => MentionNodeKind::User { mention },
             };
-            Self {
+            Ok(Self {
                 display_text,
                 kind,
                 attributes,
                 handle,
-            }
+            })
         } else {
-            Self {
-                display_text: S::from("failed to parse"),
-                kind: MentionNodeKind::Failed,
-                attributes: vec![],
-                handle,
-            }
+            Err(())
         }
     }
 
+    /// Create a new at-room MentionNode.
+    ///
+    /// NOTE: Its handle() will be unset until you call set_handle() or
+    /// append() it to another node.
     pub fn new_at_room(attributes: Vec<(S, S)>) -> Self {
         let handle = DomHandle::new_unset();
 

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -851,7 +851,8 @@ mod js {
                             .get_attribute("href")
                             .unwrap_or_default();
 
-                        let is_mention = Mention::is_valid_uri(url.to_string());
+                        let is_mention =
+                            Mention::is_valid_uri(&url.to_string());
                         let text = node.child_nodes().get(0);
                         let has_text = match text.clone() {
                             Some(node) => {

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use matrix_mentions::Mention;
 
 use crate::dom::dom_creation_error::HtmlParseError;
 use crate::dom::nodes::dom_node::DomNodeKind::CodeBlock;
@@ -36,6 +35,8 @@ where
 
 #[cfg(feature = "sys")]
 mod sys {
+    use matrix_mentions::Mention;
+
     use super::super::padom_node::PaDomNode;
     use super::super::PaNodeContainer;
     use super::super::{PaDom, PaDomCreationError, PaDomCreator};

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -316,12 +316,19 @@ mod sys {
         {
             let text = &text.content;
 
-            DomNode::new_mention(
+            // as creating a new mention might fail, we need to do something in the case where it fails
+
+            let try_create = DomNode::new_mention(
                 link.get_attr("href").unwrap_or("").into(),
                 text.as_str().into(),
                 // custom attributes are not required when cfg feature != "js"
                 vec![],
-            )
+            );
+
+            match try_create {
+                Ok(node) => node,
+                Err(_) => Self::new_link(link),
+            }
         }
 
         /// Create a list node

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -311,16 +311,15 @@ mod sys {
         {
             let text = &text.content;
 
-            // as creating a new mention might fail, we need to do something in the case where it fails
-
-            let try_create = DomNode::new_mention(
+            // creating a mention node could fail if the uri is invalid
+            let creation_result = DomNode::new_mention(
                 link.get_attr("href").unwrap_or("").into(),
                 text.as_str().into(),
                 // custom attributes are not required when cfg feature != "js"
                 vec![],
             );
 
-            match try_create {
+            match creation_result {
                 Ok(node) => node,
                 Err(_) => Self::new_link(link),
             }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -851,7 +851,7 @@ mod js {
                             .get_attribute("href")
                             .unwrap_or_default();
 
-                        let is_mention = Matrix::is_valid_uri(url.to_string());
+                        let is_mention = Mention::is_valid_uri(url.to_string());
                         let text = node.child_nodes().get(0);
                         let has_text = match text.clone() {
                             Some(node) => {

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -321,7 +321,7 @@ mod sys {
             );
 
             match creation_result {
-                Ok(node) => node,
+                Ok(node) => DomNode::Mention(node),
                 Err(_) => Self::new_link(link),
             }
         }
@@ -712,7 +712,9 @@ fn convert_text<S: UnicodeString>(
 
         for (i, part) in contents.split("@room").into_iter().enumerate() {
             if i > 0 {
-                node.append_child(DomNode::new_at_room_mention(vec![]));
+                node.append_child(DomNode::Mention(
+                    DomNode::new_at_room_mention(vec![]),
+                ));
             }
             if !part.is_empty() {
                 node.append_child(DomNode::new_text(part.into()));
@@ -863,15 +865,17 @@ mod js {
                         };
                         if has_text && is_mention {
                             dom.append_child(
-                                DomNode::new_mention(
-                                    url.into(),
-                                    text.unwrap()
-                                        .node_value()
-                                        .unwrap_or_default()
-                                        .into(),
-                                    attributes,
-                                )
-                                .unwrap(), // we unwrap because we have already confirmed the uri is valid
+                                DomNode::Mention(
+                                    DomNode::new_mention(
+                                        url.into(),
+                                        text.unwrap()
+                                            .node_value()
+                                            .unwrap_or_default()
+                                            .into(),
+                                        attributes,
+                                    )
+                                    .unwrap(),
+                                ), // we unwrap because we have already confirmed the uri is valid
                             );
                         } else {
                             let children = self

--- a/crates/wysiwyg/src/tests/test_mentions.rs
+++ b/crates/wysiwyg/src/tests/test_mentions.rs
@@ -556,6 +556,16 @@ fn selection_paragraph_spanning() {
 }
 
 /**
+ * AT-ROOM
+ */
+#[test]
+fn can_insert_at_room_mention() {
+    let mut model = cm("|");
+    model.insert_at_room_mention(vec![("style".into(), "some css".into())]);
+    assert_eq!(tx(&model), "<a style=\"some css\" href=\"#\" contenteditable=\"false\">@room</a>&nbsp;|")
+}
+
+/**
  * HELPER FUNCTIONS
  */
 fn insert_mention_at_cursor(model: &mut ComposerModel<Utf16String>) {

--- a/crates/wysiwyg/src/tests/test_mentions.rs
+++ b/crates/wysiwyg/src/tests/test_mentions.rs
@@ -18,6 +18,15 @@ use crate::{
     tests::testutils_composer_model::{cm, tx},
     ComposerModel, MenuAction,
 };
+/**
+ * INSERTING INVALID URL
+ */
+#[test]
+fn inserting_with_invalid_mention_url_does_nothing() {
+    let mut model = cm("|");
+    model.insert_mention("invalid mention url".into(), "@Alice".into(), vec![]);
+    assert_eq!(tx(&model), "|");
+}
 
 /**
  * ATTRIBUTE TESTS

--- a/crates/wysiwyg/src/tests/test_mentions.rs
+++ b/crates/wysiwyg/src/tests/test_mentions.rs
@@ -29,6 +29,31 @@ fn inserting_with_invalid_mention_url_does_nothing() {
 }
 
 /**
+ * INSERTING EXTERNAL LINKS
+ */
+#[test]
+fn inserting_with_external_user_works() {
+    let mut model = cm("|");
+    model.insert_mention(
+        "https://custom.custom.com/?secretstuff/#/@alice:example.org".into(),
+        "@Alice".into(),
+        vec![],
+    );
+    assert_eq!(tx(&model), "<a href=\"https://custom.custom.com/?secretstuff/#/@alice:example.org\" contenteditable=\"false\">@Alice</a>&nbsp;|");
+}
+
+#[test]
+fn inserting_with_external_room_works() {
+    let mut model = cm("|");
+    model.insert_mention(
+        "https://custom.custom.com/?secretstuff/#/!roomid:example.org".into(),
+        "some room".into(),
+        vec![],
+    );
+    assert_eq!(tx(&model), "<a href=\"https://custom.custom.com/?secretstuff/#/!roomid:example.org\" contenteditable=\"false\">some room</a>&nbsp;|");
+}
+
+/**
  * ATTRIBUTE TESTS
  */
 #[test]

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -206,8 +206,8 @@ fn list_ordered_and_unordered() {
 #[test]
 fn mention() {
     assert_to_md_no_roundtrip(
-        r#"<a href="https://matrix.to/#/@test:example.org">test</a>"#,
-        r#"test"#,
+        r#"<a href="https://matrix.to/#/@alice:matrix.org">test</a>"#,
+        r#"@alice:matrix.org"#,
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -204,10 +204,18 @@ fn list_ordered_and_unordered() {
 }
 
 #[test]
-fn mention() {
+fn user_mention() {
     assert_to_md_no_roundtrip(
         r#"<a href="https://matrix.to/#/@alice:matrix.org">test</a>"#,
-        r#"@alice:matrix.org"#,
+        r#"test"#,
+    );
+}
+
+#[test]
+fn room_mention() {
+    assert_to_md_no_roundtrip(
+        r#"<a href="https://matrix.to/#/#alice:matrix.org">test</a>"#,
+        r#"#alice:matrix.org"#,
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_to_message_html.rs
+++ b/crates/wysiwyg/src/tests/test_to_message_html.rs
@@ -75,15 +75,8 @@ fn only_outputs_href_attribute_on_room_mention_and_uses_mx_id() {
 #[test]
 fn only_outputs_href_inner_text_for_at_room_mention() {
     let mut model = cm("|");
-    model.insert_mention(
-        "anything".into(), // this should be ignored in favour of a # placeholder
-        "@room".into(),
-        vec![
-            ("data-mention-type".into(), "at-room".into()),
-            ("style".into(), "some css".into()),
-        ],
-    );
-    assert_eq!(tx(&model), "<a data-mention-type=\"at-room\" style=\"some css\" href=\"#\" contenteditable=\"false\">@room</a>&nbsp;|");
+    model.insert_at_room_mention(vec![("style".into(), "some css".into())]);
+    assert_eq!(tx(&model), "<a style=\"some css\" href=\"#\" contenteditable=\"false\">@room</a>&nbsp;|");
 
     let message_output = model.get_content_as_message_html();
     assert_eq!(message_output, "@room\u{a0}");

--- a/crates/wysiwyg/src/tests/test_to_message_html.rs
+++ b/crates/wysiwyg/src/tests/test_to_message_html.rs
@@ -53,7 +53,7 @@ fn only_outputs_href_attribute_on_user_mention() {
 }
 
 #[test]
-fn only_outputs_href_attribute_on_room_mention() {
+fn only_outputs_href_attribute_on_room_mention_and_uses_mx_id() {
     let mut model = cm("|");
     model.insert_mention(
         "https://matrix.to/#/#alice:matrix.org".into(),
@@ -68,7 +68,7 @@ fn only_outputs_href_attribute_on_room_mention() {
     let message_output = model.get_content_as_message_html();
     assert_eq!(
         message_output,
-        "<a href=\"https://matrix.to/#/#alice:matrix.org\">inner text</a>\u{a0}"
+        "<a href=\"https://matrix.to/#/#alice:matrix.org\">#alice:matrix.org</a>\u{a0}"
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_to_message_html.rs
+++ b/crates/wysiwyg/src/tests/test_to_message_html.rs
@@ -31,23 +31,24 @@ fn replaces_empty_paragraphs_with_newline_characters() {
     let message_output = model.get_content_as_message_html();
     assert_eq!(message_output, "<p>hello</p>\n\n\n<p>Alice</p>");
 }
+
 #[test]
 fn only_outputs_href_attribute_on_user_mention() {
     let mut model = cm("|");
     model.insert_mention(
-        "www.url.com".into(),
+        "https://matrix.to/#/@alice:matrix.org".into(),
         "inner text".into(),
         vec![
             ("data-mention-type".into(), "user".into()),
             ("style".into(), "some css".into()),
         ],
     );
-    assert_eq!(tx(&model), "<a data-mention-type=\"user\" style=\"some css\" href=\"www.url.com\" contenteditable=\"false\">inner text</a>&nbsp;|");
+    assert_eq!(tx(&model), "<a data-mention-type=\"user\" style=\"some css\" href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\">inner text</a>&nbsp;|");
 
     let message_output = model.get_content_as_message_html();
     assert_eq!(
         message_output,
-        "<a href=\"www.url.com\">inner text</a>\u{a0}"
+        "<a href=\"https://matrix.to/#/@alice:matrix.org\">inner text</a>\u{a0}"
     );
 }
 
@@ -55,19 +56,19 @@ fn only_outputs_href_attribute_on_user_mention() {
 fn only_outputs_href_attribute_on_room_mention() {
     let mut model = cm("|");
     model.insert_mention(
-        "www.url.com".into(),
+        "https://matrix.to/#/#alice:matrix.org".into(),
         "inner text".into(),
         vec![
             ("data-mention-type".into(), "room".into()),
             ("style".into(), "some css".into()),
         ],
     );
-    assert_eq!(tx(&model), "<a data-mention-type=\"room\" style=\"some css\" href=\"www.url.com\" contenteditable=\"false\">inner text</a>&nbsp;|");
+    assert_eq!(tx(&model), "<a data-mention-type=\"room\" style=\"some css\" href=\"https://matrix.to/#/#alice:matrix.org\" contenteditable=\"false\">inner text</a>&nbsp;|");
 
     let message_output = model.get_content_as_message_html();
     assert_eq!(
         message_output,
-        "<a href=\"www.url.com\">inner text</a>\u{a0}"
+        "<a href=\"https://matrix.to/#/#alice:matrix.org\">inner text</a>\u{a0}"
     );
 }
 

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -76,6 +76,16 @@ export function processInput(
                 const { text, url, attributes } = event.data;
                 const attributesMap = new Map(Object.entries(attributes));
 
+                if (text === '@room' && url === '#') {
+                    return action(
+                        composerModel.insert_at_room_at_suggestion(
+                            suggestion,
+                            attributesMap,
+                        ),
+                        'insert_at_room_mention_at_suggestion',
+                    );
+                }
+
                 return action(
                     composerModel.insert_mention_at_suggestion(
                         url,

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -78,7 +78,7 @@ export function processInput(
 
                 if (text === '@room' && url === '#') {
                     return action(
-                        composerModel.insert_at_room_at_suggestion(
+                        composerModel.insert_at_room_mention_at_suggestion(
                             suggestion,
                             attributesMap,
                         ),


### PR DESCRIPTION
This PR integrates the new parsing functions in the following ways:
- adds an `is_valid_uri` helper function to the `matrix_mentions` crate
- updates the `MentionNode` type quite a bit to accommodate the parsing changes
- updates the output as html/md of the `MentionNode` to address eg using mx_id inside room mentions and in markdown output
- enables us to detect when a link is a mention (for editing messages etc)
- updates tests where required
- enables the matrix mention parsing to handle non matrix permalinks

This will close the outstanding points on #679 , namely 
```
replace the inner text of a room mention link with the mxId (think this is what the spec dictates, should this be the same for users?)
Markdown output (to attach to body)

replace mention link representations with just the mxId, prefixed with @ or # as appropriate
```
Closes https://github.com/matrix-org/matrix-rich-text-editor/issues/679