### PR TITLE
Set DTCoreText version to 1.6.26

### DIFF
--- a/platforms/ios/example/Wysiwyg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/platforms/ios/example/Wysiwyg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/DTCoreText",
       "state" : {
-        "revision" : "9d2d4d2296e5d2d852a7d3c592b817d913a5d020",
-        "version" : "1.6.27"
+        "revision" : "b664664825da565b4c2b7a17dbe2369f68ae43d9",
+        "version" : "1.6.26"
       }
     },
     {

--- a/platforms/ios/lib/WysiwygComposer/Package.swift
+++ b/platforms/ios/lib/WysiwygComposer/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/Cocoanetics/DTCoreText",
-            from: "1.6.27"
+            exact: "1.6.26"
         ),
     ],
     targets: [

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/HTMLParser.swift
@@ -77,7 +77,9 @@ public final class HTMLParser {
         
         let parsingOptions: [String: Any] = [
             DTUseiOS6Attributes: true,
-            DTDefaultFontDescriptor: defaultFont.fontDescriptor,
+            DTDefaultFontFamily: defaultFont.familyName,
+            DTDefaultFontName: defaultFont.fontName,
+            DTDefaultFontSize: defaultFont.pointSize,
             DTDefaultStyleSheet: DTCSSStylesheet(styleBlock: defaultCSS) as Any,
             DTDocumentPreserveTrailingSpaces: true,
         ]


### PR DESCRIPTION
Set DTCoreText version down to 1.6.26 because: 

- For some reason version 1.6.27 is not officially "released" on GitHub
- Integration tests have shown that attributed strings created with 1.6.27, tend to have more [runs](https://developer.apple.com/documentation/foundation/attributedstring/runs) than those created with 1.6.26 (supposedly less runs means more performance)
- And also this doesn't seem to break anything else than not having access to `DTDefaultFontDescriptor` anymore
