### PR TITLE
Fix link splitting in lists

### DIFF
--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -162,6 +162,7 @@ where
                         first_leaf.start_offset,
                         block_location.node_handle.depth(),
                     );
+                    pre_process_sub_tree(&mut sub_tree);
                     let children = sub_tree.document_mut().remove_children();
                     self.state.dom.insert_at(
                         &block_location.node_handle.next_sibling(),

--- a/crates/wysiwyg/src/tests/test_links.rs
+++ b/crates/wysiwyg/src/tests/test_links.rs
@@ -885,3 +885,61 @@ fn set_link_with_text_and_custom_attributes() {
         "<a customattribute=\"customvalue\" href=\"https://matrix.org\">link|</a>"
     )
 }
+
+#[test]
+fn set_link_in_list_then_exit_list() {
+    // start with empty model
+    let mut model = cm("|");
+
+    // start a list, add a link
+    model.unordered_list();
+    model.set_link_with_text(
+        "https://matrix.org".into(),
+        "test".into(),
+        vec![],
+    );
+
+    assert_eq!(
+        tx(&model),
+        "<ul><li><a href=\"https://matrix.org\">test|</a></li></ul>"
+    );
+
+    // exit the list by pressing enter twice
+    model.enter();
+    model.enter();
+
+    // check that the list has ended, a new paragraph has been started, and the link has not been split
+    // into two parts
+    assert_eq!(
+        tx(&model),
+        "<ul><li><a href=\"https://matrix.org\">test</a></li></ul><p>&nbsp;|</p>"
+    );
+}
+
+#[test]
+fn set_links_in_list_then_add_list_item() {
+    // start with empty model
+    let mut model = cm("|");
+
+    // start a list, add a link
+    model.unordered_list();
+    model.set_link_with_text(
+        "https://matrix.org".into(),
+        "test".into(),
+        vec![],
+    );
+
+    assert_eq!(
+        tx(&model),
+        "<ul><li><a href=\"https://matrix.org\">test|</a></li></ul>"
+    );
+
+    // press enter once to add a new list item
+    model.enter();
+
+    // check that the link has not been split into two, with one part empty
+    assert_eq!(
+        tx(&model),
+        "<ul><li><a href=\"https://matrix.org\">test</a></li><li>|</li></ul>"
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rich-text-editor/issues/681
Closes https://github.com/vector-im/element-web/issues/25379

Previously as described in the above issues, if you started a list, inserted a link, then tried to insert a new bullet point, the internal state of the rust model would be incorrect. This was due to the link being split into two parts, one of which was a link with no inner text.

This PR fixes that behaviour by using a pre-existing util function to remove empty link nodes, and adds tests for the problem as described in the linked issues.