### PR TITLE
Update uniffi version to 0.24.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+uniffi-bindgen = "run --package uniffi-bindgen --"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -48,11 +48,7 @@ jobs:
         run: make setup
 
       - name: Install Rust targets
-        run: |
-          rustup target add i686-linux-android
-          rustup target add x86_64-linux-android
-          rustup target add armv7-linux-androideabi
-          rustup target add aarch64-linux-android
+        run: make targets-android
 
       - name: Setup Gradle & Build test cases
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,9 +44,6 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install Rust & Uniffi
-        run: make setup
-
       - name: Install Rust targets
         run: make targets-android
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -41,10 +41,7 @@ jobs:
         override: true
 
     - name: Install targets
-      run: |
-        rustup target add aarch64-apple-ios
-        rustup target add aarch64-apple-ios-sim
-        rustup target add x86_64-apple-ios
+      run: make targets-ios
 
     - name: Set XCode 14.2
       run: sudo xcode-select -switch /Applications/Xcode_14.2.app

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,7 @@ jobs:
           override: true
           
       - name: Install targets
-        run: |
-          rustup target add aarch64-apple-ios
-          rustup target add aarch64-apple-ios-sim
-          rustup target add x86_64-apple-ios
+        run: make targets-ios
           
       - name: Set XCode 14.2
         run: sudo xcode-select -switch /Applications/Xcode_14.2.app
@@ -77,11 +74,7 @@ jobs:
         run: make setup
 
       - name: 🦀 Install Rust targets
-        run: |
-          rustup target add i686-linux-android
-          rustup target add x86_64-linux-android
-          rustup target add armv7-linux-androideabi
-          rustup target add aarch64-linux-android
+        run: make targets-android
 
       - name: ⬆️ Publish to Sonatype
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,9 +70,6 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: 🦀 Install Rust toolchain & Uniffi
-        run: make setup
-
       - name: 🦀 Install Rust targets
         run: make targets-android
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,24 +19,28 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "askama"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb98f10f371286b177db5eeb9a6e5396609555686a35e1d4f7b9a9c6d8af0139"
+checksum = "47cbc3cf73fa8d9833727bbee4835ba5c421a0d65b72daf9a7b5d0e0f9cfb57e"
 dependencies = [
  "askama_derive",
  "askama_escape",
- "askama_shared",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bf87e6e8b47264efa9bde63d6225c6276a52e05e91bf37eaa8afd0032d6b71"
+checksum = "c22fbe0413545c098358e56966ff22cdd039e10215ae213cfbd65032b119fc94"
 dependencies = [
- "askama_shared",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "nom",
  "proc-macro2",
- "syn 1.0.103",
+ "quote",
+ "serde",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -44,34 +48,6 @@ name = "askama_escape"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
-name = "askama_shared"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf722b94118a07fcbc6640190f247334027685d4e218b794dbfe17c32bf38ed0"
-dependencies = [
- "askama_escape",
- "mime",
- "mime_guess",
- "nom",
- "proc-macro2",
- "quote",
- "serde",
- "syn 1.0.103",
- "toml 0.5.9",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -84,6 +60,15 @@ name = "base64"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -108,9 +93,9 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "camino"
@@ -132,16 +117,23 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
+ "thiserror",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -151,42 +143,46 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "4.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "906f7fe1da4185b7a282b2bc90172a496f9def1aca4545fe7526810741591e14"
 dependencies = [
- "atty",
- "bitflags",
+ "clap_builder",
  "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351f9ad9688141ed83dfd8f5fb998a06225ef444b48ff4dc43de6d409b7fd10b"
+dependencies = [
+ "bitflags",
  "clap_lex",
- "indexmap",
- "lazy_static",
+ "is-terminal",
+ "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "4.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "81d7dc0031c3a59a04fc2ba395c8e2dd463cba1859275f065d225f6122221b45"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -205,6 +201,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -261,10 +278,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "goblin"
-version = "0.5.4"
+name = "glob"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "goblin"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
 dependencies = [
  "log",
  "plain",
@@ -285,12 +308,18 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "html-escape"
@@ -341,6 +370,29 @@ name = "indoc"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2d6f23ffea9d7e76c53eee25dfb67bcd8fde7f1198b0855350698c9f07c780"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itoa"
@@ -398,16 +450,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "984e109462d46ad18314f10e392c286c3d47bce203088a09012de1015b45b737"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -585,12 +637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,7 +656,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -717,34 +763,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.103",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -762,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -972,6 +994,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,22 +1062,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1168,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1190,18 +1226,12 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 
 [[package]]
 name = "thiserror"
@@ -1220,7 +1250,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1301,7 +1331,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1351,9 +1381,76 @@ checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "uniffi"
-version = "0.21.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54af5ada67d1173457a99a7bb44a7917f63e7466764cb4714865c7a6678b830"
+checksum = "6da26ba712a8547207ededc70f3e0952c09754be9516c320f71731d2f18daf3e"
+dependencies = [
+ "anyhow",
+ "camino",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+]
+
+[[package]]
+name = "uniffi-bindgen"
+version = "0.1.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bff3ba24868022fc82e2f1558f3a0fdcc2655e1335459a35f25d1ec4ff1d0c"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "serde",
+ "serde_json",
+ "toml 0.5.9",
+ "uniffi_meta",
+ "uniffi_testing",
+ "weedle2",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b7cd03e17b997469e5438d1a491c3b9e2d41c2a87c86fd91ba96e87aecba6a"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi_checksum_derive"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af98d58e238b6aef9ff62a93b5c60caa710bdb49351434a639b9bd7b4c84c808"
+dependencies = [
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68640fa1b5dfbb4ccc149057c81b40adc51a01d295ce798c15c6c76f7e899907"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1363,48 +1460,13 @@ dependencies = [
  "once_cell",
  "paste",
  "static_assertions",
- "uniffi_macros",
-]
-
-[[package]]
-name = "uniffi_bindgen"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc4af3c0180c7e86c4a3acf2b6587af04ba2567b1e948993df10f421796621"
-dependencies = [
- "anyhow",
- "askama",
- "bincode",
- "camino",
- "clap",
- "fs-err",
- "goblin",
- "heck",
- "once_cell",
- "paste",
- "serde",
- "serde_json",
- "toml 0.5.9",
- "uniffi_meta",
- "weedle2",
-]
-
-[[package]]
-name = "uniffi_build"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510287c368a9386eb731ebe824a6fc6c82a105e20d020af1aa20519c1c1561db"
-dependencies = [
- "anyhow",
- "camino",
- "uniffi_bindgen",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.21.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8604503caa2cbcf271578dc51ca236d40e3b22e1514ffa2e638e2c39f6ad10"
+checksum = "76f72684ff48a8ff0ee95fde6dbcfa687236ad1789dc18205cb3305432a7b35c"
 dependencies = [
  "bincode",
  "camino",
@@ -1413,7 +1475,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 1.0.103",
+ "syn 2.0.27",
  "toml 0.5.9",
  "uniffi_build",
  "uniffi_meta",
@@ -1421,11 +1483,31 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.21.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9417cc653937681436b93838d8c5f97a5b8c58697813982ee8810bd1dc3b57"
+checksum = "fe3388a58b13dad8f0cdcbdee1c59af6408608ce8d85a3ef5d1429369ca7b217"
 dependencies = [
+ "anyhow",
+ "bytes",
  "serde",
+ "siphasher",
+ "uniffi_checksum_derive",
+ "uniffi_core",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb437a2c8565249274e381fd88bc75b539897f321b79022c9fe7e275d2c2bbb"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1627,13 +1709,37 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.0",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm 0.42.0",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1643,10 +1749,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1655,10 +1773,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1667,16 +1797,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-wysiwyg-composer"
+version = "2.3.1"
+dependencies = [
+ "uniffi",
+ "uniffi_build",
+ "uniffi_macros",
+ "widestring",
+ "wysiwyg",
+]
+
+[[package]]
 name = "uniffi_bindgen"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,17 +1867,6 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
  "widestring",
-]
-
-[[package]]
-name = "wysiwyg-ffi"
-version = "2.3.1"
-dependencies = [
- "uniffi",
- "uniffi_build",
- "uniffi_macros",
- "widestring",
- "wysiwyg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,8 +1382,7 @@ checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 [[package]]
 name = "uniffi"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da26ba712a8547207ededc70f3e0952c09754be9516c320f71731d2f18daf3e"
+source = "git+https://github.com/aringenbach/uniffi-rs.git?rev=7fea5def9b7a00cec35b94bd1916172cd0ca60fb#7fea5def9b7a00cec35b94bd1916172cd0ca60fb"
 dependencies = [
  "anyhow",
  "camino",
@@ -1414,8 +1413,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bff3ba24868022fc82e2f1558f3a0fdcc2655e1335459a35f25d1ec4ff1d0c"
+source = "git+https://github.com/aringenbach/uniffi-rs.git?rev=7fea5def9b7a00cec35b94bd1916172cd0ca60fb#7fea5def9b7a00cec35b94bd1916172cd0ca60fb"
 dependencies = [
  "anyhow",
  "askama",
@@ -1439,8 +1437,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b7cd03e17b997469e5438d1a491c3b9e2d41c2a87c86fd91ba96e87aecba6a"
+source = "git+https://github.com/aringenbach/uniffi-rs.git?rev=7fea5def9b7a00cec35b94bd1916172cd0ca60fb#7fea5def9b7a00cec35b94bd1916172cd0ca60fb"
 dependencies = [
  "anyhow",
  "camino",
@@ -1450,8 +1447,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af98d58e238b6aef9ff62a93b5c60caa710bdb49351434a639b9bd7b4c84c808"
+source = "git+https://github.com/aringenbach/uniffi-rs.git?rev=7fea5def9b7a00cec35b94bd1916172cd0ca60fb#7fea5def9b7a00cec35b94bd1916172cd0ca60fb"
 dependencies = [
  "quote",
  "syn 2.0.27",
@@ -1460,8 +1456,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68640fa1b5dfbb4ccc149057c81b40adc51a01d295ce798c15c6c76f7e899907"
+source = "git+https://github.com/aringenbach/uniffi-rs.git?rev=7fea5def9b7a00cec35b94bd1916172cd0ca60fb#7fea5def9b7a00cec35b94bd1916172cd0ca60fb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1476,8 +1471,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f72684ff48a8ff0ee95fde6dbcfa687236ad1789dc18205cb3305432a7b35c"
+source = "git+https://github.com/aringenbach/uniffi-rs.git?rev=7fea5def9b7a00cec35b94bd1916172cd0ca60fb#7fea5def9b7a00cec35b94bd1916172cd0ca60fb"
 dependencies = [
  "bincode",
  "camino",
@@ -1495,8 +1489,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3388a58b13dad8f0cdcbdee1c59af6408608ce8d85a3ef5d1429369ca7b217"
+source = "git+https://github.com/aringenbach/uniffi-rs.git?rev=7fea5def9b7a00cec35b94bd1916172cd0ca60fb#7fea5def9b7a00cec35b94bd1916172cd0ca60fb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1509,8 +1502,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb437a2c8565249274e381fd88bc75b539897f321b79022c9fe7e275d2c2bbb"
+source = "git+https://github.com/aringenbach/uniffi-rs.git?rev=7fea5def9b7a00cec35b94bd1916172cd0ca60fb#7fea5def9b7a00cec35b94bd1916172cd0ca60fb"
 dependencies = [
  "anyhow",
  "camino",
@@ -1665,8 +1657,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
+source = "git+https://github.com/aringenbach/uniffi-rs.git?rev=7fea5def9b7a00cec35b94bd1916172cd0ca60fb#7fea5def9b7a00cec35b94bd1916172cd0ca60fb"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ resolver = "2"
 rust-version = "1.71"
 
 [workspace.dependencies]
+# We use a custom version of Uniffi that renames symbols that might clash
+# with other Rust libraries. See https://github.com/mozilla/uniffi-rs/issues/1670
 uniffi = { git = "https://github.com/aringenbach/uniffi-rs.git", rev = "7fea5def9b7a00cec35b94bd1916172cd0ca60fb" }
 uniffi_macros = { git = "https://github.com/aringenbach/uniffi-rs.git", rev = "7fea5def9b7a00cec35b94bd1916172cd0ca60fb" }
 uniffi_build = { git = "https://github.com/aringenbach/uniffi-rs.git", rev = "7fea5def9b7a00cec35b94bd1916172cd0ca60fb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ resolver = "2"
 rust-version = "1.71"
 
 [workspace.dependencies]
-uniffi = "=0.24.1"
-uniffi_macros = "=0.24.1"
-uniffi_build = "=0.24.1"
+uniffi = { git = "https://github.com/aringenbach/uniffi-rs.git", rev = "7fea5def9b7a00cec35b94bd1916172cd0ca60fb" }
+uniffi_macros = { git = "https://github.com/aringenbach/uniffi-rs.git", rev = "7fea5def9b7a00cec35b94bd1916172cd0ca60fb" }
+uniffi_build = { git = "https://github.com/aringenbach/uniffi-rs.git", rev = "7fea5def9b7a00cec35b94bd1916172cd0ca60fb" }
 
 [profile.release]
 opt-level = 'z'     # Optimize for size.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,21 @@ members = [
     "bindings/wysiwyg-wasm",
     "crates/wysiwyg",
     "crates/matrix_mentions",
+    "uniffi-bindgen",
+]
+default-members = [
+    "crates/wysiwyg",
+    "crates/matrix_mentions",
 ]
 resolver = "2"
 
 [workspace.package]
 rust-version = "1.71"
+
+[workspace.dependencies]
+uniffi = "=0.24.1"
+uniffi_macros = "=0.24.1"
+uniffi_build = "=0.24.1"
 
 [profile.release]
 opt-level = 'z'     # Optimize for size.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: android ios web
 
 # The gradle plugin will take care of building the bindings too
-android: setup
+android: targets-android
 	cd platforms/android && \
 		./gradlew publishToMavenLocal
 
@@ -21,14 +21,10 @@ android-bindings-x86_64:
 	# Not copying into the Android project here, since the gradle plugin
 	# actually performs this build itself.
 
-
-IOS_PACKAGE_DIR := ../../platforms/ios/lib/WysiwygComposer
-IOS_GENERATION_DIR := .generated/ios
-
-ios: setup
+ios: targets-ios
 	@sh build_xcframework.sh
 
-web: setup
+web:
 	cd bindings/wysiwyg-wasm && \
 	npm install && \
 	npm run build && \
@@ -45,6 +41,17 @@ web-format:
 	cd platforms/web && \
 	yarn prettier --write .
 
+targets-android:
+	rustup target add aarch64-linux-android
+	rustup target add x86_64-linux-android
+	rustup target add i686-linux-android
+	rustup target add armv7-linux-androideabi
+
+targets-ios:
+	rustup target add aarch64-apple-ios
+	rustup target add aarch64-apple-ios-sim
+	rustup target add x86_64-apple-ios
+
 clean:
 	cargo clean
 	rm -rf bindings/wysiwyg-wasm/node_modules
@@ -52,7 +59,6 @@ clean:
 	rm -rf bindings/wysiwyg-ffi/src/generated
 	rm -rf platforms/android/out
 	cd platforms/android && ./gradlew clean
-
 
 test:
 	cargo test
@@ -62,7 +68,3 @@ coverage:
 	@echo "Requires `rustup component add llvm-tools-preview`"
 	@echo "Requires `cargo install cargo-llvm-cov`"
 	cargo llvm-cov --open
-
-setup:
-	cargo install uniffi_bindgen --version 0.21.0
-

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://gitlab.com/andybalaam/wysiwyg-rust"
 description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
-name = "wysiwyg-ffi"
+name = "uniffi-wysiwyg-composer"
 version = "2.3.1"
 rust-version = { workspace = true }
 

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -10,6 +10,10 @@ name = "uniffi-wysiwyg-composer"
 version = "2.3.1"
 rust-version = { workspace = true }
 
+[features]
+default = []
+assert-invariants = ["wysiwyg/assert-invariants"]
+
 [lib]
 crate-type = ["cdylib", "staticlib"]
 

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -17,10 +17,10 @@ crate-type = ["cdylib", "staticlib"]
 # Keep the uniffi version here in sync with the installed version of
 # uniffi-bindgen that is called from
 # ../../examples/example-android/app/build.gradle
-uniffi = "=0.21.0"
-uniffi_macros = "=0.21.0"
+uniffi = { workspace = true }
+uniffi_macros = { workspace = true }
 widestring = "1.0.2"
 wysiwyg = { path = "../../crates/wysiwyg" }
 
 [build-dependencies]
-uniffi_build = { version = "=0.21.0", features = ["builtin-bindgen"] }
+uniffi_build = { workspace = true, features = ["builtin-bindgen"] }

--- a/bindings/wysiwyg-ffi/README.md
+++ b/bindings/wysiwyg-ffi/README.md
@@ -7,18 +7,7 @@ Rust code that can be used to generate Kotlin and Swift bindings for wysiwyg-rus
 ### 1. Install Rust
 See the [installation guide](https://www.rust-lang.org/tools/install).
 
-### 2. Install `uniffi-bindgen`
-`uniffi-bindgen` is used to generate the Kotlin and Swift bindings.
-
-It's important that the version of `uniffi-bindgen` that you install globally matches the version of `uniffi` declared in this project.
-
-Find the version of `uniffi` in `bindings/wysiwyg-ffi/Cargo.toml` and install `uniffi-bindgen` using the following command:
-
-```bash
-cargo install uniffi_bindgen --version <uniffi-version>
-```
-
-### 3. Configure cross compilation
+### 2. Configure cross compilation
 Configure Rust for [cross compilation](https://rust-lang.github.io/rustup/cross-compilation.html) to any target platforms you'll need.
 
 ```bash
@@ -132,12 +121,8 @@ lipo -create \
 
 * Generate the bindings inside given output dir:
 
-⚠️ The installed version should always match the version used by Cargo, see
-`Cargo.toml` content inside this directory to retrieve it and use
-`cargo install uniffi_bindgen --version <VERSION_NUMBER>` if needed.
-
 ```bash
-uniffi-bindgen \
+cargo uniffi-bindgen \
     generate src/wysiwyg_composer.udl \
     --language swift \
     --config uniffi.toml \
@@ -163,6 +148,11 @@ xcodebuild -create-xcframework \
   -headers MY_OUTPUT_DIR/headers \
   -output MY_OUTPUT_DIR/ExampleRustBindings.xcframework"
 ```
+
+Note: Generating with xcodebuild is not recommended as it might
+make the resulting library clash with other Rust libraries or even
+some C/C++ libraries. See this [script](../../build_xcframework.sh) in the
+root directory for further details.
 
 Now you can use the framework wherever you see fit, just add the framework (as
 well as the generated Swift code from `MY_OUTPUT_DIR/Sources/`) as a dependency

--- a/bindings/wysiwyg-ffi/README.md
+++ b/bindings/wysiwyg-ffi/README.md
@@ -107,16 +107,16 @@ cargo build --release --target x86_64-apple-ios
 
 mkdir -p ../../target/ios-simulator
 lipo -create \
-  ../../target/x86_64-apple-ios/release/libwysiwyg_ffi.a \
-  ../../target/aarch64-apple-ios-sim/release/libwysiwyg_ffi.a \
-  -output ../../target/ios-simulator/libwysiwyg_ffi.a
+  ../../target/x86_64-apple-ios/release/libuniffi_wysiwyg_composer.a \
+  ../../target/aarch64-apple-ios-sim/release/libuniffi_wysiwyg_composer.a \
+  -output ../../target/ios-simulator/libuniffi_wysiwyg_composer.a
 ```
 
 * This will create static libraries for both iOS devices and simulators:
 
 ```
-../../target/x86_64-apple-ios/debug/libwysiwyg_ffi.a
-../../target/ios-simulator/libwysiwyg_ffi.a
+../../target/x86_64-apple-ios/debug/libuniffi_wysiwyg_composer.a
+../../target/ios-simulator/libuniffi_wysiwyg_composer.a
 ```
 
 * Generate the bindings inside given output dir:

--- a/build_xcframework.sh
+++ b/build_xcframework.sh
@@ -42,7 +42,7 @@ rm -rf $GENERATION_PATH
 
 # Generate headers & Swift bindings
 mkdir -p $GENERATION_PATH
-uniffi-bindgen generate $UDL_FILE_PATH -l swift --config $UNIFFI_CONFIG_FILE_PATH --out-dir $GENERATION_PATH
+cargo uniffi-bindgen generate $UDL_FILE_PATH -l swift --config $UNIFFI_CONFIG_FILE_PATH --out-dir $GENERATION_PATH
 
 # Move Swift file to expected location
 #

--- a/build_xcframework.sh
+++ b/build_xcframework.sh
@@ -5,10 +5,10 @@ GENERATION_PATH=.generated/ios
 UDL_FILE_PATH=bindings/wysiwyg-ffi/src/wysiwyg_composer.udl
 UNIFFI_CONFIG_FILE_PATH=bindings/wysiwyg-ffi/uniffi.toml
 
-ARM64_LIB_PATH=target/aarch64-apple-ios/release/libwysiwyg_ffi.a
-ARM64_SIM_LIB_PATH=target/aarch64-apple-ios-sim/release/libwysiwyg_ffi.a
-X86_LIB_PATH=target/x86_64-apple-ios/release/libwysiwyg_ffi.a
-SIM_LIB_PATH=target/ios-simulator/libwysiwyg_ffi.a
+ARM64_LIB_PATH=target/aarch64-apple-ios/release/libuniffi_wysiwyg_composer.a
+ARM64_SIM_LIB_PATH=target/aarch64-apple-ios-sim/release/libuniffi_wysiwyg_composer.a
+X86_LIB_PATH=target/x86_64-apple-ios/release/libuniffi_wysiwyg_composer.a
+SIM_LIB_PATH=target/ios-simulator/libuniffi_wysiwyg_composer.a
 
 IOS_PATH=platforms/ios
 TOOLS_PATH="${IOS_PATH}/tools"
@@ -27,9 +27,9 @@ XCFRAMEWORK_ARM64_MODULES_PATH="${XCFRAMEWORK_ARM64_PATH}/Modules"
 XCFRAMEWORK_ARM64_LIBRARY_PATH="${XCFRAMEWORK_ARM64_PATH}/WysiwygComposerFFI"
 
 # Build libraries for each platform
-cargo build -p wysiwyg-ffi --release --target aarch64-apple-ios
-cargo build -p wysiwyg-ffi --release --target aarch64-apple-ios-sim
-cargo build -p wysiwyg-ffi --release --target x86_64-apple-ios
+cargo build -p uniffi-wysiwyg-composer --release --target aarch64-apple-ios
+cargo build -p uniffi-wysiwyg-composer --release --target aarch64-apple-ios-sim
+cargo build -p uniffi-wysiwyg-composer --release --target x86_64-apple-ios
 
 # Merge x86 and simulator arm libraries with lipo
 mkdir -p target/ios-simulator

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -14,8 +14,8 @@ if (project.hasProperty("coverage")) {
 apply plugin: "com.vanniktech.maven.publish"
 
 cargo {
-    module = "../../../crates"       // Or whatever directory contains your Cargo.toml
-    libname = "uniffi-wysiwyg-composer"          // Or whatever matches Cargo.toml's [package] name.
+    module = "../../../bindings/wysiwyg-ffi"    // The directory which contains Cargo.toml
+    libname = "uniffi-wysiwyg-composer"         // The Cargo.toml's [package] name.
     targets = ["arm", "x86", "x86_64", "arm64"]
     targetIncludes = ["libuniffi_wysiwyg_composer.so"]
     targetDirectory = '../../../target'

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -95,8 +95,7 @@ dependencies {
 android.libraryVariants.all { variant ->
     def generateBindingTasks = tasks.register("generate${variant.name.capitalize()}UniFFIBindings", Exec) {
         workingDir "${project.projectDir}"
-        // Runs the bindings generation, note that you must have uniffi-bindgen installed and in your PATH environment variable
-        commandLine 'uniffi-bindgen', 'generate', '../../../bindings/wysiwyg-ffi/src/wysiwyg_composer.udl', '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
+        commandLine 'cargo', 'uniffi-bindgen', 'generate', '../../../bindings/wysiwyg-ffi/src/wysiwyg_composer.udl', '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
         dependsOn("cargoBuild")
     }
     tasks.preBuild.dependsOn(generateBindingTasks)

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -15,7 +15,7 @@ apply plugin: "com.vanniktech.maven.publish"
 
 cargo {
     module = "../../../crates"       // Or whatever directory contains your Cargo.toml
-    libname = "wysiwyg-ffi"          // Or whatever matches Cargo.toml's [package] name.
+    libname = "uniffi-wysiwyg-composer"          // Or whatever matches Cargo.toml's [package] name.
     targets = ["arm", "x86", "x86_64", "arm64"]
     targetIncludes = ["libuniffi_wysiwyg_composer.so"]
     targetDirectory = '../../../target'

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
@@ -86,7 +86,7 @@ class EditorEditTextInputTests {
         onView(withId(R.id.rich_text_edit_text))
             .perform(EditorActions.setMentionDisplayHandler(TestMentionDisplayHandler(TextDisplay.Pill)))
             .perform(typeText("Hello @"))
-            .perform(EditorActions.insertMentionAtSuggestion("alice", "link"))
+            .perform(EditorActions.insertMentionAtSuggestion("alice", "https://matrix.to/#/@alice:example.org"))
             .perform(pressKey(KeyEvent.KEYCODE_DEL)) // Delete the space added after the pill
             .perform(pressKey(KeyEvent.KEYCODE_DEL)) // Delete the pill
             .perform(pressKey(KeyEvent.KEYCODE_DEL)) // Delete the trailing space after "Hello"

--- a/uniffi-bindgen/Cargo.toml
+++ b/uniffi-bindgen/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "uniffi-bindgen"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+uniffi = { workspace = true, features = ["cli"] }

--- a/uniffi-bindgen/src/main.rs
+++ b/uniffi-bindgen/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}


### PR DESCRIPTION
Also adds a set of tools to help keep the same version everywhere. 

Also rename the ffi crate back to its previous non-standard name to avoid some issues with the Gradle plugin, see https://github.com/matrix-org/matrix-rich-text-editor/blob/main/platforms/android/README.md

Link to Uniffi-rs issue with multiple Rust libraries: https://github.com/mozilla/uniffi-rs/issues/1670