### PR TITLE
Amend web conversion functions

### DIFF
--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -76,66 +76,6 @@ describe('markdownToPlain', () => {
 });
 
 describe('PlainToRich', () => {
-    describe('Mentions', () => {
-        it('converts at-room mentions for composer as expected', async () => {
-            const input = '@room';
-            const asComposerHtml = await plainToRich(input, false);
-
-            expect(asComposerHtml).toBe(
-                '<a data-mention-type="at-room" href="#" contenteditable="false">@room</a>',
-            );
-        });
-
-        it('converts at-room mentions for message as expected', async () => {
-            const input = '@room';
-            const asMessageHtml = await plainToRich(input, true);
-
-            expect(asMessageHtml).toBe('@room');
-        });
-
-        it('converts user mentions for composer as expected', async () => {
-            const input =
-                '<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
-            const asComposerHtml = await plainToRich(input, false);
-
-            expect(asComposerHtml).toMatchInlineSnapshot(
-                '"<a style=\\"some styling\\" data-mention-type=\\"user\\" href=\\"https://matrix.to/#/@test_user:element.io\\" contenteditable=\\"false\\">a test user</a> "',
-            );
-        });
-
-        it('converts user mentions for message as expected', async () => {
-            const input =
-                '<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
-            const asMessageHtml = await plainToRich(input, true);
-
-            expect(asMessageHtml).toMatchInlineSnapshot(
-                '"<a href=\\"https://matrix.to/#/@test_user:element.io\\">a test user</a> "',
-            );
-        });
-
-        it('converts room mentions for composer as expected', async () => {
-            const input =
-                '<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
-            const asComposerHtml = await plainToRich(input, false);
-
-            // note inner text is the same as the input inner text
-            expect(asComposerHtml).toMatchInlineSnapshot(
-                '"<a style=\\"some styling\\" data-mention-type=\\"room\\" href=\\"https://matrix.to/#/#test_room:element.io\\" contenteditable=\\"false\\">a test user</a> "',
-            );
-        });
-
-        it('converts room mentions for message as expected', async () => {
-            const input =
-                '<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
-            const asMessageHtml = await plainToRich(input, true);
-
-            // note inner text is the mx id
-            expect(asMessageHtml).toMatchInlineSnapshot(
-                '"<a href=\\"https://matrix.to/#/#test_room:element.io\\">#test_room:element.io</a> "',
-            );
-        });
-    });
-
     it('handles quotes', async () => {
         const text = '> quote from html';
         const div = document.createElement('div');
@@ -155,26 +95,6 @@ describe('PlainToRich', () => {
 
         const input = div.innerText;
         const expected = '&lt; &gt; &lt;&lt; &gt;&gt; &lt; hi!';
-        const output = await plainToRich(input, true);
-
-        expect(output).toBe(expected);
-    });
-
-    it('does what is expected with an angle bracket', async () => {
-        const input = '> quote from string';
-        const expected = '<blockquote><p>quote from string</p></blockquote>';
-        const output = await plainToRich(input, true);
-
-        expect(output).toBe(expected);
-    });
-
-    it('does not crash with html like input', async () => {
-        const div = document.createElement('div');
-        const text = document.createTextNode('<h1>crash!</h1>');
-        div.appendChild(text);
-
-        const input = div.innerHTML;
-        const expected = '&lt;h1&gt;crash!&lt;/h1&gt;';
         const output = await plainToRich(input, true);
 
         expect(output).toBe(expected);

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -21,19 +21,6 @@ import {
 } from '../generated/wysiwyg.js';
 import { initOnce } from './useComposerModel.js';
 
-// In plain text, due to cursor positioning, ending at a linebreak will
-// include an extra \n, so trim that off if required.
-// We replace the remaining \n with valid markdown before
-// parsing by MarkdownHTMLParser::to_html.
-export const plainToMarkdown = (plainText: string) => {
-    let markdown = plainText;
-    if (markdown.endsWith('\n')) {
-        // manually remove the final linebreak
-        markdown = markdown.slice(0, -1);
-    }
-    return markdown.replaceAll(/\n/g, '<br />');
-};
-
 // In plain text, markdown newlines (displays '\' character followed by
 // a newline character) will be represented as \n for display as the
 // display box can not interpret markdown.
@@ -67,18 +54,14 @@ export async function richToPlain(richText: string) {
     return plainText;
 }
 
-export async function plainToRich(plainText: string, inMessageFormat: boolean) {
-    if (plainText.length === 0) {
+export async function plainToRich(markdown: string, inMessageFormat: boolean) {
+    if (markdown.length === 0) {
         return '';
     }
 
     // this function could be called before initialising the WASM
     // so we need to try to initialise
     await initOnce();
-
-    // convert the plain text into markdown so that we can use it to
-    // set the model
-    const markdown = plainToMarkdown(plainText);
 
     // set the model and return the rich text
     const model = new_composer_model();


### PR DESCRIPTION
Dependent on the blockquote rust fix. In draft until work is carried out to update the state management for the rich text editor in element web (required to be able to use this properly).

This supports work in element web to enable us to better parse the output from the plain text composer by reading from `.innerText` instead of from `.innerHTML`. Required to address P2 for blockquote markdown not working in element web rte in plain mode.

This work removes all the mentions tests as previously, mentions would persist when moving from plain to rich, but not from rich to plain modes. The upcoming PR on element web means that mentions will now become plain text when moving between modes in either direction.