### PR TITLE
Use correct message output format in conversion function

### DIFF
--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -99,46 +99,60 @@ describe('Plain text <=> markdown', () => {
     });
 });
 
-describe('Mentions conversion from plain text to rich', () => {
-    it('converts at-room mentions as expected', async () => {
+describe('Mentions', () => {
+    it('converts at-room mentions for composer as expected', async () => {
         const input = '@room';
         const asComposerHtml = await plainToRich(input);
-        const asMessageHtml = await plainToRich(input, true);
 
-        // for this case, we'd expect the composer html to be an <a> tag, whereas
-        // the message html should be the equivalent plain text
         expect(asComposerHtml).toBe(
             '<a data-mention-type="at-room" href="#" contenteditable="false">@room</a>',
         );
+    });
+
+    it('converts at-room mentions for message as expected', async () => {
+        const input = '@room';
+        const asMessageHtml = await plainToRich(input, true);
+
         expect(asMessageHtml).toBe('@room');
     });
 
-    it('converts user mentions as expected', async () => {
+    it('converts user mentions for composer as expected', async () => {
         const input =
             '<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
         const asComposerHtml = await plainToRich(input);
-        const asMessageHtml = await plainToRich(input, true);
 
-        // for this case, we'd expect the composer html to be an <a> tag, whereas
-        // the message html should be the equivalent plain text
         expect(asComposerHtml).toMatchInlineSnapshot(
             '"<a style=\\"some styling\\" data-mention-type=\\"user\\" href=\\"https://matrix.to/#/@test_user:element.io\\" contenteditable=\\"false\\">a test user</a> "',
         );
+    });
+
+    it('converts user mentions for message as expected', async () => {
+        const input =
+            '<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
+        const asMessageHtml = await plainToRich(input, true);
+
         expect(asMessageHtml).toMatchInlineSnapshot(
             '"<a href=\\"https://matrix.to/#/@test_user:element.io\\">a test user</a> "',
         );
     });
 
-    it('converts room mentions as expected', async () => {
+    it('converts room mentions for composer as expected', async () => {
         const input =
             '<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
         const asComposerHtml = await plainToRich(input);
-        const asMessageHtml = await plainToRich(input, true);
 
-        // note here that the message html includes the mx_id as the message content
+        // note inner text is the same as the input inner text
         expect(asComposerHtml).toMatchInlineSnapshot(
             '"<a style=\\"some styling\\" data-mention-type=\\"room\\" href=\\"https://matrix.to/#/#test_room:element.io\\" contenteditable=\\"false\\">a test user</a> "',
         );
+    });
+
+    it('converts room mentions for message as expected', async () => {
+        const input =
+            '<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
+        const asMessageHtml = await plainToRich(input, true);
+
+        // note inner text is the mx id
         expect(asMessageHtml).toMatchInlineSnapshot(
             '"<a href=\\"https://matrix.to/#/#test_room:element.io\\">#test_room:element.io</a> "',
         );

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -98,3 +98,49 @@ describe('Plain text <=> markdown', () => {
         expect(convertedPlainText).toBe(expectedPlainText);
     });
 });
+
+describe('Mentions conversion from plain text to rich', () => {
+    it('converts at-room mentions as expected', async () => {
+        const input = '@room';
+        const asComposerHtml = await plainToRich(input);
+        const asMessageHtml = await plainToRich(input, true);
+
+        // for this case, we'd expect the composer html to be an <a> tag, whereas
+        // the message html should be the equivalent plain text
+        expect(asComposerHtml).toBe(
+            '<a data-mention-type="at-room" href="#" contenteditable="false">@room</a>',
+        );
+        expect(asMessageHtml).toBe('@room');
+    });
+
+    it('converts user mentions as expected', async () => {
+        const input =
+            '<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
+        const asComposerHtml = await plainToRich(input);
+        const asMessageHtml = await plainToRich(input, true);
+
+        // for this case, we'd expect the composer html to be an <a> tag, whereas
+        // the message html should be the equivalent plain text
+        expect(asComposerHtml).toMatchInlineSnapshot(
+            '"<a style=\\"some styling\\" data-mention-type=\\"user\\" href=\\"https://matrix.to/#/@test_user:element.io\\" contenteditable=\\"false\\">a test user</a> "',
+        );
+        expect(asMessageHtml).toMatchInlineSnapshot(
+            '"<a href=\\"https://matrix.to/#/@test_user:element.io\\">a test user</a> "',
+        );
+    });
+
+    it('converts room mentions as expected', async () => {
+        const input =
+            '<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
+        const asComposerHtml = await plainToRich(input);
+        const asMessageHtml = await plainToRich(input, true);
+
+        // note here that the message html includes the mx_id as the message content
+        expect(asComposerHtml).toMatchInlineSnapshot(
+            '"<a style=\\"some styling\\" data-mention-type=\\"room\\" href=\\"https://matrix.to/#/#test_room:element.io\\" contenteditable=\\"false\\">a test user</a> "',
+        );
+        expect(asMessageHtml).toMatchInlineSnapshot(
+            '"<a href=\\"https://matrix.to/#/#test_room:element.io\\">#test_room:element.io</a> "',
+        );
+    });
+});

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -35,7 +35,7 @@ describe('Rich text <=> plain text', () => {
     test.each(mappedTestCases)(
         'rich: `%s` - plain: `%s`',
         async (rich, plain) => {
-            const convertedRichText = await plainToRich(plain);
+            const convertedRichText = await plainToRich(plain, false);
             const convertedPlainText = await richToPlain(rich);
 
             expect(convertedRichText).toBe(rich);
@@ -53,7 +53,7 @@ describe('Rich text <=> plain text', () => {
 
     it('converts linebreaks for display plain => rich', async () => {
         const plainText = 'multi\nline';
-        const convertedRichText = await plainToRich(plainText);
+        const convertedRichText = await plainToRich(plainText, false);
         const expectedRichText = 'multi<br />line';
 
         expect(convertedRichText).toBe(expectedRichText);
@@ -102,7 +102,7 @@ describe('Plain text <=> markdown', () => {
 describe('Mentions', () => {
     it('converts at-room mentions for composer as expected', async () => {
         const input = '@room';
-        const asComposerHtml = await plainToRich(input);
+        const asComposerHtml = await plainToRich(input, false);
 
         expect(asComposerHtml).toBe(
             '<a data-mention-type="at-room" href="#" contenteditable="false">@room</a>',
@@ -119,7 +119,7 @@ describe('Mentions', () => {
     it('converts user mentions for composer as expected', async () => {
         const input =
             '<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
-        const asComposerHtml = await plainToRich(input);
+        const asComposerHtml = await plainToRich(input, false);
 
         expect(asComposerHtml).toMatchInlineSnapshot(
             '"<a style=\\"some styling\\" data-mention-type=\\"user\\" href=\\"https://matrix.to/#/@test_user:element.io\\" contenteditable=\\"false\\">a test user</a> "',
@@ -139,7 +139,7 @@ describe('Mentions', () => {
     it('converts room mentions for composer as expected', async () => {
         const input =
             '<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
-        const asComposerHtml = await plainToRich(input);
+        const asComposerHtml = await plainToRich(input, false);
 
         // note inner text is the same as the input inner text
         expect(asComposerHtml).toMatchInlineSnapshot(

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -83,7 +83,7 @@ export async function plainToRich(plainText: string) {
     // set the model and return the rich text
     const model = new_composer_model();
     model.set_content_from_markdown(markdown);
-    const richText = model.get_content_as_html();
+    const richText = model.get_content_as_message_html();
 
     return richText;
 }

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -67,7 +67,7 @@ export async function richToPlain(richText: string) {
     return plainText;
 }
 
-export async function plainToRich(plainText: string, inMessageFormat = false) {
+export async function plainToRich(plainText: string, inMessageFormat: boolean) {
     if (plainText.length === 0) {
         return '';
     }

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -67,7 +67,7 @@ export async function richToPlain(richText: string) {
     return plainText;
 }
 
-export async function plainToRich(plainText: string) {
+export async function plainToRich(plainText: string, inMessageFormat = false) {
     if (plainText.length === 0) {
         return '';
     }
@@ -83,7 +83,8 @@ export async function plainToRich(plainText: string) {
     // set the model and return the rich text
     const model = new_composer_model();
     model.set_content_from_markdown(markdown);
-    const richText = model.get_content_as_message_html();
 
-    return richText;
+    return inMessageFormat
+        ? model.get_content_as_message_html()
+        : model.get_content_as_html();
 }


### PR DESCRIPTION
I missed that this function would also require switching over to the new message format output function. Have updated the function to allow us to choose if we want the output from this call in message format or not, then added tests.

This is required due to where we call this from in the client, as we call it when converting between composers and also when sending a message.