### PR TITLE
Support initialising composer with mentions

### DIFF
--- a/platforms/web/lib/useComposerModel.test.tsx
+++ b/platforms/web/lib/useComposerModel.test.tsx
@@ -1,0 +1,110 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { RefObject } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import * as mockRustModel from '../generated/wysiwyg';
+import { useComposerModel } from './useComposerModel';
+
+describe('useComposerModel', () => {
+    const mockComposer = document.createElement('div');
+    const mockNullRef = { current: null } as RefObject<null>;
+    const mockComposerRef = { current: mockComposer } as RefObject<HTMLElement>;
+
+    beforeEach(() => {
+        vi.spyOn(mockRustModel, 'new_composer_model');
+        vi.spyOn(mockRustModel, 'new_composer_model_from_html');
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('Does not create a composerModel without a ref', () => {
+        const { result } = renderHook(() => useComposerModel(mockNullRef));
+
+        expect(result.current.composerModel).toBeNull();
+    });
+
+    it('Only calls `new_composer_model` if ref exists but no initial content exists', async () => {
+        const { result } = renderHook(() => useComposerModel(mockComposerRef));
+
+        // wait for the composerModel to be created
+        await waitFor(() => {
+            expect(result.current.composerModel).not.toBeNull();
+        });
+
+        // check only new_composer_model has been called
+        expect(mockRustModel.new_composer_model).toHaveBeenCalledTimes(1);
+        expect(
+            mockRustModel.new_composer_model_from_html,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('Calls `new_composer_model_from_html` if ref and initial content exists', async () => {
+        const { result } = renderHook(() =>
+            useComposerModel(mockComposerRef, 'some content'),
+        );
+
+        // wait for the composerModel to be created
+        await waitFor(() => {
+            expect(result.current.composerModel).not.toBeNull();
+        });
+
+        // check only new_composer_model_from_html has been called
+        expect(
+            mockRustModel.new_composer_model_from_html,
+        ).toHaveBeenCalledTimes(1);
+        expect(mockRustModel.new_composer_model).not.toHaveBeenCalled();
+    });
+
+    it('Sets the ref inner html when initial content is valid html', async () => {
+        const inputContent = `<a href="this is allowed" other="disallowedattribute">test link</a>`;
+
+        // the rust model will strip "bad" attributes and the hook always adds a trailing <br>
+        const expectedComposerInnerHtml = `<a href="this is allowed">test link</a><br>`;
+        const { result } = renderHook(() =>
+            useComposerModel(mockComposerRef, inputContent),
+        );
+
+        // wait for the composerModel to be created
+        await waitFor(() => {
+            expect(result.current.composerModel).not.toBeNull();
+        });
+
+        // check that the content of the div is the rust model output
+        expect(mockComposer.innerHTML).toBe(expectedComposerInnerHtml);
+    });
+
+    it('Falls back to calling `new_composer_model` if there is a parsing error', async () => {
+        // Use badly formed initial content to cause a html parsing error
+        const { result } = renderHook(() =>
+            useComposerModel(mockComposerRef, '<badly>formed content</>'),
+        );
+
+        // wait for the composerModel to be created
+        await waitFor(() => {
+            expect(result.current.composerModel).not.toBeNull();
+        });
+
+        // check that both functions have been called
+        expect(
+            mockRustModel.new_composer_model_from_html,
+        ).toHaveBeenCalledTimes(1);
+        expect(mockRustModel.new_composer_model).toHaveBeenCalledTimes(1);
+    });
+});

--- a/platforms/web/lib/useComposerModel.test.tsx
+++ b/platforms/web/lib/useComposerModel.test.tsx
@@ -21,17 +21,26 @@ import * as mockRustModel from '../generated/wysiwyg';
 import { useComposerModel } from './useComposerModel';
 
 describe('useComposerModel', () => {
-    const mockComposer = document.createElement('div');
-    const mockNullRef = { current: null } as RefObject<null>;
-    const mockComposerRef = { current: mockComposer } as RefObject<HTMLElement>;
+    let mockComposer: HTMLDivElement;
+    let mockNullRef: RefObject<null>;
+    let mockComposerRef: RefObject<HTMLElement>;
 
     beforeEach(() => {
+        mockComposer = document.createElement('div');
+        mockNullRef = { current: null };
+        mockComposerRef = {
+            current: mockComposer,
+        };
         vi.spyOn(mockRustModel, 'new_composer_model');
         vi.spyOn(mockRustModel, 'new_composer_model_from_html');
     });
 
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    afterAll(() => {
+        vi.restoreAllMocks();
     });
 
     it('Does not create a composerModel without a ref', () => {

--- a/platforms/web/lib/useComposerModel.ts
+++ b/platforms/web/lib/useComposerModel.ts
@@ -85,6 +85,7 @@ export function useComposerModel(
                         );
                     }
                 } catch (e) {
+                    // if the initialisation fails, due to a parsing failure of the html, fallback to an empty composer
                     setComposerModel(new_composer_model());
                 }
             } else {
@@ -100,10 +101,7 @@ export function useComposerModel(
         }
     }, [editorRef, initModel, initialContent]);
 
-    // If a panic occurs, call this function to attempt to reinitialise the composer
-    // with some plain text (called in useListeners). If this were to be called with invalid
-    // html, the initialisation may also fail, in that case fallback to initialising a new
-    // empty composer.
-
+    // If a panic occurs, we call onError to attempt to reinitialise the composer
+    // with some plain text (called in useListeners).
     return { composerModel, onError: initModel };
 }

--- a/platforms/web/lib/useComposerModel.ts
+++ b/platforms/web/lib/useComposerModel.ts
@@ -76,6 +76,8 @@ export function useComposerModel(
                     setComposerModel(newModel);
 
                     if (editorRef.current) {
+                        // we need to use the rust model as the source of truth, to allow it to do things
+                        // like add attributes to mentions automatically
                         const modelContent = newModel.get_content_as_html();
                         replaceEditor(
                             editorRef.current,

--- a/platforms/web/lib/useComposerModel.ts
+++ b/platforms/web/lib/useComposerModel.ts
@@ -68,20 +68,20 @@ export function useComposerModel(
 
             if (initialContent) {
                 try {
-                    setComposerModel(
-                        new_composer_model_from_html(
-                            initialContent,
-                            0,
-                            initialContent.length,
-                        ),
+                    const newModel = new_composer_model_from_html(
+                        initialContent,
+                        0,
+                        initialContent.length,
                     );
+                    setComposerModel(newModel);
 
                     if (editorRef.current) {
+                        const modelContent = newModel.get_content_as_html();
                         replaceEditor(
                             editorRef.current,
-                            initialContent,
+                            modelContent,
                             0,
-                            initialContent.length,
+                            modelContent.length,
                         );
                     }
                 } catch (e) {
@@ -100,5 +100,10 @@ export function useComposerModel(
         }
     }, [editorRef, initModel, initialContent]);
 
-    return { composerModel, initModel };
+    // If a panic occurs, call this function to attempt to reinitialise the composer
+    // with some plain text (called in useListeners). If this were to be called with invalid
+    // html, the initialisation may also fail, in that case fallback to initialising a new
+    // empty composer.
+
+    return { composerModel, onError: initModel };
 }

--- a/platforms/web/lib/useListeners/useListeners.ts
+++ b/platforms/web/lib/useListeners/useListeners.ts
@@ -42,11 +42,10 @@ export function useListeners(
     testUtilities: TestUtilities,
     formattingFunctions: FormattingFunctions,
     onError: (content?: string) => void,
-    initialContent?: string,
     inputEventProcessor?: InputEventProcessor,
 ) {
     const [state, setState] = useState<State>({
-        content: initialContent || null,
+        content: null,
         actionStates: createDefaultActionStates(),
         suggestion: null,
     });

--- a/platforms/web/lib/useWysiwyg.test.tsx
+++ b/platforms/web/lib/useWysiwyg.test.tsx
@@ -140,6 +140,19 @@ describe('useWysiwyg', () => {
         );
     });
 
+    test.only('Initialising composer with a mention displays all mention attributes', async () => {
+        const testUser = 'TEST_USER';
+        const content = `<a href="https://matrix.to/#/@test_user:element.io">${testUser}</a> `;
+        render(<Editor initialContent={content} />);
+
+        // Wait for the mention to appear on the screen, then check it has the attributes
+        // required for correct display in the composer.
+        const mention = await screen.findByText(testUser);
+        expect(mention).toHaveAttribute('data-mention-type');
+        expect(mention).toHaveAttribute('style');
+        expect(mention).toHaveAttribute('contenteditable', 'false');
+    });
+
     test('Handle panic', async () => {
         // When
         const content = 'fo<strng>o</strng><br />b<em><kar</em>';

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -79,7 +79,6 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
             testUtilities,
             formattingFunctions,
             onError,
-            wysiwygProps?.initialContent,
             wysiwygProps?.inputEventProcessor,
         );
 

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
+import { RefObject, useEffect, useMemo, useRef } from 'react';
 
 import { InputEventProcessor } from './types.js';
 import { useFormattingFunctions } from './useFormattingFunctions';

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -60,7 +60,7 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
     const ref = useEditor();
     const modelRef = useRef<HTMLDivElement>(null);
 
-    const { composerModel, initModel } = useComposerModel(
+    const { composerModel, onError } = useComposerModel(
         ref,
         wysiwygProps?.initialContent,
     );
@@ -70,11 +70,6 @@ export function useWysiwyg(wysiwygProps?: WysiwygProps) {
     );
 
     const formattingFunctions = useFormattingFunctions(ref, composerModel);
-
-    const onError = useCallback(
-        (content?: string) => initModel(content),
-        [initModel],
-    );
 
     const { content, actionStates, areListenersReady, suggestion } =
         useListeners(


### PR DESCRIPTION
In order to be able to initialise the composer with mentions properly, we can't simply slap the html from the message being edited into the composer (as the rust model needs to deduce and add some attributes to it first, like `data-mention-type` and `contenteditable`).

This PR:

- stops us using the `initialContent` to set any state directly (as this wouldn't work correctly for mentions)
- creates a model from `initialContent` then reads from the model, using the model output to set the composer content
- adds tests for parsing mentions
- adds a test file for the whole `useComposer` hook
