### PR TITLE
Allow markdown in message format

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_model.rs
@@ -65,6 +65,14 @@ impl ComposerModel {
             .to_string()
     }
 
+    pub fn get_content_as_message_markdown(self: &Arc<Self>) -> String {
+        self.inner
+            .lock()
+            .unwrap()
+            .get_content_as_message_markdown()
+            .to_string()
+    }
+
     pub fn get_content_as_plain_text(self: &Arc<Self>) -> String {
         self.inner
             .lock()

--- a/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
+++ b/bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
@@ -24,6 +24,7 @@ interface ComposerModel {
     string get_content_as_html();
     string get_content_as_message_html();
     string get_content_as_markdown();
+    string get_content_as_message_markdown();
     string get_content_as_plain_text();
     ComposerUpdate clear();
     ComposerUpdate select(u32 start_utf16_codeunit, u32 end_utf16_codeunit);

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -128,6 +128,10 @@ impl ComposerModel {
         self.inner.get_content_as_markdown().to_string()
     }
 
+    pub fn get_content_as_message_markdown(&self) -> String {
+        self.inner.get_content_as_message_markdown().to_string()
+    }
+
     pub fn get_content_as_plain_text(&self) -> String {
         self.inner.get_content_as_plain_text().to_string()
     }

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -203,6 +203,10 @@ where
         self.state.dom.to_markdown().unwrap()
     }
 
+    pub fn get_content_as_message_markdown(&self) -> S {
+        self.state.dom.to_message_markdown().unwrap()
+    }
+
     pub fn get_content_as_plain_text(&self) -> S {
         self.state.dom.to_plain_text()
     }

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -669,8 +669,9 @@ where
         &self,
         buffer: &mut S,
         options: &MarkdownOptions,
+        as_message: bool,
     ) -> Result<(), MarkdownError<S>> {
-        self.document.fmt_markdown(buffer, options)
+        self.document.fmt_markdown(buffer, options, as_message)
     }
 }
 

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -497,7 +497,9 @@ where
             DomNode::LineBreak(node) => {
                 node.fmt_markdown(buffer, options, as_message)
             }
-            DomNode::Mention(node) => node.fmt_markdown(buffer, options),
+            DomNode::Mention(node) => {
+                node.fmt_markdown(buffer, options, as_message)
+            }
         }
     }
 }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -485,10 +485,11 @@ where
         &self,
         buffer: &mut S,
         options: &MarkdownOptions,
+        as_message: bool,
     ) -> Result<(), MarkdownError<S>> {
         match self {
             DomNode::Container(container) => {
-                container.fmt_markdown(buffer, options)
+                container.fmt_markdown(buffer, options, as_message)
             }
             DomNode::Text(text) => text.fmt_markdown(buffer, options),
             DomNode::LineBreak(node) => node.fmt_markdown(buffer, options),

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -491,7 +491,9 @@ where
             DomNode::Container(container) => {
                 container.fmt_markdown(buffer, options, as_message)
             }
-            DomNode::Text(text) => text.fmt_markdown(buffer, options),
+            DomNode::Text(text) => {
+                text.fmt_markdown(buffer, options, as_message)
+            }
             DomNode::LineBreak(node) => node.fmt_markdown(buffer, options),
             DomNode::Mention(node) => node.fmt_markdown(buffer, options),
         }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -494,7 +494,9 @@ where
             DomNode::Text(text) => {
                 text.fmt_markdown(buffer, options, as_message)
             }
-            DomNode::LineBreak(node) => node.fmt_markdown(buffer, options),
+            DomNode::LineBreak(node) => {
+                node.fmt_markdown(buffer, options, as_message)
+            }
             DomNode::Mention(node) => node.fmt_markdown(buffer, options),
         }
     }

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -128,6 +128,7 @@ where
         &self,
         buffer: &mut S,
         options: &MarkdownOptions,
+        as_message: bool,
     ) -> Result<(), MarkdownError<S>> {
         if options.contains(MarkdownOptions::IGNORE_LINE_BREAK) {
             // Replace the line break by a single space.

--- a/crates/wysiwyg/src/dom/nodes/line_break_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/line_break_node.rs
@@ -128,7 +128,7 @@ where
         &self,
         buffer: &mut S,
         options: &MarkdownOptions,
-        as_message: bool,
+        _as_message: bool,
     ) -> Result<(), MarkdownError<S>> {
         if options.contains(MarkdownOptions::IGNORE_LINE_BREAK) {
             // Replace the line break by a single space.

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -268,6 +268,7 @@ where
         &self,
         buffer: &mut S,
         _: &MarkdownOptions,
+        as_message: bool,
     ) -> Result<(), MarkdownError<S>> {
         fmt_mention(self, buffer)?;
         return Ok(());

--- a/crates/wysiwyg/src/dom/nodes/mention_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/mention_node.rs
@@ -296,32 +296,33 @@ where
                 buffer.push(text);
                 Ok(())
             } else {
-                // clone the attributes, then push in anything extra required
+                // clone the attributes and set up variables to assign attributes to
                 let mut attrs = this.attributes.clone();
+                let data_mention_type;
+                let href;
 
+                // assign values based on the mention type
                 match this.kind() {
                     MentionNodeKind::MatrixUri { mention } => {
-                        let data_mention_type = match mention.kind() {
+                        data_mention_type = match mention.kind() {
                             MentionKind::Room => "room",
                             MentionKind::User => "user",
                         };
-                        attrs.push((
-                            "data-mention-type".into(),
-                            data_mention_type.into(),
-                        ));
-                        attrs.push(("href".into(), S::from(mention.uri())));
-                        attrs.push(("contenteditable".into(), "false".into()));
+                        href = mention.uri();
                     }
                     MentionNodeKind::AtRoom => {
-                        // this is now only required for us to attach a custom style attribute for web
-                        attrs.push((
-                            "data-mention-type".into(),
-                            "at-room".into(),
-                        ));
-                        attrs.push(("href".into(), "#".into())); // designates a placeholder link in html
-                        attrs.push(("contenteditable".into(), "false".into()));
+                        data_mention_type = "at-room";
+                        href = "#";
                     }
                 };
+
+                // push the attributes into the vec for writing
+                attrs.push((
+                    "data-mention-type".into(),
+                    data_mention_type.into(),
+                ));
+                attrs.push(("href".into(), href.into()));
+                attrs.push(("contenteditable".into(), "false".into()));
 
                 // HTML is valid markdown. For a mention in a composer, output it as HTML.
                 buffer.push("<a");

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -294,7 +294,7 @@ where
         &self,
         buffer: &mut S,
         _options: &MarkdownOptions,
-        as_message: bool,
+        _as_message: bool,
     ) -> Result<(), MarkdownError<S>> {
         buffer.push(self.data.to_owned());
 

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -294,6 +294,7 @@ where
         &self,
         buffer: &mut S,
         _options: &MarkdownOptions,
+        as_message: bool,
     ) -> Result<(), MarkdownError<S>> {
         buffer.push(self.data.to_owned());
 

--- a/crates/wysiwyg/src/dom/to_markdown.rs
+++ b/crates/wysiwyg/src/dom/to_markdown.rs
@@ -46,11 +46,18 @@ where
         &self,
         buffer: &mut S,
         options: &MarkdownOptions,
+        as_message: bool,
     ) -> Result<(), MarkdownError<S>>;
 
+    fn to_message_markdown(&self) -> Result<S, MarkdownError<S>> {
+        let mut buffer = S::default();
+        self.fmt_markdown(&mut buffer, &MarkdownOptions::empty(), true)?;
+
+        Ok(buffer)
+    }
     fn to_markdown(&self) -> Result<S, MarkdownError<S>> {
         let mut buffer = S::default();
-        self.fmt_markdown(&mut buffer, &MarkdownOptions::empty())?;
+        self.fmt_markdown(&mut buffer, &MarkdownOptions::empty(), false)?;
 
         Ok(buffer)
     }

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -13,29 +13,32 @@
 // limitations under the License.
 
 use crate::{
-    dom::parser::markdown::MarkdownHTMLParser, ComposerModel, ToMarkdown,
+    dom::parser::markdown::MarkdownHTMLParser,
+    tests::testutils_composer_model::tx, ComposerModel, ToMarkdown,
 };
 use widestring::Utf16String;
 
+use super::testutils_composer_model::cm;
+
 #[test]
 fn text() {
-    assert_to_md("abc", "abc");
-    assert_to_md("abc def", "abc def");
+    assert_to_message_md("abc", "abc");
+    assert_to_message_md("abc def", "abc def");
     // Internal spaces are preserved.
-    assert_to_md("abc   def", "abc   def");
+    assert_to_message_md("abc   def", "abc   def");
 }
 
 #[test]
 fn text_with_linebreaks() {
     // One new line.
-    assert_to_md(
+    assert_to_message_md(
         "abc<br />def",
         r#"abc\
 def"#,
     );
 
     // Two new lines (isn't transformed into a new block).
-    assert_to_md(
+    assert_to_message_md(
         "abc<br /><br />def",
         r#"abc\
 \
@@ -45,9 +48,9 @@ def"#,
 
 #[test]
 fn text_with_italic() {
-    assert_to_md("<em>abc</em>", "*abc*");
-    assert_to_md("abc <em>def</em> ghi", "abc *def* ghi");
-    assert_to_md(
+    assert_to_message_md("<em>abc</em>", "*abc*");
+    assert_to_message_md("abc <em>def</em> ghi", "abc *def* ghi");
+    assert_to_message_md(
         "abc <em>line1<br />line2<br /><br />line3</em> def",
         r#"abc *line1\
 line2\
@@ -56,7 +59,7 @@ line3* def"#,
     );
 
     // Intraword emphasis is restricted to `*` so it works here!
-    assert_to_md("abc<em>def</em>ghi", "abc*def*ghi");
+    assert_to_message_md("abc<em>def</em>ghi", "abc*def*ghi");
 
     // Immediate intra-spaces for a strong emphasis isn't supported.
     assert_to_md_no_roundtrip("abc<em> def </em>ghi", "abc* def *ghi");
@@ -64,9 +67,9 @@ line3* def"#,
 
 #[test]
 fn text_with_bold() {
-    assert_to_md("<strong>abc</strong>", "__abc__");
-    assert_to_md("abc <strong>def</strong> ghi", "abc __def__ ghi");
-    assert_to_md(
+    assert_to_message_md("<strong>abc</strong>", "__abc__");
+    assert_to_message_md("abc <strong>def</strong> ghi", "abc __def__ ghi");
+    assert_to_message_md(
         "abc <strong>line1<br />line2<br /><br />line3</strong> def",
         r#"abc __line1\
 line2\
@@ -87,9 +90,12 @@ line3__ def"#,
 
 #[test]
 fn text_with_italic_and_bold() {
-    assert_to_md("<em><strong>abc</strong></em>", "*__abc__*");
-    assert_to_md("<em>abc <strong>def</strong></em> ghi", "*abc __def__* ghi");
-    assert_to_md(
+    assert_to_message_md("<em><strong>abc</strong></em>", "*__abc__*");
+    assert_to_message_md(
+        "<em>abc <strong>def</strong></em> ghi",
+        "*abc __def__* ghi",
+    );
+    assert_to_message_md(
         "abc <em><strong>line1<br />line2</strong> def</em>",
         r#"abc *__line1\
 line2__ def*"#,
@@ -98,9 +104,9 @@ line2__ def*"#,
 
 #[test]
 fn text_with_strikethrough() {
-    assert_to_md("<del>abc</del>", "~~abc~~");
-    assert_to_md("abc <del>def</del> ghi", "abc ~~def~~ ghi");
-    assert_to_md(
+    assert_to_message_md("<del>abc</del>", "~~abc~~");
+    assert_to_message_md("abc <del>def</del> ghi", "abc ~~def~~ ghi");
+    assert_to_message_md(
         "abc <del>line1<br />line2<br /><br />line3</del> def",
         r#"abc ~~line1\
 line2\
@@ -117,18 +123,18 @@ line3~~ def"#,
 
 #[test]
 fn text_with_underline() {
-    assert_to_md("<u>abc</u>", "<u>abc</u>");
+    assert_to_message_md("<u>abc</u>", "<u>abc</u>");
 }
 
 #[test]
 fn text_with_inline_code() {
-    assert_to_md("<code>abc</code>", "`` abc ``");
+    assert_to_message_md("<code>abc</code>", "`` abc ``");
     // Inline code with a backtick inside.
-    assert_to_md("<code>abc ` def</code>", "`` abc ` def ``");
+    assert_to_message_md("<code>abc ` def</code>", "`` abc ` def ``");
     // Inline code with a backtick at the start.
-    assert_to_md("<code>`abc</code>", "`` `abc ``");
-    assert_to_md("abc <code>def</code> ghi", "abc `` def `` ghi");
-    assert_to_md("abc<code> def </code>ghi", "abc``  def  ``ghi");
+    assert_to_message_md("<code>`abc</code>", "`` `abc ``");
+    assert_to_message_md("abc <code>def</code> ghi", "abc `` def `` ghi");
+    assert_to_message_md("abc<code> def </code>ghi", "abc``  def  ``ghi");
 
     // It's impossible to get a line break inside an inline code with Markdown.
     assert_to_md_no_roundtrip(
@@ -144,15 +150,15 @@ fn text_with_inline_code() {
 
 #[test]
 fn link() {
-    assert_to_md(r#"<a href="url">abc</a>"#, "[abc](<url>)");
+    assert_to_message_md(r#"<a href="url">abc</a>"#, "[abc](<url>)");
     // Empty link.
-    assert_to_md(r#"<a href="">abc</a>"#, r#"[abc](<>)"#);
+    assert_to_message_md(r#"<a href="">abc</a>"#, r#"[abc](<>)"#);
     // Formatting inside link.
-    assert_to_md(
+    assert_to_message_md(
         r#"<a href="url">abc <strong>def</strong> ghi</a>"#,
         r#"[abc __def__ ghi](<url>)"#,
     );
-    assert_to_md(r#"<a href="(url)">abc</a>"#, r#"[abc](<\(url\)>)"#);
+    assert_to_message_md(r#"<a href="(url)">abc</a>"#, r#"[abc](<\(url\)>)"#);
 
     // Escaping cannot be roundtrip'ed.
     assert_to_md_no_roundtrip(r#"<a href="u<rl">abc</a>"#, r#"[abc](<u\<rl>)"#);
@@ -160,7 +166,7 @@ fn link() {
 
 #[test]
 fn list_unordered() {
-    assert_to_md(
+    assert_to_message_md(
         r#"<ul><li>item1</li><li>item2</li></ul>"#,
         r#"* item1
 * item2"#,
@@ -177,7 +183,7 @@ fn list_unordered() {
 
 #[test]
 fn list_ordered() {
-    assert_to_md(
+    assert_to_message_md(
         r#"<ol><li>item1</li><li>item2</li></ol>"#,
         r#"1. item1
 2. item2"#,
@@ -204,7 +210,7 @@ fn list_ordered_and_unordered() {
 }
 
 #[test]
-fn user_mention() {
+fn user_mention_for_message() {
     assert_to_md_no_roundtrip(
         r#"<a href="https://matrix.to/#/@alice:matrix.org">test</a>"#,
         r#"test"#,
@@ -212,7 +218,15 @@ fn user_mention() {
 }
 
 #[test]
-fn room_mention() {
+fn user_mention_for_composer() {
+    assert_to_composer_md(
+        "<a data-mention-type=\"user\" href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\">test</a>",
+        "<a data-mention-type=\"user\" href=\"https://matrix.to/#/@alice:matrix.org\" contenteditable=\"false\">test</a>",
+    );
+}
+
+#[test]
+fn room_mention_for_message() {
     assert_to_md_no_roundtrip(
         r#"<a href="https://matrix.to/#/#alice:matrix.org">test</a>"#,
         r#"#alice:matrix.org"#,
@@ -220,17 +234,35 @@ fn room_mention() {
 }
 
 #[test]
-fn at_room_mention() {
-    assert_to_md("@room hello!", "@room hello!");
+fn room_mention_for_composer() {
+    assert_to_composer_md(
+        "<a data-mention-type=\"room\" href=\"https://matrix.to/#/#alice:matrix.org\" contenteditable=\"false\">test</a>",
+        "<a data-mention-type=\"room\" href=\"https://matrix.to/#/#alice:matrix.org\" contenteditable=\"false\">test</a>",
+    );
+}
+
+#[test]
+fn at_room_mention_for_message() {
+    assert_to_message_md("@room hello!", "@room hello!");
+}
+
+#[test]
+fn at_room_mention_for_composer() {
+    let model = cm("@room hello!|");
+
+    assert_eq!(tx(&model), "<a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a> hello!|");
+
+    assert_eq!(model.get_content_as_markdown(), "<a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a> hello!");
+    assert_eq!(model.get_content_as_message_markdown(), "@room hello!");
 }
 
 fn assert_to_md_no_roundtrip(html: &str, expected_markdown: &str) {
-    let markdown = to_markdown(html);
+    let markdown = to_message_markdown(html);
     assert_eq!(markdown, expected_markdown);
 }
 
-fn assert_to_md(html: &str, expected_markdown: &str) {
-    let markdown = to_markdown(html);
+fn assert_to_message_md(html: &str, expected_markdown: &str) {
+    let markdown = to_message_markdown(html);
     assert_eq!(markdown, expected_markdown);
 
     let expected_html = html;
@@ -238,7 +270,28 @@ fn assert_to_md(html: &str, expected_markdown: &str) {
 
     assert_eq!(html, expected_html);
 }
-fn to_markdown(html: &str) -> Utf16String {
+
+fn assert_to_composer_md(html: &str, expected_markdown: &str) {
+    let markdown = to_composer_markdown(html);
+    assert_eq!(markdown, expected_markdown);
+
+    let expected_html = html;
+    let html = MarkdownHTMLParser::to_html(&markdown).unwrap();
+
+    assert_eq!(html, expected_html);
+}
+
+fn to_message_markdown(html: &str) -> Utf16String {
+    let markdown = ComposerModel::from_html(html, 0, 0)
+        .state
+        .dom
+        .to_message_markdown();
+    assert!(markdown.is_ok());
+
+    markdown.unwrap()
+}
+
+fn to_composer_markdown(html: &str) -> Utf16String {
     let markdown = ComposerModel::from_html(html, 0, 0).state.dom.to_markdown();
     assert!(markdown.is_ok());
 

--- a/platforms/web/lib/conversion.test.ts
+++ b/platforms/web/lib/conversion.test.ts
@@ -204,35 +204,35 @@ describe('Mentions', () => {
 
         it('keeps user mentions as html for composer', async () => {
             const input =
-                '<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
+                '<a href="https://matrix.to/#/@test_user:element.io">a test user</a> ';
             const asComposerMarkdown = await richToPlain(input, false);
 
             expect(asComposerMarkdown).toMatchInlineSnapshot(
-                '"<a style=\\"some styling\\" data-mention-type=\\"user\\" href=\\"https://matrix.to/#/@test_user:element.io\\" contenteditable=\\"false\\">a test user</a> "',
+                '"<a data-mention-type=\\"user\\" href=\\"https://matrix.to/#/@test_user:element.io\\" contenteditable=\\"false\\">a test user</a> "',
             );
         });
 
         it('converts user mentions to inner text for message', async () => {
             const input =
-                '<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
+                '<a href="https://matrix.to/#/@test_user:element.io">a test user</a> ';
             const asMessageMarkdown = await richToPlain(input, true);
 
-            expect(asMessageMarkdown).toMatchInlineSnapshot('"a test user "');
+            expect(asMessageMarkdown).toBe('a test user ');
         });
 
         it('keeps room mentions as html for composer', async () => {
             const input =
-                '<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
+                '<a href="https://matrix.to/#/#test_room:element.io">a test user</a> ';
             const asComposerMarkdown = await richToPlain(input, false);
 
             expect(asComposerMarkdown).toMatchInlineSnapshot(
-                '"<a style=\\"some styling\\" data-mention-type=\\"room\\" href=\\"https://matrix.to/#/#test_room:element.io\\" contenteditable=\\"false\\">a test user</a> "',
+                '"<a data-mention-type=\\"room\\" href=\\"https://matrix.to/#/#test_room:element.io\\" contenteditable=\\"false\\">a test user</a> "',
             );
         });
 
         it('converts room mentions to mxId for message', async () => {
             const input =
-                '<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> ';
+                '<a href="https://matrix.to/#/#test_room:element.io">a test user</a> ';
             const asMessageMarkdown = await richToPlain(input, true);
 
             // note inner text is the mx id

--- a/platforms/web/lib/conversion.ts
+++ b/platforms/web/lib/conversion.ts
@@ -36,7 +36,7 @@ export const markdownToPlain = (markdown: string) => {
     return plainText.replaceAll(/\\/g, '');
 };
 
-export async function richToPlain(richText: string) {
+export async function richToPlain(richText: string, inMessageFormat: boolean) {
     if (richText.length === 0) {
         return '';
     }
@@ -49,8 +49,11 @@ export async function richToPlain(richText: string) {
     const model = new_composer_model();
     model.set_content_from_html(richText);
 
-    // transform the markdown to plain text for display
-    const markdown = model.get_content_as_markdown();
+    // get the markdown in either composer or message format as required
+    const markdown = inMessageFormat
+        ? model.get_content_as_message_markdown()
+        : model.get_content_as_markdown();
+
     const plainText = markdownToPlain(markdown);
 
     return plainText;


### PR DESCRIPTION
This work brings the markdown output in line with html output and allows the client to get markdown either for the composer (in which case it will keep mentions as html) or for a message (in which case it will format the mentions as it currently does). I believe that the changes will also help us to unbreak the iOS implementation of mentions in plain text mode.

This PR:

- updates bindings 
- adds a new function `get_content_as_message_markdown`
- passes an `as_message` argument through calls to functions that render the model as markdown
- uses that new argument to conditionally render mentions in the desired way