### PR TITLE
Update web text parsing

### DIFF
--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -82,7 +82,7 @@ describe('Rich text <=> plain text', () => {
     });
 });
 
-describe('Plain text <=> markdown', () => {
+describe('markdownToPlain', () => {
     it('converts single linebreak for markdown => plain', () => {
         const markdown = 'multi\\\nline';
         const convertedPlainText = markdownToPlain(markdown);

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -239,6 +239,7 @@ describe('amendHtmlInABetterWay', () => {
         mention.setAttribute('contenteditable', 'false');
         mockComposer.appendChild(mention);
 
+        // eslint-disable-next-line max-len
         const expected = `<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>`;
         expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
     });
@@ -255,6 +256,7 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.appendChild(mention);
         mockComposer.appendChild(document.createTextNode(' following'));
 
+        // eslint-disable-next-line max-len
         const expected = `preceding <a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a> following`;
         expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
     });
@@ -270,6 +272,7 @@ describe('amendHtmlInABetterWay', () => {
         innerDiv.appendChild(mention);
         mockComposer.appendChild(innerDiv);
 
+        // eslint-disable-next-line max-len
         const expected = `<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>`;
         expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
     });
@@ -288,6 +291,7 @@ describe('amendHtmlInABetterWay', () => {
         innerDiv.appendChild(document.createTextNode(' following'));
         mockComposer.appendChild(innerDiv);
 
+        // eslint-disable-next-line max-len
         const expected = `preceding <a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a> following`;
         expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
     });
@@ -306,6 +310,7 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.appendChild(innerDiv);
         mockComposer.appendChild(document.createTextNode('following'));
 
+        // eslint-disable-next-line max-len
         const expected = `preceding\n<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>\nfollowing`;
         expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
     });
@@ -322,6 +327,7 @@ describe('amendHtmlInABetterWay', () => {
             mockComposer.appendChild(mention);
         });
 
+        // eslint-disable-next-line max-len
         const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a><a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a><a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
         expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
     });
@@ -344,6 +350,7 @@ describe('amendHtmlInABetterWay', () => {
             }
         });
 
+        // eslint-disable-next-line max-len
         const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a>\n<a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a>\n<a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
         expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
     });

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -72,6 +72,14 @@ describe('Rich text <=> plain text', () => {
 
         expect(convertedPlainText).toBe(expectedPlainText);
     });
+
+    it.skip('converts blockquotes from plain => rich', async () => {
+        const plainText = '> I am a quote';
+        const convertedRichText = await plainToRich(plainText, false);
+        const expectedRichText = '<blockquote><p>I am a quote</p></blockquote>';
+
+        expect(convertedRichText).toBe(expectedRichText);
+    });
 });
 
 describe('Plain text <=> markdown', () => {
@@ -157,7 +165,7 @@ describe('Mentions', () => {
 // Although a bit clunky, all of these tests simulate a plain text composer by creating a content editable
 // div, appending children to it and then reading the composer's innerHTML. This way we can ensure that we
 // are giving the conversion function decent input for the tests.
-describe('amendHtmlInABetterWay', () => {
+describe('plainTextInnerHtmlToMarkdown', () => {
     let mockComposer: HTMLDivElement;
 
     function createMentionElement(identifier = ''): HTMLAnchorElement {

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -75,25 +75,6 @@ describe('Rich text <=> plain text', () => {
 });
 
 describe('Plain text <=> markdown', () => {
-    // it('converts single linebreak for plain => markdown', () => {
-    //     const plain = 'multi\nline';
-    //     const convertedMarkdown = plainToMarkdown(plain);
-    //     const expectedMarkdown = `multi<br />line`;
-
-    //     expect(convertedMarkdown).toBe(expectedMarkdown);
-    // });
-
-    // it('converts multiple linebreak for plain => markdown', () => {
-    //     // nb for correct display, there will be one br tag less
-    //     // than \n at the end
-    //     const plain = 'multiple\nline\n\nbreaks\n\n\n';
-    //     const convertedMarkdown = plainToMarkdown(plain);
-    //     const expectedMarkdown =
-    //         'multiple<br />line<br /><br />breaks<br /><br />';
-
-    //     expect(convertedMarkdown).toBe(expectedMarkdown);
-    // });
-
     it('converts single linebreak for markdown => plain', () => {
         const markdown = 'multi\\\nline';
         const convertedPlainText = markdownToPlain(markdown);
@@ -181,6 +162,26 @@ describe('amendHtmlInABetterWay', () => {
     beforeEach(() => {
         mockComposer = document.createElement('div');
         mockComposer.setAttribute('contenteditable', 'true');
+    });
+
+    it('can cope with two lines of text, second line empty, shift+enter linebreak entry', () => {
+        const textNode = document.createTextNode('firstline\n\n');
+        mockComposer.appendChild(textNode);
+
+        const expected = 'firstline\n';
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
+    });
+
+    it('can maintain consecutive newlines between text lines', () => {
+        const textNode = document.createTextNode('first\n\n\n\nlast');
+        mockComposer.appendChild(textNode);
+
+        const expected = 'first\n\n\n\nlast';
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with divs with a line break', () => {

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -170,12 +170,19 @@ describe('amendHtmlInABetterWay', () => {
         return mention;
     }
 
+    function createPlaceholderDiv(): HTMLDivElement {
+        const div = document.createElement('div');
+        const br = document.createElement('br');
+        div.appendChild(br);
+        return div;
+    }
+
     beforeEach(() => {
         mockComposer = document.createElement('div');
         mockComposer.setAttribute('contenteditable', 'true');
     });
 
-    it('can cope with two lines of text, second line empty, shift+enter linebreak entry', () => {
+    it('can cope with two lines of text, second line empty, for newline chars', () => {
         const textNode = document.createTextNode('firstline\n\n');
         mockComposer.appendChild(textNode);
 
@@ -185,9 +192,44 @@ describe('amendHtmlInABetterWay', () => {
         );
     });
 
-    it('can maintain consecutive newlines between text lines', () => {
+    it('can cope with two lines of text, second line empty, for placeholder div', () => {
+        const textNode = document.createTextNode('firstline');
+
+        mockComposer.append(textNode, createPlaceholderDiv());
+
+        const expected = 'firstline\n';
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
+    });
+
+    it('can maintain consecutive newlines between text lines for newline chars', () => {
         const textNode = document.createTextNode('first\n\n\n\nlast');
         mockComposer.appendChild(textNode);
+
+        const expected = 'first\n\n\n\nlast';
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
+    });
+
+    it('can maintain consecutive newlines between text lines for placeholder divs', () => {
+        const firstText = document.createTextNode('first');
+
+        // after the placeholders have started, text can only be inserted inside divs
+        const lastDiv = document.createElement('div');
+        const lastText = document.createTextNode('last');
+        lastDiv.appendChild(lastText);
+
+        const children = [
+            firstText,
+            createPlaceholderDiv(),
+            createPlaceholderDiv(),
+            createPlaceholderDiv(),
+            lastDiv,
+        ];
+
+        mockComposer.append(...children);
 
         const expected = 'first\n\n\n\nlast';
         expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -340,17 +340,16 @@ describe('amendHtmlInABetterWay', () => {
         );
     });
 
-    it('can cope with a nested mention next to top level text nodes', () => {
+    it('can cope with a nested mention next to top level text node', () => {
         const innerDiv = document.createElement('div');
         const mention = createMentionElement();
 
         mockComposer.appendChild(document.createTextNode('preceding'));
         innerDiv.appendChild(mention);
         mockComposer.appendChild(innerDiv);
-        mockComposer.appendChild(document.createTextNode('following'));
 
         // eslint-disable-next-line max-len
-        const expected = `preceding\n<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>\nfollowing`;
+        const expected = `preceding\n<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>`;
         expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
             expected,
         );
@@ -370,21 +369,31 @@ describe('amendHtmlInABetterWay', () => {
     });
 
     it('can cope with adjacent nested mentions', () => {
+        const innerDiv = document.createElement('div');
         ['1', '2', '3'].forEach((id) => {
             const mention = createMentionElement(id);
-
-            // nest the middle mention
-            if (id === '2') {
-                const innerDiv = document.createElement('div');
-                innerDiv.appendChild(mention);
-                mockComposer.appendChild(innerDiv);
-            } else {
-                mockComposer.appendChild(mention);
-            }
+            innerDiv.appendChild(mention);
         });
+        mockComposer.appendChild(innerDiv);
 
         // eslint-disable-next-line max-len
-        const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a>\n<a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a>\n<a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
+        const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a><a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a><a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
+    });
+
+    it('can cope with adjacent top level and nested mentions', () => {
+        const topLevelMention = createMentionElement('1');
+        const nestedMention = createMentionElement('2');
+
+        const innerDiv = document.createElement('div');
+        innerDiv.appendChild(nestedMention);
+
+        mockComposer.append(topLevelMention, innerDiv);
+
+        // eslint-disable-next-line max-len
+        const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a>\n<a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a>`;
         expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
             expected,
         );

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -159,6 +159,17 @@ describe('Mentions', () => {
 // are giving the conversion function decent input for the tests.
 describe('amendHtmlInABetterWay', () => {
     let mockComposer: HTMLDivElement;
+
+    function createMentionElement(identifier = ''): HTMLAnchorElement {
+        const mention = document.createElement('a');
+        mention.appendChild(document.createTextNode(`inner text${identifier}`));
+        mention.setAttribute('href', `testHref${identifier}`);
+        mention.setAttribute('data-mention-type', `testType${identifier}`);
+        mention.setAttribute('style', `testStyle${identifier}`);
+        mention.setAttribute('contenteditable', 'false');
+        return mention;
+    }
+
     beforeEach(() => {
         mockComposer = document.createElement('div');
         mockComposer.setAttribute('contenteditable', 'true');
@@ -276,12 +287,7 @@ describe('amendHtmlInABetterWay', () => {
     });
 
     it('can cope with a mention at the top level', () => {
-        const mention = document.createElement('a');
-        mention.appendChild(document.createTextNode('inner text'));
-        mention.setAttribute('href', 'testHref');
-        mention.setAttribute('data-mention-type', 'testType');
-        mention.setAttribute('style', 'testStyle');
-        mention.setAttribute('contenteditable', 'false');
+        const mention = createMentionElement();
         mockComposer.appendChild(mention);
 
         // eslint-disable-next-line max-len
@@ -292,12 +298,7 @@ describe('amendHtmlInABetterWay', () => {
     });
 
     it('can cope with a mention at the top level inline with textnodes', () => {
-        const mention = document.createElement('a');
-        mention.appendChild(document.createTextNode('inner text'));
-        mention.setAttribute('href', 'testHref');
-        mention.setAttribute('data-mention-type', 'testType');
-        mention.setAttribute('style', 'testStyle');
-        mention.setAttribute('contenteditable', 'false');
+        const mention = createMentionElement();
 
         mockComposer.appendChild(document.createTextNode('preceding '));
         mockComposer.appendChild(mention);
@@ -312,12 +313,7 @@ describe('amendHtmlInABetterWay', () => {
 
     it('can cope with a nested mention', () => {
         const innerDiv = document.createElement('div');
-        const mention = document.createElement('a');
-        mention.appendChild(document.createTextNode('inner text'));
-        mention.setAttribute('href', 'testHref');
-        mention.setAttribute('data-mention-type', 'testType');
-        mention.setAttribute('style', 'testStyle');
-        mention.setAttribute('contenteditable', 'false');
+        const mention = createMentionElement();
         innerDiv.appendChild(mention);
         mockComposer.appendChild(innerDiv);
 
@@ -330,12 +326,7 @@ describe('amendHtmlInABetterWay', () => {
 
     it('can cope with a nested mention with nested text nodes', () => {
         const innerDiv = document.createElement('div');
-        const mention = document.createElement('a');
-        mention.appendChild(document.createTextNode('inner text'));
-        mention.setAttribute('href', 'testHref');
-        mention.setAttribute('data-mention-type', 'testType');
-        mention.setAttribute('style', 'testStyle');
-        mention.setAttribute('contenteditable', 'false');
+        const mention = createMentionElement();
 
         innerDiv.appendChild(document.createTextNode('preceding '));
         innerDiv.appendChild(mention);
@@ -351,12 +342,7 @@ describe('amendHtmlInABetterWay', () => {
 
     it('can cope with a nested mention next to top level text nodes', () => {
         const innerDiv = document.createElement('div');
-        const mention = document.createElement('a');
-        mention.appendChild(document.createTextNode('inner text'));
-        mention.setAttribute('href', 'testHref');
-        mention.setAttribute('data-mention-type', 'testType');
-        mention.setAttribute('style', 'testStyle');
-        mention.setAttribute('contenteditable', 'false');
+        const mention = createMentionElement();
 
         mockComposer.appendChild(document.createTextNode('preceding'));
         innerDiv.appendChild(mention);
@@ -372,13 +358,7 @@ describe('amendHtmlInABetterWay', () => {
 
     it('can cope with adjacent top level mentions', () => {
         ['1', '2', '3'].forEach((id) => {
-            const mention = document.createElement('a');
-            mention.appendChild(document.createTextNode('inner text' + id));
-            mention.setAttribute('href', 'testHref' + id);
-            mention.setAttribute('data-mention-type', 'testType' + id);
-            mention.setAttribute('style', 'testStyle' + id);
-            mention.setAttribute('contenteditable', 'false');
-
+            const mention = createMentionElement(id);
             mockComposer.appendChild(mention);
         });
 
@@ -391,13 +371,9 @@ describe('amendHtmlInABetterWay', () => {
 
     it('can cope with adjacent nested mentions', () => {
         ['1', '2', '3'].forEach((id) => {
-            const mention = document.createElement('a');
-            mention.appendChild(document.createTextNode('inner text' + id));
-            mention.setAttribute('href', 'testHref' + id);
-            mention.setAttribute('data-mention-type', 'testType' + id);
-            mention.setAttribute('style', 'testStyle' + id);
-            mention.setAttribute('contenteditable', 'false');
+            const mention = createMentionElement(id);
 
+            // nest the middle mention
             if (id === '2') {
                 const innerDiv = document.createElement('div');
                 innerDiv.appendChild(mention);

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -72,14 +72,6 @@ describe('Rich text <=> plain text', () => {
 
         expect(convertedPlainText).toBe(expectedPlainText);
     });
-
-    it('converts linebreaks for display plain => rich', async () => {
-        const plainText = 'multi\nline';
-        const convertedRichText = await plainToRich(plainText, false);
-        const expectedRichText = 'multi<br />line';
-
-        expect(convertedRichText).toBe(expectedRichText);
-    });
 });
 
 describe('Plain text <=> markdown', () => {
@@ -239,12 +231,20 @@ describe('amendHtmlInABetterWay', () => {
     });
 
     it('can cope with multiple adjacent text nodes at top level', () => {
-        const strings = ['first string', 'second string', 'third string'];
+        // this is how chrome structures the child nodes
+        const strings = [
+            'first string',
+            '\n',
+            'second string',
+            '\n',
+            'third string',
+        ];
         strings.forEach((s) =>
             mockComposer.appendChild(document.createTextNode(s)),
         );
 
-        const expected = strings.join('\n');
+        const expected = 'first string\nsecond string\nthird string';
+
         expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
             expected,
         );
@@ -252,13 +252,20 @@ describe('amendHtmlInABetterWay', () => {
 
     it('can cope with multiple adjacent text nodes in nested div', () => {
         const innerDiv = document.createElement('div');
-        const strings = ['first string', 'second string', 'third string'];
+        // this is how chrome structures the child nodes
+        const strings = [
+            'first string',
+            '\n',
+            'second string',
+            '\n',
+            'third string',
+        ];
         strings.forEach((s) =>
             innerDiv.appendChild(document.createTextNode(s)),
         );
         mockComposer.appendChild(innerDiv);
 
-        const expected = strings.join('\n');
+        const expected = 'first string\nsecond string\nthird string';
         expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
             expected,
         );

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -448,4 +448,39 @@ describe('plainTextInnerHtmlToMarkdown', () => {
             expected,
         );
     });
+
+    it('outputs to console.debug for unexpected node types', () => {
+        const debugSpy = vi
+            .spyOn(console, 'debug')
+            .mockImplementation(() => {});
+
+        const unorderedList = document.createElement('ul');
+        const listItem = document.createElement('li');
+        const textNode = document.createTextNode('list text');
+
+        listItem.appendChild(textNode);
+        unorderedList.appendChild(listItem);
+        mockComposer.appendChild(unorderedList);
+
+        // check that it pulls the inner text out correctly, despite the unexpected tags
+        const expected = `list text`;
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
+
+        // check that it has also called console.debug with some useful output
+        expect(debugSpy.mock.calls).toMatchInlineSnapshot(`
+          [
+            [
+              "Converting unexpected node type UL",
+            ],
+            [
+              "Converting unexpected node type LI",
+            ],
+          ]
+        `);
+
+        // reset the spy
+        debugSpy.mockRestore();
+    });
 });

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -173,11 +173,14 @@ describe('Mentions', () => {
     });
 });
 
-// ;when
+// Although a bit clunky, all of these tests simulate a plain text composer by creating a content editable
+// div, appending children to it and then reading the composer's innerHTML. This way we can ensure that we
+// are giving the conversion function decent input for the tests.
 describe('amendHtmlInABetterWay', () => {
     let mockComposer: HTMLDivElement;
     beforeEach(() => {
         mockComposer = document.createElement('div');
+        mockComposer.setAttribute('contenteditable', 'true');
     });
 
     it('can cope with divs with a line break', () => {

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -190,7 +190,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         mockComposer.setAttribute('contenteditable', 'true');
     });
 
-    it('can cope with two lines of text, second line empty, for newline chars', () => {
+    it('handles two lines of text, second line empty, with newline char', () => {
         const textNode = document.createTextNode('firstline\n\n');
         mockComposer.appendChild(textNode);
 
@@ -200,7 +200,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with two lines of text, second line empty, for placeholder div', () => {
+    it('handles two lines of text, second line empty, with placeholder div', () => {
         const textNode = document.createTextNode('firstline');
 
         mockComposer.append(textNode, createPlaceholderDiv());
@@ -211,7 +211,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can maintain consecutive newlines between text lines for newline chars', () => {
+    it('handles consecutive newlines between text lines for newline chars', () => {
         const textNode = document.createTextNode('first\n\n\n\nlast');
         mockComposer.appendChild(textNode);
 
@@ -221,7 +221,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can maintain consecutive newlines between text lines for placeholder divs', () => {
+    it('handles consecutive newlines between text lines for placeholder divs', () => {
         const firstText = document.createTextNode('first');
 
         // after the placeholders have started, text can only be inserted inside divs
@@ -245,7 +245,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with divs with a line break', () => {
+    it('handles divs with a line break', () => {
         const innerDiv = document.createElement('div');
         const innerBreak = document.createElement('br');
         innerDiv.appendChild(innerBreak);
@@ -257,7 +257,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with divs with text content', () => {
+    it('handles divs with text content', () => {
         const innerDiv = document.createElement('div');
         innerDiv.appendChild(document.createTextNode('some text'));
         mockComposer.appendChild(innerDiv);
@@ -268,7 +268,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with multiple divs with text content', () => {
+    it('handles multiple divs with text content', () => {
         const firstInnerDiv = document.createElement('div');
         const secondInnerDiv = document.createElement('div');
         firstInnerDiv.appendChild(document.createTextNode('some text'));
@@ -282,7 +282,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope div following plain text node', () => {
+    it('handles div following plain text node', () => {
         const firstTextNode = 'textnode text';
         const secondDiv = document.createElement('div');
         secondDiv.appendChild(document.createTextNode('some more text'));
@@ -295,7 +295,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with multiple adjacent text nodes at top level', () => {
+    it('handles multiple adjacent text nodes at top level', () => {
         // this is how chrome structures the child nodes
         const strings = [
             'first string',
@@ -315,7 +315,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with multiple adjacent text nodes in nested div', () => {
+    it('handles multiple adjacent text nodes in nested div', () => {
         const innerDiv = document.createElement('div');
         // this is how chrome structures the child nodes
         const strings = [
@@ -336,7 +336,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with a mention at the top level', () => {
+    it('handles a mention at the top level', () => {
         const mention = createMentionElement();
         mockComposer.appendChild(mention);
 
@@ -347,7 +347,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with a mention at the top level inline with textnodes', () => {
+    it('handles a mention at the top level inline with textnodes', () => {
         const mention = createMentionElement();
 
         mockComposer.appendChild(document.createTextNode('preceding '));
@@ -361,7 +361,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with a nested mention', () => {
+    it('handles a nested mention', () => {
         const innerDiv = document.createElement('div');
         const mention = createMentionElement();
         innerDiv.appendChild(mention);
@@ -374,7 +374,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with a nested mention with nested text nodes', () => {
+    it('handles a nested mention with nested text nodes', () => {
         const innerDiv = document.createElement('div');
         const mention = createMentionElement();
 
@@ -390,7 +390,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with a nested mention next to top level text node', () => {
+    it('handles a nested mention next to top level text node', () => {
         const innerDiv = document.createElement('div');
         const mention = createMentionElement();
 
@@ -405,7 +405,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with adjacent top level mentions', () => {
+    it('handles adjacent top level mentions', () => {
         ['1', '2', '3'].forEach((id) => {
             const mention = createMentionElement(id);
             mockComposer.appendChild(mention);
@@ -418,7 +418,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with adjacent nested mentions', () => {
+    it('handles adjacent nested mentions', () => {
         const innerDiv = document.createElement('div');
         ['1', '2', '3'].forEach((id) => {
             const mention = createMentionElement(id);
@@ -433,7 +433,7 @@ describe('plainTextInnerHtmlToMarkdown', () => {
         );
     });
 
-    it('can cope with adjacent top level and nested mentions', () => {
+    it('handles adjacent top level and nested mentions', () => {
         const topLevelMention = createMentionElement('1');
         const nestedMention = createMentionElement('2');
 

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import {
     richToPlain,
     plainToRich,
-    plainToMarkdown,
     markdownToPlain,
     plainTextInnerHtmlToMarkdown,
 } from './conversion';
@@ -62,24 +61,24 @@ describe('Rich text <=> plain text', () => {
 });
 
 describe('Plain text <=> markdown', () => {
-    it('converts single linebreak for plain => markdown', () => {
-        const plain = 'multi\nline';
-        const convertedMarkdown = plainToMarkdown(plain);
-        const expectedMarkdown = `multi<br />line`;
+    // it('converts single linebreak for plain => markdown', () => {
+    //     const plain = 'multi\nline';
+    //     const convertedMarkdown = plainToMarkdown(plain);
+    //     const expectedMarkdown = `multi<br />line`;
 
-        expect(convertedMarkdown).toBe(expectedMarkdown);
-    });
+    //     expect(convertedMarkdown).toBe(expectedMarkdown);
+    // });
 
-    it('converts multiple linebreak for plain => markdown', () => {
-        // nb for correct display, there will be one br tag less
-        // than \n at the end
-        const plain = 'multiple\nline\n\nbreaks\n\n\n';
-        const convertedMarkdown = plainToMarkdown(plain);
-        const expectedMarkdown =
-            'multiple<br />line<br /><br />breaks<br /><br />';
+    // it('converts multiple linebreak for plain => markdown', () => {
+    //     // nb for correct display, there will be one br tag less
+    //     // than \n at the end
+    //     const plain = 'multiple\nline\n\nbreaks\n\n\n';
+    //     const convertedMarkdown = plainToMarkdown(plain);
+    //     const expectedMarkdown =
+    //         'multiple<br />line<br /><br />breaks<br /><br />';
 
-        expect(convertedMarkdown).toBe(expectedMarkdown);
-    });
+    //     expect(convertedMarkdown).toBe(expectedMarkdown);
+    // });
 
     it('converts single linebreak for markdown => plain', () => {
         const markdown = 'multi\\\nline';
@@ -174,7 +173,9 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.appendChild(innerDiv);
 
         const expected = '\n';
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with divs with text content', () => {
@@ -183,7 +184,9 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.appendChild(innerDiv);
 
         const expected = 'some text';
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with multiple divs with text content', () => {
@@ -195,7 +198,9 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.append(firstInnerDiv, secondInnerDiv);
 
         const expected = 'some text\nsome more text';
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope div following plain text node', () => {
@@ -206,7 +211,9 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.append(firstTextNode, secondDiv);
 
         const expected = 'textnode text\nsome more text';
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with multiple adjacent text nodes at top level', () => {
@@ -216,7 +223,9 @@ describe('amendHtmlInABetterWay', () => {
         );
 
         const expected = strings.join('\n');
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with multiple adjacent text nodes in nested div', () => {
@@ -228,7 +237,9 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.appendChild(innerDiv);
 
         const expected = strings.join('\n');
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with a mention at the top level', () => {
@@ -242,7 +253,9 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>`;
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with a mention at the top level inline with textnodes', () => {
@@ -259,7 +272,9 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `preceding <a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a> following`;
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with a nested mention', () => {
@@ -275,7 +290,9 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>`;
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with a nested mention with nested text nodes', () => {
@@ -294,7 +311,9 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `preceding <a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a> following`;
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with a nested mention next to top level text nodes', () => {
@@ -313,7 +332,9 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `preceding\n<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>\nfollowing`;
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with adjacent top level mentions', () => {
@@ -330,7 +351,9 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a><a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a><a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 
     it('can cope with adjacent nested mentions', () => {
@@ -353,6 +376,8 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a>\n<a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a>\n<a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
-        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer.innerHTML)).toBe(
+            expected,
+        );
     });
 });

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -73,7 +73,7 @@ describe('Rich text <=> plain text', () => {
         expect(convertedPlainText).toBe(expectedPlainText);
     });
 
-    it.skip('converts blockquotes from plain => rich', async () => {
+    it('converts blockquotes from plain => rich', async () => {
         const plainText = '> I am a quote';
         const convertedRichText = await plainToRich(plainText, false);
         const expectedRichText = '<blockquote><p>I am a quote</p></blockquote>';

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -19,6 +19,7 @@ import {
     plainToRich,
     plainToMarkdown,
     markdownToPlain,
+    amendInnerHtmlButBetter,
 } from './conversion';
 
 describe('Rich text <=> plain text', () => {
@@ -156,5 +157,194 @@ describe('Mentions', () => {
         expect(asMessageHtml).toMatchInlineSnapshot(
             '"<a href=\\"https://matrix.to/#/#test_room:element.io\\">#test_room:element.io</a> "',
         );
+    });
+});
+
+describe('amendHtmlInABetterWay', () => {
+    let mockComposer: HTMLDivElement;
+    beforeEach(() => {
+        mockComposer = document.createElement('div');
+    });
+
+    it('can cope with divs with a line break', () => {
+        const innerDiv = document.createElement('div');
+        const innerBreak = document.createElement('br');
+        innerDiv.appendChild(innerBreak);
+        mockComposer.appendChild(innerDiv);
+
+        const expected = '\n';
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with divs with text content', () => {
+        const innerDiv = document.createElement('div');
+        innerDiv.appendChild(document.createTextNode('some text'));
+        mockComposer.appendChild(innerDiv);
+
+        const expected = 'some text';
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with multiple divs with text content', () => {
+        const firstInnerDiv = document.createElement('div');
+        const secondInnerDiv = document.createElement('div');
+        firstInnerDiv.appendChild(document.createTextNode('some text'));
+        secondInnerDiv.appendChild(document.createTextNode('some more text'));
+
+        mockComposer.append(firstInnerDiv, secondInnerDiv);
+
+        const expected = 'some text\nsome more text';
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope div following plain text node', () => {
+        const firstTextNode = 'textnode text';
+        const secondDiv = document.createElement('div');
+        secondDiv.appendChild(document.createTextNode('some more text'));
+
+        mockComposer.append(firstTextNode, secondDiv);
+
+        const expected = 'textnode text\nsome more text';
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with multiple adjacent text nodes at top level', () => {
+        const strings = ['first string', 'second string', 'third string'];
+        strings.forEach((s) =>
+            mockComposer.appendChild(document.createTextNode(s)),
+        );
+
+        const expected = strings.join('\n');
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with multiple adjacent text nodes in nested div', () => {
+        const innerDiv = document.createElement('div');
+        const strings = ['first string', 'second string', 'third string'];
+        strings.forEach((s) =>
+            innerDiv.appendChild(document.createTextNode(s)),
+        );
+        mockComposer.appendChild(innerDiv);
+
+        const expected = strings.join('\n');
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with a mention at the top level', () => {
+        const mention = document.createElement('a');
+        mention.appendChild(document.createTextNode('inner text'));
+        mention.setAttribute('href', 'testHref');
+        mention.setAttribute('data-mention-type', 'testType');
+        mention.setAttribute('style', 'testStyle');
+        mention.setAttribute('contenteditable', 'false');
+        mockComposer.appendChild(mention);
+
+        const expected = `<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>`;
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with a mention at the top level inline with textnodes', () => {
+        const mention = document.createElement('a');
+        mention.appendChild(document.createTextNode('inner text'));
+        mention.setAttribute('href', 'testHref');
+        mention.setAttribute('data-mention-type', 'testType');
+        mention.setAttribute('style', 'testStyle');
+        mention.setAttribute('contenteditable', 'false');
+
+        mockComposer.appendChild(document.createTextNode('preceding '));
+        mockComposer.appendChild(mention);
+        mockComposer.appendChild(document.createTextNode(' following'));
+
+        const expected = `preceding <a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a> following`;
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with a nested mention', () => {
+        const innerDiv = document.createElement('div');
+        const mention = document.createElement('a');
+        mention.appendChild(document.createTextNode('inner text'));
+        mention.setAttribute('href', 'testHref');
+        mention.setAttribute('data-mention-type', 'testType');
+        mention.setAttribute('style', 'testStyle');
+        mention.setAttribute('contenteditable', 'false');
+        innerDiv.appendChild(mention);
+        mockComposer.appendChild(innerDiv);
+
+        const expected = `<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>`;
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with a nested mention with nested text nodes', () => {
+        const innerDiv = document.createElement('div');
+        const mention = document.createElement('a');
+        mention.appendChild(document.createTextNode('inner text'));
+        mention.setAttribute('href', 'testHref');
+        mention.setAttribute('data-mention-type', 'testType');
+        mention.setAttribute('style', 'testStyle');
+        mention.setAttribute('contenteditable', 'false');
+
+        innerDiv.appendChild(document.createTextNode('preceding '));
+        innerDiv.appendChild(mention);
+        innerDiv.appendChild(document.createTextNode(' following'));
+        mockComposer.appendChild(innerDiv);
+
+        const expected = `preceding <a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a> following`;
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with a nested mention next to top level text nodes', () => {
+        const innerDiv = document.createElement('div');
+        const mention = document.createElement('a');
+        mention.appendChild(document.createTextNode('inner text'));
+        mention.setAttribute('href', 'testHref');
+        mention.setAttribute('data-mention-type', 'testType');
+        mention.setAttribute('style', 'testStyle');
+        mention.setAttribute('contenteditable', 'false');
+
+        mockComposer.appendChild(document.createTextNode('preceding'));
+        innerDiv.appendChild(mention);
+        mockComposer.appendChild(innerDiv);
+        mockComposer.appendChild(document.createTextNode('following'));
+
+        const expected = `preceding\n<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>\nfollowing`;
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with adjacent top level mentions', () => {
+        ['1', '2', '3'].forEach((id) => {
+            const mention = document.createElement('a');
+            mention.appendChild(document.createTextNode('inner text' + id));
+            mention.setAttribute('href', 'testHref' + id);
+            mention.setAttribute('data-mention-type', 'testType' + id);
+            mention.setAttribute('style', 'testStyle' + id);
+            mention.setAttribute('contenteditable', 'false');
+
+            mockComposer.appendChild(mention);
+        });
+
+        const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a><a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a><a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+    });
+
+    it('can cope with adjacent nested mentions', () => {
+        ['1', '2', '3'].forEach((id) => {
+            const mention = document.createElement('a');
+            mention.appendChild(document.createTextNode('inner text' + id));
+            mention.setAttribute('href', 'testHref' + id);
+            mention.setAttribute('data-mention-type', 'testType' + id);
+            mention.setAttribute('style', 'testStyle' + id);
+            mention.setAttribute('contenteditable', 'false');
+
+            if (id === '2') {
+                const innerDiv = document.createElement('div');
+                innerDiv.appendChild(mention);
+                mockComposer.appendChild(innerDiv);
+            } else {
+                mockComposer.appendChild(mention);
+            }
+        });
+
+        const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a>\n<a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a>\n<a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
+        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
     });
 });

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -19,7 +19,7 @@ import {
     plainToRich,
     plainToMarkdown,
     markdownToPlain,
-    amendInnerHtmlButBetter,
+    plainTextInnerHtmlToMarkdown,
 } from './conversion';
 
 describe('Rich text <=> plain text', () => {
@@ -160,6 +160,7 @@ describe('Mentions', () => {
     });
 });
 
+// ;when
 describe('amendHtmlInABetterWay', () => {
     let mockComposer: HTMLDivElement;
     beforeEach(() => {
@@ -173,7 +174,7 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.appendChild(innerDiv);
 
         const expected = '\n';
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with divs with text content', () => {
@@ -182,7 +183,7 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.appendChild(innerDiv);
 
         const expected = 'some text';
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with multiple divs with text content', () => {
@@ -194,7 +195,7 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.append(firstInnerDiv, secondInnerDiv);
 
         const expected = 'some text\nsome more text';
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope div following plain text node', () => {
@@ -205,7 +206,7 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.append(firstTextNode, secondDiv);
 
         const expected = 'textnode text\nsome more text';
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with multiple adjacent text nodes at top level', () => {
@@ -215,7 +216,7 @@ describe('amendHtmlInABetterWay', () => {
         );
 
         const expected = strings.join('\n');
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with multiple adjacent text nodes in nested div', () => {
@@ -227,7 +228,7 @@ describe('amendHtmlInABetterWay', () => {
         mockComposer.appendChild(innerDiv);
 
         const expected = strings.join('\n');
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with a mention at the top level', () => {
@@ -241,7 +242,7 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>`;
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with a mention at the top level inline with textnodes', () => {
@@ -258,7 +259,7 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `preceding <a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a> following`;
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with a nested mention', () => {
@@ -274,7 +275,7 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>`;
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with a nested mention with nested text nodes', () => {
@@ -293,7 +294,7 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `preceding <a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a> following`;
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with a nested mention next to top level text nodes', () => {
@@ -312,7 +313,7 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `preceding\n<a href="testHref" data-mention-type="testType" style="testStyle" contenteditable="false">inner text</a>\nfollowing`;
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with adjacent top level mentions', () => {
@@ -329,7 +330,7 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a><a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a><a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 
     it('can cope with adjacent nested mentions', () => {
@@ -352,6 +353,6 @@ describe('amendHtmlInABetterWay', () => {
 
         // eslint-disable-next-line max-len
         const expected = `<a href="testHref1" data-mention-type="testType1" style="testStyle1" contenteditable="false">inner text1</a>\n<a href="testHref2" data-mention-type="testType2" style="testStyle2" contenteditable="false">inner text2</a>\n<a href="testHref3" data-mention-type="testType3" style="testStyle3" contenteditable="false">inner text3</a>`;
-        expect(amendInnerHtmlButBetter(mockComposer)).toBe(expected);
+        expect(plainTextInnerHtmlToMarkdown(mockComposer)).toBe(expected);
     });
 });

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -27,7 +27,6 @@ describe('Rich text <=> plain text', () => {
         { rich: 'plain', plain: 'plain' },
         { rich: '<strong>bold</strong>', plain: '__bold__' },
         { rich: '<em>italic</em>', plain: '*italic*' },
-        { rich: '<u>underline</u>', plain: '<u>underline</u>' },
         { rich: '<del>strike</del>', plain: '~~strike~~' },
     ];
     const mappedTestCases = testCases.map(({ rich, plain }) => [rich, plain]);
@@ -42,6 +41,29 @@ describe('Rich text <=> plain text', () => {
             expect(convertedPlainText).toBe(plain);
         },
     );
+
+    it('converts underline case rich => plain', async () => {
+        // This is the html representation of underlining
+        const rich = '<u>underline</u>';
+
+        // When we convert the plain text, we expect the output to be the `rich` string - it
+        // is then set as `.innerText` in element web so that handles html escaping entities
+        const expectedPlainText = '<u>underline</u>';
+
+        const convertedPlainText = await richToPlain(rich);
+        expect(convertedPlainText).toBe(expectedPlainText);
+    });
+
+    it('converts underline case plain => rich', async () => {
+        // When the above is typed by a user in the plain text editor, the innerHTML
+        // will look like this
+        const plain = '&lt;u&gt;underline&lt;/u&gt;';
+
+        const expectedRichText = '<u>underline</u>';
+
+        const convertedRichText = await plainToRich(plain, false);
+        expect(convertedRichText).toBe(expectedRichText);
+    });
 
     it('converts linebreaks for display rich => plain', async () => {
         const richText = 'multi<br />line';

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -100,22 +100,22 @@ export function amendInnerHtmlButBetter(composer: HTMLDivElement): string {
     while (node !== null) {
         const isTopLevelTextNode =
             node.nodeName === '#text' &&
-            node.parentElement.isSameNode(composer);
+            node.parentElement?.isSameNode(composer);
         const isNestedTextNode =
             node.nodeName === '#text' &&
-            !node.parentElement.isSameNode(composer) &&
-            node.parentElement.nodeName === 'DIV';
+            !node.parentElement?.isSameNode(composer) &&
+            node.parentElement?.nodeName === 'DIV';
         const isTopLevelMention =
             node.nodeName === '#text' &&
-            node.parentElement.nodeName === 'A' &&
-            node.parentElement.parentElement.isSameNode(composer);
+            node.parentElement?.nodeName === 'A' &&
+            node.parentElement?.parentElement?.isSameNode(composer);
         const isNestedMention =
             node.nodeName === '#text' &&
-            node.parentElement.nodeName === 'A' &&
-            node.parentElement.parentElement.nodeName === 'DIV' &&
+            node.parentElement?.nodeName === 'A' &&
+            node.parentElement?.parentElement?.nodeName === 'DIV' &&
             !node.parentElement.parentElement.isSameNode(composer);
         const isLineBreak =
-            node.nodeName === 'BR' && node.parentElement.nodeName === 'DIV';
+            node.nodeName === 'BR' && node.parentElement?.nodeName === 'DIV';
 
         // if we find a br inside a div, take an \n
         if (isLineBreak) {
@@ -126,7 +126,7 @@ export function amendInnerHtmlButBetter(composer: HTMLDivElement): string {
         if (isNestedTextNode) {
             let content = node.textContent;
             const nextSibling =
-                node.nextSibling || node.parentElement.nextSibling;
+                node.nextSibling || node.parentElement?.nextSibling;
             if (nextSibling && nextSibling.nodeName !== 'A') {
                 content += '\n';
             }
@@ -147,8 +147,8 @@ export function amendInnerHtmlButBetter(composer: HTMLDivElement): string {
 
         // for a top level mention, grab the outerHTML
         if (isTopLevelMention) {
-            outputStuff += node.parentElement.outerHTML;
-            const nextSibling = node.parentElement.nextSibling;
+            outputStuff += node.parentElement?.outerHTML;
+            const nextSibling = node.parentElement?.nextSibling;
             const isNextToBlockNode =
                 nextSibling && !['#text', 'A'].includes(nextSibling.nodeName);
             if (isNextToBlockNode) {
@@ -158,15 +158,15 @@ export function amendInnerHtmlButBetter(composer: HTMLDivElement): string {
 
         // for a nested mention, grab the outerHTML but we need to consider if we add a newline or not
         if (isNestedMention) {
-            outputStuff += node.parentElement.outerHTML;
+            outputStuff += node.parentElement?.outerHTML;
             const isNextToBlockNode =
-                node.parentElement.nextSibling !== null &&
+                node.parentElement?.nextSibling !== null &&
                 !['#text', 'A'].includes(
-                    node.parentElement.nextSibling.nodeName,
+                    node.parentElement?.nextSibling.nodeName ?? '',
                 );
             const isInDivNextToAnything =
-                node.parentElement.nextSibling === null &&
-                node.parentElement.parentElement.nextSibling !== null;
+                node.parentElement?.nextSibling === null &&
+                node.parentElement?.parentElement?.nextSibling !== null;
             if (isInDivNextToAnything || isNextToBlockNode) {
                 outputStuff += '\n';
             }

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -101,7 +101,7 @@ we do it manually so that we can extract:
     in the plain text composer can be parsed into mentions inside the rust model
 */
 export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
-    // Parse the innerHtml into a DOM and treat the `body` as the `composer
+    // Parse the innerHtml into a DOM and treat the `body` as the `composer`
     const { body: composer } = new DOMParser().parseFromString(
         innerHtml,
         'text/html',

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -112,6 +112,7 @@ we do it manually so that we can extract:
     in the plain text composer can be parsed into mentions inside the rust model
 */
 
+const NEWLINE_CHAR = '\n';
 export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
     const { body: composer } = new DOMParser().parseFromString(
         innerHtml,
@@ -142,9 +143,9 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
         const isLineBreak =
             node.nodeName === 'BR' && node.parentElement?.nodeName === 'DIV';
 
-        // if we find a br inside a div, take an \n
+        // if we find a br inside a div, replace it with an \n
         if (isLineBreak) {
-            outputStuff += '\n';
+            outputStuff += NEWLINE_CHAR;
         }
 
         // if we find a text node inside a nested div, take the text content
@@ -153,7 +154,7 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
             const nextSibling =
                 node.nextSibling || node.parentElement?.nextSibling;
             if (nextSibling && nextSibling.nodeName !== 'A') {
-                content += '\n';
+                content += NEWLINE_CHAR;
             }
             outputStuff += content;
         }
@@ -165,7 +166,7 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
                 node.nextSibling !== null &&
                 node.nextSibling.nodeName !== 'A'
             ) {
-                content += '\n';
+                content += NEWLINE_CHAR;
             }
             outputStuff += content;
         }
@@ -177,7 +178,7 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
             const isNextToBlockNode =
                 nextSibling && !['#text', 'A'].includes(nextSibling.nodeName);
             if (isNextToBlockNode) {
-                outputStuff += '\n';
+                outputStuff += NEWLINE_CHAR;
             }
         }
 
@@ -193,7 +194,7 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
                 node.parentElement?.nextSibling === null &&
                 node.parentElement?.parentElement?.nextSibling !== null;
             if (isInDivNextToAnything || isNextToBlockNode) {
-                outputStuff += '\n';
+                outputStuff += NEWLINE_CHAR;
             }
         }
 
@@ -202,7 +203,7 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
 
     // finally, after the conversion, we need to trim a single `\n` off the end of the
     // output if we have consecutive newlines, as this is a browser placeholder
-    if (outputStuff.endsWith('\n\n')) {
+    if (outputStuff.endsWith(NEWLINE_CHAR.repeat(2))) {
         outputStuff = outputStuff.slice(0, -1);
     }
 

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -200,5 +200,11 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
         node = i.nextNode();
     }
 
+    // finally, after the conversion, we need to trim a single `\n` off the end of the
+    // output if we have consecutive newlines, as this is a browser placeholder
+    if (outputStuff.endsWith('\n\n')) {
+        outputStuff = outputStuff.slice(0, -1);
+    }
+
     return outputStuff;
 }

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -113,9 +113,13 @@ we do it manually so that we can extract:
 */
 
 export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
-    const composer = new DOMParser().parseFromString(innerHtml, 'text/html');
+    const { body: composer } = new DOMParser().parseFromString(
+        innerHtml,
+        'text/html',
+    );
     const i = document.createNodeIterator(composer, NodeFilter.SHOW_ALL);
     let node = i.nextNode();
+
     // loop through every single node and do...something
     let outputStuff = '';
     while (node !== null) {

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -112,7 +112,8 @@ we do it manually so that we can extract:
     in the plain text composer can be parsed into mentions inside the rust model
 */
 
-export function plainTextInnerHtmlToMarkdown(composer: HTMLDivElement): string {
+export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
+    const composer = new DOMParser().parseFromString(innerHtml, 'text/html');
     const i = document.createNodeIterator(composer, NodeFilter.SHOW_ALL);
     let node = i.nextNode();
     // loop through every single node and do...something

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -132,6 +132,9 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
             node.childNodes.length === 1 &&
             node.firstChild?.nodeName === 'BR';
 
+        // UNEXPECTED NODE - `node` represents an unexpected tag type
+        const isUnexpectedNode = !expectedNodeNames.includes(node.nodeName);
+
         if (isDivContainingBreak) {
             markdownOutput += NEWLINE_CHAR;
         } else if (isTextNode) {
@@ -148,6 +151,8 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
                 content += NEWLINE_CHAR;
             }
             markdownOutput += content;
+        } else if (isUnexpectedNode) {
+            console.debug(`Converting unexpected node type ${node.nodeName}`);
         }
 
         node = iterator.nextNode();
@@ -161,6 +166,8 @@ export function plainTextInnerHtmlToMarkdown(innerHtml: string): string {
 
     return markdownOutput;
 }
+
+const expectedNodeNames = ['#text', 'BR', 'A', 'DIV', 'BODY'];
 
 // When we parse the nodes, we need to manually add newlines if the node is either
 // adjacent to a div or is the last child and it's parent is adjacent to a div

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -88,3 +88,92 @@ export async function plainToRich(plainText: string, inMessageFormat: boolean) {
         ? model.get_content_as_message_html()
         : model.get_content_as_html();
 }
+
+// We need to do something better and less hacky to now account for the fact that mentions are html
+// The approach will be to manually build a string by parsing the html into a document then manually
+// creating a string of exactly the format required by the markdown parser of the rust model.
+export function amendInnerHtmlButBetter(composer: HTMLDivElement): string {
+    const i = document.createNodeIterator(composer, NodeFilter.SHOW_ALL);
+    let node = i.nextNode();
+    // loop through every single node and do...something
+    let outputStuff = '';
+    while (node !== null) {
+        const isTopLevelTextNode =
+            node.nodeName === '#text' &&
+            node.parentElement.isSameNode(composer);
+        const isNestedTextNode =
+            node.nodeName === '#text' &&
+            !node.parentElement.isSameNode(composer) &&
+            node.parentElement.nodeName === 'DIV';
+        const isTopLevelMention =
+            node.nodeName === '#text' &&
+            node.parentElement.nodeName === 'A' &&
+            node.parentElement.parentElement.isSameNode(composer);
+        const isNestedMention =
+            node.nodeName === '#text' &&
+            node.parentElement.nodeName === 'A' &&
+            node.parentElement.parentElement.nodeName === 'DIV' &&
+            !node.parentElement.parentElement.isSameNode(composer);
+        const isLineBreak =
+            node.nodeName === 'BR' && node.parentElement.nodeName === 'DIV';
+
+        // if we find a br inside a div, take an \n
+        if (isLineBreak) {
+            outputStuff += '\n';
+        }
+
+        // if we find a text node inside a nested div, take the text content
+        if (isNestedTextNode) {
+            let content = node.textContent;
+            const nextSibling =
+                node.nextSibling || node.parentElement.nextSibling;
+            if (nextSibling && nextSibling.nodeName !== 'A') {
+                content += '\n';
+            }
+            outputStuff += content;
+        }
+
+        // if we find a top level text node, take the text content
+        if (isTopLevelTextNode) {
+            let content = node.textContent;
+            if (
+                node.nextSibling !== null &&
+                node.nextSibling.nodeName !== 'A'
+            ) {
+                content += '\n';
+            }
+            outputStuff += content;
+        }
+
+        // for a top level mention, grab the outerHTML
+        if (isTopLevelMention) {
+            outputStuff += node.parentElement.outerHTML;
+            const nextSibling = node.parentElement.nextSibling;
+            const isNextToBlockNode =
+                nextSibling && !['#text', 'A'].includes(nextSibling.nodeName);
+            if (isNextToBlockNode) {
+                outputStuff += '\n';
+            }
+        }
+
+        // for a nested mention, grab the outerHTML but we need to consider if we add a newline or not
+        if (isNestedMention) {
+            outputStuff += node.parentElement.outerHTML;
+            const isNextToBlockNode =
+                node.parentElement.nextSibling !== null &&
+                !['#text', 'A'].includes(
+                    node.parentElement.nextSibling.nodeName,
+                );
+            const isInDivNextToAnything =
+                node.parentElement.nextSibling === null &&
+                node.parentElement.parentElement.nextSibling !== null;
+            if (isInDivNextToAnything || isNextToBlockNode) {
+                outputStuff += '\n';
+            }
+        }
+
+        node = i.nextNode();
+    }
+
+    return outputStuff;
+}


### PR DESCRIPTION
Allows us to parse "markdown" from a plain text composer into a rust model correctly. This needs to work because when the user uses the plain text composer, the a rust model is built to convert their input into the `formatted_body` html type output that is appended to the matrix message.