### PR TITLE
Set WysiwygComposerView as MainActor

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -18,6 +18,7 @@ import OSLog
 import SwiftUI
 
 /// Provides a SwiftUI displayable view for the composer UITextView component.
+@MainActor
 public struct WysiwygComposerView: UIViewRepresentable {
     // MARK: - Public
 


### PR DESCRIPTION
Might fix/silence some SwiftUI warnings about Publishing properties.
Issue seems to be with the `focused` property of the model but it's called from this view's context:

```swift
        public func textViewDidBeginEditing(_ textView: UITextView) {
            focused.wrappedValue = true
        }
        
        public func textViewDidEndEditing(_ textView: UITextView) {
            focused.wrappedValue = false
        }
```

