### PR TITLE
Alter attribute input for mentions

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -282,7 +282,7 @@ impl ComposerModel {
         self: &Arc<Self>,
         url: String,
         text: String,
-        attributes: Vec<Attribute>, // TODO remove attributes
+        _attributes: Vec<Attribute>, // TODO remove attributes
     ) -> Arc<ComposerUpdate> {
         let url = Utf16String::from_str(&url);
         let text = Utf16String::from_str(&text);
@@ -324,7 +324,7 @@ impl ComposerModel {
         url: String,
         text: String,
         suggestion: SuggestionPattern,
-        attributes: Vec<Attribute>, // TODO remove attributes
+        _attributes: Vec<Attribute>, // TODO remove attributes
     ) -> Arc<ComposerUpdate> {
         let url = Utf16String::from_str(&url);
         let text = Utf16String::from_str(&text);

--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -282,19 +282,11 @@ impl ComposerModel {
         self: &Arc<Self>,
         url: String,
         text: String,
-        attributes: Vec<Attribute>,
+        attributes: Vec<Attribute>, // TODO remove attributes
     ) -> Arc<ComposerUpdate> {
         let url = Utf16String::from_str(&url);
         let text = Utf16String::from_str(&text);
-        let attrs = attributes
-            .iter()
-            .map(|attr| {
-                (
-                    Utf16String::from_str(&attr.key),
-                    Utf16String::from_str(&attr.value),
-                )
-            })
-            .collect();
+        let attrs = vec![];
         Arc::new(ComposerUpdate::from(
             self.inner.lock().unwrap().insert_mention(url, text, attrs),
         ))
@@ -332,20 +324,12 @@ impl ComposerModel {
         url: String,
         text: String,
         suggestion: SuggestionPattern,
-        attributes: Vec<Attribute>,
+        attributes: Vec<Attribute>, // TODO remove attributes
     ) -> Arc<ComposerUpdate> {
         let url = Utf16String::from_str(&url);
         let text = Utf16String::from_str(&text);
         let suggestion = wysiwyg::SuggestionPattern::from(suggestion);
-        let attrs = attributes
-            .iter()
-            .map(|attr| {
-                (
-                    Utf16String::from_str(&attr.key),
-                    Utf16String::from_str(&attr.value),
-                )
-            })
-            .collect();
+        let attrs = vec![];
         Arc::new(ComposerUpdate::from(
             self.inner
                 .lock()

--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::vec;
 
 use widestring::Utf16String;
 
@@ -259,21 +260,9 @@ impl ComposerModel {
     }
 
     /// Creates an at-room mention node and inserts it into the composer at the current selection
-    pub fn insert_at_room_mention(
-        self: &Arc<Self>,
-        attributes: Vec<Attribute>,
-    ) -> Arc<ComposerUpdate> {
-        let attrs = attributes
-            .iter()
-            .map(|attr| {
-                (
-                    Utf16String::from_str(&attr.key),
-                    Utf16String::from_str(&attr.value),
-                )
-            })
-            .collect();
+    pub fn insert_at_room_mention(self: &Arc<Self>) -> Arc<ComposerUpdate> {
         Arc::new(ComposerUpdate::from(
-            self.inner.lock().unwrap().insert_at_room_mention(attrs),
+            self.inner.lock().unwrap().insert_at_room_mention(vec![]),
         ))
     }
 
@@ -297,18 +286,9 @@ impl ComposerModel {
     pub fn insert_at_room_mention_at_suggestion(
         self: &Arc<Self>,
         suggestion: SuggestionPattern,
-        attributes: Vec<Attribute>,
     ) -> Arc<ComposerUpdate> {
         let suggestion = wysiwyg::SuggestionPattern::from(suggestion);
-        let attrs = attributes
-            .iter()
-            .map(|attr| {
-                (
-                    Utf16String::from_str(&attr.key),
-                    Utf16String::from_str(&attr.value),
-                )
-            })
-            .collect();
+        let attrs = vec![];
         Arc::new(ComposerUpdate::from(
             self.inner
                 .lock()

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -229,10 +229,7 @@ mod test {
             "https://matrix.to/#/@alice:matrix.org".into(),
             "Alice".into(),
             suggestion_pattern,
-            vec![Attribute {
-                key: "data-mention-type".into(),
-                value: "user".into(),
-            }],
+            vec![], // TODO remove argument when function signature changes
         );
     }
 

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -31,8 +31,8 @@ mod test {
     use std::{collections::HashMap, sync::Arc};
 
     use crate::{
-        ActionState, Attribute, ComposerAction, ComposerModel, MenuAction,
-        MenuState, SuggestionPattern,
+        ActionState, ComposerAction, ComposerModel, MenuAction, MenuState,
+        SuggestionPattern,
     };
 
     #[test]

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -48,9 +48,9 @@ interface ComposerModel {
     ComposerUpdate set_link(string url, sequence<Attribute> attributes);
     ComposerUpdate set_link_with_text(string url, string text, sequence<Attribute> attributes);
     ComposerUpdate remove_links();
-    ComposerUpdate insert_at_room_mention(sequence<Attribute> attributes);
+    ComposerUpdate insert_at_room_mention();
     ComposerUpdate insert_mention(string url, string text, sequence<Attribute> attributes);
-    ComposerUpdate insert_at_room_mention_at_suggestion(SuggestionPattern suggestion, sequence<Attribute> attributes);
+    ComposerUpdate insert_at_room_mention_at_suggestion(SuggestionPattern suggestion);
     ComposerUpdate insert_mention_at_suggestion(string url, string text, SuggestionPattern suggestion, sequence<Attribute> attributes);
     ComposerUpdate code_block();
     ComposerUpdate quote();

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -164,7 +164,14 @@ impl<S: UnicodeString> MentionNode<S> {
                 } else {
                     // this is now only required for us to attach a custom style attribute for web
                     let mut attrs = self.attributes.clone();
-                    attrs.push(("data-mention-type".into(), "user".into()));
+                    let data_mention_type = match mention.kind() {
+                        MentionKind::Room => "room",
+                        MentionKind::User => "user",
+                    };
+                    attrs.push((
+                        "data-mention-type".into(),
+                        data_mention_type.into(),
+                    ));
                     attrs.push(("href".into(), S::from(mention.uri())));
                     attrs.push(("contenteditable".into(), "false".into()));
                     attrs

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -162,7 +162,9 @@ impl<S: UnicodeString> MentionNode<S> {
                 let attributes = if as_message {
                     vec![("href".into(), S::from(mention.uri()))]
                 } else {
+                    // this is now only required for us to attach a custom style attribute for web
                     let mut attrs = self.attributes.clone();
+                    attrs.push(("data-mention-type".into(), "user".into()));
                     attrs.push(("href".into(), S::from(mention.uri())));
                     attrs.push(("contenteditable".into(), "false".into()));
                     attrs
@@ -184,7 +186,10 @@ impl<S: UnicodeString> MentionNode<S> {
                 if as_message {
                     formatter.push(self.display_text())
                 } else {
+                    // this is now only required for us to attach a custom style attribute for web
                     let mut attributes = self.attributes.clone();
+                    attributes
+                        .push(("data-mention-type".into(), "at-room".into()));
                     attributes.push(("href".into(), "#".into())); // designates a placeholder link in html
                     attributes.push(("contenteditable".into(), "false".into()));
 

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -1104,7 +1104,7 @@ mod js {
             let dom = HtmlParser::default().parse::<Utf16String>(html).unwrap();
             assert_eq!(
                 dom.to_string(),
-                r#"<a data-mention-type=\"user\" href=\"https://matrix.to/#/@test:example.org\" contenteditable=\"false\">test</a>"#
+                r#"<a data-mention-type="user" href="https://matrix.to/#/@test:example.org" contenteditable="false">test</a>"#
             );
         }
 

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -831,8 +831,8 @@ mod js {
                         self.current_path.push(DomNodeKind::Link);
 
                         let mut attributes = vec![];
-                        let valid_attributes =
-                            ["contenteditable", "data-mention-type", "style"];
+                        // we only need to pass in a style attribute from web to allow CSS variable insertion
+                        let valid_attributes = ["style"];
 
                         for attr in valid_attributes.into_iter() {
                             if node

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -1082,16 +1082,6 @@ mod js {
         }
 
         #[wasm_bindgen_test]
-        fn a_with_bad_attribute() {
-            let html = r#"<a invalidattribute="true" href="http://example.com">a user mention</a>"#;
-            let dom = HtmlParser::default().parse::<Utf16String>(html).unwrap();
-            assert_eq!(
-                dom.to_string(),
-                r#"<a href="http://example.com">a user mention</a>"#
-            );
-        }
-
-        #[wasm_bindgen_test]
         fn mention_with_attributes() {
             roundtrip(
                 r#"<a style="something" href="https://matrix.to/@test:example.org">test</a>"#,

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -1082,13 +1082,6 @@ mod js {
         }
 
         #[wasm_bindgen_test]
-        fn a_with_attributes() {
-            roundtrip(
-                r#"<a contenteditable="false" data-mention-type="user" style="something" href="http://example.com">a user mention</a>"#,
-            );
-        }
-
-        #[wasm_bindgen_test]
         fn a_with_bad_attribute() {
             let html = r#"<a invalidattribute="true" href="http://example.com">a user mention</a>"#;
             let dom = HtmlParser::default().parse::<Utf16String>(html).unwrap();
@@ -1101,7 +1094,7 @@ mod js {
         #[wasm_bindgen_test]
         fn mention_with_attributes() {
             roundtrip(
-                r#"<a contenteditable="false" data-mention-type="user" style="something" href="https://matrix.to/@test:example.org">test</a>"#,
+                r#"<a style="something" href="https://matrix.to/@test:example.org">test</a>"#,
             );
         }
 
@@ -1111,7 +1104,7 @@ mod js {
             let dom = HtmlParser::default().parse::<Utf16String>(html).unwrap();
             assert_eq!(
                 dom.to_string(),
-                r#"<a href="https://matrix.to/#/@test:example.org" contenteditable="false">test</a>"#
+                r#"<a data-mention-type=\"user\" href=\"https://matrix.to/#/@test:example.org\" contenteditable=\"false\">test</a>"#
             );
         }
 

--- a/crates/wysiwyg/src/tests/test_deleting.rs
+++ b/crates/wysiwyg/src/tests/test_deleting.rs
@@ -901,7 +901,7 @@ fn backspace_mention_multiple() {
     model.backspace();
     assert_eq!(
         restore_whitespace(&tx(&model)),
-        "<a href=\"https://matrix.to/#/@test:example.org\" contenteditable=\"false\">first</a>|"
+        "<a data-mention-type=\"user\" href=\"https://matrix.to/#/@test:example.org\" contenteditable=\"false\">first</a>|"
     );
     model.backspace();
     assert_eq!(restore_whitespace(&tx(&model)), "|");
@@ -972,7 +972,7 @@ fn delete_first_mention_of_multiple() {
     model.delete();
     assert_eq!(
         restore_whitespace(&tx(&model)),
-        "|<a href=\"https://matrix.to/#/@test:example.org\" contenteditable=\"false\">second</a>"
+        "|<a data-mention-type=\"user\" href=\"https://matrix.to/#/@test:example.org\" contenteditable=\"false\">second</a>"
     );
     model.delete();
     assert_eq!(restore_whitespace(&tx(&model)), "|");
@@ -1000,7 +1000,7 @@ fn delete_second_mention_of_multiple() {
     model.delete();
     assert_eq!(
         restore_whitespace(&tx(&model)),
-        "<a href=\"https://matrix.to/#/@test:example.org\" contenteditable=\"false\">first</a> |"
+        "<a data-mention-type=\"user\" href=\"https://matrix.to/#/@test:example.org\" contenteditable=\"false\">first</a> |"
     );
 }
 

--- a/crates/wysiwyg/src/tests/test_mentions.rs
+++ b/crates/wysiwyg/src/tests/test_mentions.rs
@@ -68,7 +68,7 @@ fn inserting_with_external_user_works() {
         "@Alice".into(),
         vec![],
     );
-    assert_eq!(tx(&model), "<a href=\"https://custom.custom.com/?secretstuff/#/@alice:example.org\" contenteditable=\"false\">@Alice</a>&nbsp;|");
+    assert_eq!(tx(&model), "<a data-mention-type=\"user\" href=\"https://custom.custom.com/?secretstuff/#/@alice:example.org\" contenteditable=\"false\">@Alice</a>&nbsp;|");
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn inserting_with_external_room_works() {
         "some room".into(),
         vec![],
     );
-    assert_eq!(tx(&model), "<a href=\"https://custom.custom.com/?secretstuff/#/!roomid:example.org\" contenteditable=\"false\">some room</a>&nbsp;|");
+    assert_eq!(tx(&model), "<a data-mention-type=\"room\" href=\"https://custom.custom.com/?secretstuff/#/!roomid:example.org\" contenteditable=\"false\">some room</a>&nbsp;|");
 }
 
 /**

--- a/crates/wysiwyg/src/tests/test_mentions.rs
+++ b/crates/wysiwyg/src/tests/test_mentions.rs
@@ -53,7 +53,7 @@ fn inserting_with_user_url_inserts_user_type() {
 #[test]
 fn inserting_with_at_room_inner_text_inserts_at_room_type() {
     let mut model = cm("|");
-    model.insert_mention("could_be_anything".into(), "@room".into(), vec![]);
+    model.insert_at_room_mention(vec![]);
     assert_eq!(tx(&model), "<a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a>&nbsp;|");
 }
 
@@ -591,7 +591,7 @@ fn selection_paragraph_spanning() {
 fn can_insert_at_room_mention() {
     let mut model = cm("|");
     model.insert_at_room_mention(vec![("style".into(), "some css".into())]);
-    assert_eq!(tx(&model), "<a style=\"some css\" href=\"#\" contenteditable=\"false\">@room</a>&nbsp;|")
+    assert_eq!(tx(&model), "<a style=\"some css\" data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a>&nbsp;|")
 }
 
 /**

--- a/crates/wysiwyg/src/tests/test_to_message_html.rs
+++ b/crates/wysiwyg/src/tests/test_to_message_html.rs
@@ -38,12 +38,9 @@ fn only_outputs_href_attribute_on_user_mention() {
     model.insert_mention(
         "https://matrix.to/#/@alice:matrix.org".into(),
         "inner text".into(),
-        vec![
-            ("data-mention-type".into(), "user".into()),
-            ("style".into(), "some css".into()),
-        ],
+        vec![("style".into(), "some css".into())],
     );
-    assert_eq!(tx(&model), "<a data-mention-type=\"user\" style=\"some css\" href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\">inner text</a>&nbsp;|");
+    assert_eq!(tx(&model), "<a style=\"some css\" data-mention-type=\"user\" href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\">inner text</a>&nbsp;|");
 
     let message_output = model.get_content_as_message_html();
     assert_eq!(
@@ -58,12 +55,9 @@ fn only_outputs_href_attribute_on_room_mention_and_uses_mx_id() {
     model.insert_mention(
         "https://matrix.to/#/#alice:matrix.org".into(),
         "inner text".into(),
-        vec![
-            ("data-mention-type".into(), "room".into()),
-            ("style".into(), "some css".into()),
-        ],
+        vec![("style".into(), "some css".into())],
     );
-    assert_eq!(tx(&model), "<a data-mention-type=\"room\" style=\"some css\" href=\"https://matrix.to/#/#alice:matrix.org\" contenteditable=\"false\">inner text</a>&nbsp;|");
+    assert_eq!(tx(&model), "<a style=\"some css\" data-mention-type=\"room\" href=\"https://matrix.to/#/#alice:matrix.org\" contenteditable=\"false\">inner text</a>&nbsp;|");
 
     let message_output = model.get_content_as_message_html();
     assert_eq!(

--- a/crates/wysiwyg/src/tests/test_to_message_html.rs
+++ b/crates/wysiwyg/src/tests/test_to_message_html.rs
@@ -70,7 +70,7 @@ fn only_outputs_href_attribute_on_room_mention_and_uses_mx_id() {
 fn only_outputs_href_inner_text_for_at_room_mention() {
     let mut model = cm("|");
     model.insert_at_room_mention(vec![("style".into(), "some css".into())]);
-    assert_eq!(tx(&model), "<a style=\"some css\" href=\"#\" contenteditable=\"false\">@room</a>&nbsp;|");
+    assert_eq!(tx(&model), "<a style=\"some css\" data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a>&nbsp;|");
 
     let message_output = model.get_content_as_message_html();
     assert_eq!(message_output, "@room\u{a0}");

--- a/platforms/web/.eslintrc.json
+++ b/platforms/web/.eslintrc.json
@@ -27,7 +27,7 @@
                 "leadingUnderscore": "allow"
             }
         ],
-        "max-len": ["error", { "code": 80, "ignoreUrls": true }],
+        "max-len": ["error", { "code": 120, "ignoreUrls": true }],
         "matrix-org/require-copyright-header": "error",
         "prettier/prettier": "error"
     }

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -75,6 +75,11 @@ export function processInput(
         case 'insertAtRoomSuggestion': {
             if (suggestion && isAtRoomSuggestionEvent(event)) {
                 const { attributes } = event.data;
+                // we need to track data-mention-type in element web, ensure we do not pass
+                // it in as rust model can handle this automatically
+                if (attributes.has('data-mention-type')) {
+                    attributes.delete('data-mention-type');
+                }
                 return action(
                     composerModel.insert_at_room_mention_at_suggestion(
                         suggestion,
@@ -88,7 +93,11 @@ export function processInput(
         case 'insertSuggestion': {
             if (suggestion && isSuggestionEvent(event)) {
                 const { text, url, attributes } = event.data;
-
+                // we need to track data-mention-type in element web, ensure we do not pass
+                // it in as rust model can handle this automatically
+                if (attributes.has('data-mention-type')) {
+                    attributes.delete('data-mention-type');
+                }
                 return action(
                     composerModel.insert_mention_at_suggestion(
                         url,

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -23,6 +23,7 @@ import {
     WysiwygEvent,
 } from './types';
 import {
+    isAtRoomSuggestionEvent,
     isClipboardEvent,
     isLinkEvent,
     isSuggestionEvent,
@@ -71,19 +72,22 @@ export function processInput(
     }
 
     switch (event.inputType) {
+        case 'insertAtRoomSuggestion': {
+            if (suggestion && isAtRoomSuggestionEvent(event)) {
+                const { attributes } = event.data;
+                return action(
+                    composerModel.insert_at_room_mention_at_suggestion(
+                        suggestion,
+                        attributes,
+                    ),
+                    'insert_at_room_mention_at_suggestion',
+                );
+            }
+            break;
+        }
         case 'insertSuggestion': {
             if (suggestion && isSuggestionEvent(event)) {
                 const { text, url, attributes } = event.data;
-
-                if (text === '@room' && url === '#') {
-                    return action(
-                        composerModel.insert_at_room_mention_at_suggestion(
-                            suggestion,
-                            attributes,
-                        ),
-                        'insert_at_room_mention_at_suggestion',
-                    );
-                }
 
                 return action(
                     composerModel.insert_mention_at_suggestion(

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -74,7 +74,6 @@ export function processInput(
         case 'insertSuggestion': {
             if (suggestion && isSuggestionEvent(event)) {
                 const { text, url, attributes } = event.data;
-                const attributesMap = new Map(Object.entries(attributes));
 
                 if (text === '@room' && url === '#') {
                     return action(
@@ -91,7 +90,7 @@ export function processInput(
                         url,
                         text,
                         suggestion,
-                        attributesMap,
+                        attributes,
                     ),
                     'insert_mention_at_suggestion',
                 );

--- a/platforms/web/lib/composer.ts
+++ b/platforms/web/lib/composer.ts
@@ -79,7 +79,7 @@ export function processInput(
                     return action(
                         composerModel.insert_at_room_mention_at_suggestion(
                             suggestion,
-                            attributesMap,
+                            attributes,
                         ),
                         'insert_at_room_mention_at_suggestion',
                     );

--- a/platforms/web/lib/testUtils/Editor.tsx
+++ b/platforms/web/lib/testUtils/Editor.tsx
@@ -121,9 +121,7 @@ export const Editor = forwardRef<HTMLDivElement, EditorProps>(function Editor(
                     wysiwyg.mention(
                         'https://matrix.to/#/@test_user:element.io',
                         'test user',
-                        {
-                            'data-mention-type': 'user',
-                        },
+                        new Map(),
                     );
                 }}
             >

--- a/platforms/web/lib/testUtils/Editor.tsx
+++ b/platforms/web/lib/testUtils/Editor.tsx
@@ -57,6 +57,7 @@ export const Editor = forwardRef<HTMLDivElement, EditorProps>(function Editor(
             | 'command'
             | 'indent'
             | 'unindent'
+            | 'mentionAtRoom'
         >
     >;
 

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -46,6 +46,7 @@ export type FormattingFunctions = Record<
         text: string,
         attributes: AllowedMentionAttributes,
     ) => void;
+    mentionAtRoom: (attributes: AllowedMentionAttributes) => void;
     command: (text: string) => void;
     removeLinks: () => void;
     getLink: () => string;

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ACTION_TYPES, SUGGESTIONS } from './constants';
-import { Attributes, LinkEvent } from './useListeners/types';
+import { AllowedMentionAttributes, LinkEvent } from './useListeners/types';
 
 export type BlockType = InputEvent['inputType'] | 'formatInlineCode' | 'clear';
 
@@ -41,7 +41,11 @@ export type FormattingFunctions = Record<
 > & {
     insertText: (text: string) => void;
     link: (url: string, text?: string) => void;
-    mention: (url: string, text: string, attributes: Attributes) => void;
+    mention: (
+        url: string,
+        text: string,
+        attributes: AllowedMentionAttributes,
+    ) => void;
     command: (text: string) => void;
     removeLinks: () => void;
     getLink: () => string;

--- a/platforms/web/lib/useFormattingFunctions.ts
+++ b/platforms/web/lib/useFormattingFunctions.ts
@@ -20,6 +20,7 @@ import { BlockType, FormattingFunctions } from './types';
 import { sendWysiwygInputEvent } from './useListeners';
 import {
     AllowedMentionAttributes,
+    AtRoomSuggestionEvent,
     LinkEvent,
     SuggestionEvent,
 } from './useListeners/types';
@@ -36,7 +37,11 @@ export function useFormattingFunctions(
         // and we do not use the browser input event handling
         const sendEvent = (
             blockType: BlockType,
-            data?: string | LinkEvent['data'] | SuggestionEvent['data'],
+            data?:
+                | string
+                | LinkEvent['data']
+                | SuggestionEvent['data']
+                | AtRoomSuggestionEvent['data'],
         ) =>
             editorRef.current &&
             sendWysiwygInputEvent(
@@ -73,6 +78,8 @@ export function useFormattingFunctions(
                 attributes: AllowedMentionAttributes,
             ) => sendEvent('insertSuggestion', { url, text, attributes }),
             command: (text: string) => sendEvent('insertCommand', text),
+            mentionAtRoom: (attributes: AllowedMentionAttributes) =>
+                sendEvent('insertAtRoomSuggestion', { attributes }),
         };
     }, [editorRef, composerModel]);
 

--- a/platforms/web/lib/useFormattingFunctions.ts
+++ b/platforms/web/lib/useFormattingFunctions.ts
@@ -18,7 +18,11 @@ import { RefObject, useMemo } from 'react';
 
 import { BlockType, FormattingFunctions } from './types';
 import { sendWysiwygInputEvent } from './useListeners';
-import { Attributes, LinkEvent, SuggestionEvent } from './useListeners/types';
+import {
+    AllowedMentionAttributes,
+    LinkEvent,
+    SuggestionEvent,
+} from './useListeners/types';
 import { ComposerModel } from '../generated/wysiwyg';
 
 export function useFormattingFunctions(
@@ -63,8 +67,11 @@ export function useFormattingFunctions(
             quote: () => sendEvent('insertQuote'),
             indent: () => sendEvent('formatIndent'),
             unindent: () => sendEvent('formatOutdent'),
-            mention: (url: string, text: string, attributes: Attributes) =>
-                sendEvent('insertSuggestion', { url, text, attributes }),
+            mention: (
+                url: string,
+                text: string,
+                attributes: AllowedMentionAttributes,
+            ) => sendEvent('insertSuggestion', { url, text, attributes }),
             command: (text: string) => sendEvent('insertCommand', text),
         };
     }, [editorRef, composerModel]);

--- a/platforms/web/lib/useListeners/assert.ts
+++ b/platforms/web/lib/useListeners/assert.ts
@@ -28,6 +28,10 @@ export function isSuggestionEvent(e: Event): e is SuggestionEvent {
     return isInputEvent(e) && e.inputType === 'insertSuggestion';
 }
 
+export function isAtRoomSuggestionEvent(e: Event): e is SuggestionEvent {
+    return isInputEvent(e) && e.inputType === 'insertAtRoomSuggestion';
+}
+
 export function isLinkEvent(e: Event): e is LinkEvent {
     return isInputEvent(e) && e.inputType == 'insertLink';
 }

--- a/platforms/web/lib/useListeners/event.ts
+++ b/platforms/web/lib/useListeners/event.ts
@@ -36,7 +36,7 @@ import {
 import { TestUtilities } from '../useTestCases/types';
 import { AllActionStates } from '../types';
 import { mapToAllActionStates } from './utils';
-import { LinkEvent } from './types';
+import { AtRoomSuggestionEvent, LinkEvent, SuggestionEvent } from './types';
 
 /**
  * Send a custom event named wysiwygInput
@@ -50,7 +50,11 @@ export function sendWysiwygInputEvent(
     editor: HTMLElement,
     blockType: BlockType,
     e?: ReactMouseEvent<HTMLElement, MouseEvent> | KeyboardEvent,
-    data?: string | LinkEvent['data'],
+    data?:
+        | string
+        | LinkEvent['data']
+        | SuggestionEvent['data']
+        | AtRoomSuggestionEvent['data'],
 ) {
     e?.preventDefault();
     e?.stopPropagation();

--- a/platforms/web/lib/useListeners/types.ts
+++ b/platforms/web/lib/useListeners/types.ts
@@ -26,9 +26,7 @@ export type LinkEvent = Omit<InputEvent, 'data'> & {
     data: { url: string; text?: string };
 };
 
-export type AllowedMentionAttributes = {
-    style?: string;
-};
+export type AllowedMentionAttributes = Map<'style', string>;
 
 export type SuggestionEvent = Omit<InputEvent, 'data'> & {
     inputType: 'insertSuggestion';

--- a/platforms/web/lib/useListeners/types.ts
+++ b/platforms/web/lib/useListeners/types.ts
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { HTMLAttributes } from 'react';
-
 import { BlockType } from '../types';
 
 export type FormatBlockEvent = CustomEvent<{
@@ -28,15 +26,11 @@ export type LinkEvent = Omit<InputEvent, 'data'> & {
     data: { url: string; text?: string };
 };
 
-type AnchorElementAttributes =
-    | keyof HTMLAttributes<HTMLAnchorElement>
-    | `data-${string}`;
-
-export type Attributes = {
-    [K in AnchorElementAttributes]?: string;
+export type AllowedMentionAttributes = {
+    style?: string;
 };
 
 export type SuggestionEvent = Omit<InputEvent, 'data'> & {
     inputType: 'insertSuggestion';
-    data: { url: string; text: string; attributes: Attributes };
+    data: { url: string; text: string; attributes: AllowedMentionAttributes };
 };

--- a/platforms/web/lib/useListeners/types.ts
+++ b/platforms/web/lib/useListeners/types.ts
@@ -32,3 +32,8 @@ export type SuggestionEvent = Omit<InputEvent, 'data'> & {
     inputType: 'insertSuggestion';
     data: { url: string; text: string; attributes: AllowedMentionAttributes };
 };
+
+export type AtRoomSuggestionEvent = Omit<InputEvent, 'data'> & {
+    inputType: 'insertAtRoomSuggestion';
+    data: { attributes: AllowedMentionAttributes };
+};

--- a/platforms/web/lib/useListeners/types.ts
+++ b/platforms/web/lib/useListeners/types.ts
@@ -26,7 +26,10 @@ export type LinkEvent = Omit<InputEvent, 'data'> & {
     data: { url: string; text?: string };
 };
 
-export type AllowedMentionAttributes = Map<'style', string>;
+export type AllowedMentionAttributes = Map<
+    'style' | 'data-mention-type',
+    string
+>;
 
 export type SuggestionEvent = Omit<InputEvent, 'data'> & {
     inputType: 'insertSuggestion';

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -109,6 +109,6 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
         },
         suggestion: memoisedMappedSuggestion,
         getMessageHTMLContent: () =>
-            composerModel?.get_content_as_message_html() ?? '',
+            composerModel?.get_content_as_message_html() ?? null,
     };
 }

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -108,7 +108,6 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
             traceAction: testUtilities.traceAction,
         },
         suggestion: memoisedMappedSuggestion,
-        getMessageHTMLContent: () =>
-            composerModel?.get_content_as_message_html() ?? null,
+        messageContent: composerModel?.get_content_as_message_html() ?? null,
     };
 }

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -108,5 +108,7 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
             traceAction: testUtilities.traceAction,
         },
         suggestion: memoisedMappedSuggestion,
+        getMessageHTMLContent: () =>
+            composerModel?.get_content_as_message_html() ?? '',
     };
 }

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -205,6 +205,7 @@ function App() {
                                                     'style',
                                                     'background-color:#d5f9d5',
                                                 ],
+                                                ['data-mention-type', 'user'],
                                             ]),
                                         )
                                     }

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -200,9 +200,12 @@ function App() {
                                         wysiwyg.mention(
                                             'https://matrix.to/#/@alice_user:element.io',
                                             'Alice',
-                                            {
-                                                style: 'background-color:#d5f9d5',
-                                            },
+                                            new Map([
+                                                [
+                                                    'style',
+                                                    'background-color:#d5f9d5',
+                                                ],
+                                            ]),
                                         )
                                     }
                                 >
@@ -211,9 +214,16 @@ function App() {
                                 <button
                                     type="button"
                                     onClick={(_e) =>
-                                        wysiwyg.mention('#', '@room', {
-                                            style: 'background-color:#d5f9d5',
-                                        })
+                                        wysiwyg.mention(
+                                            '#',
+                                            '@room',
+                                            new Map([
+                                                [
+                                                    'style',
+                                                    'background-color:#d5f9d5',
+                                                ],
+                                            ]),
+                                        )
                                     }
                                 >
                                     Add at-room mention
@@ -227,9 +237,12 @@ function App() {
                                     wysiwyg.mention(
                                         'https://matrix.to/#/#my_room:element.io',
                                         'My room',
-                                        {
-                                            'data-mention-type': 'room',
-                                        },
+                                        new Map([
+                                            [
+                                                'style',
+                                                'background-color:#d5f9d5',
+                                            ],
+                                        ]),
                                     )
                                 }
                             >

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -201,7 +201,7 @@ function App() {
                                             'https://matrix.to/#/@alice_user:element.io',
                                             'Alice',
                                             {
-                                                'data-mention-type': 'user',
+                                                style: 'background-color:#d5f9d5',
                                             },
                                         )
                                     }
@@ -212,7 +212,7 @@ function App() {
                                     type="button"
                                     onClick={(_e) =>
                                         wysiwyg.mention('#', '@room', {
-                                            'data-mention-type': 'at-room',
+                                            style: 'background-color:#d5f9d5',
                                         })
                                     }
                                 >

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -214,9 +214,7 @@ function App() {
                                 <button
                                     type="button"
                                     onClick={(_e) =>
-                                        wysiwyg.mention(
-                                            '#',
-                                            '@room',
+                                        wysiwyg.mentionAtRoom(
                                             new Map([
                                                 [
                                                     'style',


### PR DESCRIPTION
This PR:

- "unhooks" the attributes from the mobile side of things - they no longer need to pass in any attributes as per this issue https://github.com/matrix-org/matrix-rich-text-editor/issues/721, but still require removal from the mobile side of the codebase
- makes the addition of `data-mention-type` automatic
- updates the tests to reflect this new behaviour
- stops web passing in the unneeded `data-mention-type` attribute in web, and changes the type for attributes to a map
- associated event/type changes in web to allow us to get the formatted message output and also to handle at room mentions using the new exposed api function