### PR TITLE
[Android] Expose style configuration for compose

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import io.element.android.wysiwyg.compose.RichTextEditor
+import io.element.android.wysiwyg.compose.RichTextEditorDefaults
 import io.element.android.wysiwyg.compose.rememberRichTextEditorState
 import io.element.wysiwyg.compose.ui.components.FormattingButtons
 import io.element.wysiwyg.compose.ui.theme.RichTextEditorTheme
@@ -33,6 +34,7 @@ class MainActivity : ComponentActivity() {
                         RichTextEditor(
                             state = state,
                             modifier = Modifier.fillMaxWidth(),
+                            style = RichTextEditorDefaults.style(),
                         )
                         FormattingButtons(
                             onResetText = {

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStyleTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStyleTest.kt
@@ -1,0 +1,76 @@
+package io.element.android.wysiwyg.compose
+
+import android.content.res.Resources.NotFoundException
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import io.element.android.wysiwyg.compose.testutils.StateFactory.createState
+import io.element.android.wysiwyg.compose.testutils.ViewMatchers.isRichTextEditor
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class RichTextEditorStyleTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val state = createState()
+    private val styleFlow = MutableStateFlow(RichTextEditorDefaults.style())
+
+    @Test
+    fun testContentIsStillDisplayedAfterSetStyle() = runTest {
+        showContent()
+
+        composeTestRule.runOnUiThread {
+            state.setHtml("<ul><li>Hello, world</li></ul>")
+        }
+
+        styleFlow.emit(
+            RichTextEditorDefaults.style(
+                bulletList = RichTextEditorDefaults.bulletListStyle(
+                    bulletRadius = 20.dp
+                )
+            )
+        )
+        composeTestRule.awaitIdle()
+
+        onView(isRichTextEditor())
+            .check(matches(withText("Hello, world")))
+    }
+
+    @Test(expected = NotFoundException::class)
+    fun testBadResourceThrows() = runTest {
+        val nonExistentDrawable = 0
+        showContent()
+
+        styleFlow.emit(
+            RichTextEditorDefaults.style(
+                codeBlock = RichTextEditorDefaults.codeBlockStyle(
+                    backgroundDrawable = nonExistentDrawable
+                )
+            )
+        )
+
+        composeTestRule.awaitIdle()
+    }
+
+    private fun showContent() =
+        composeTestRule.setContent {
+            val styleState by styleFlow.collectAsState()
+            MaterialTheme {
+                RichTextEditor(
+                    state = state,
+                    modifier = Modifier.fillMaxWidth(),
+                    style = styleState
+                )
+            }
+        }
+}

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.widget.addTextChangedListener
 import io.element.android.wysiwyg.EditorEditText
+import io.element.android.wysiwyg.compose.internal.toStyleConfig
 import io.element.android.wysiwyg.compose.internal.ViewConnection
 import io.element.android.wysiwyg.view.models.InlineFormat
 
@@ -17,11 +18,13 @@ import io.element.android.wysiwyg.view.models.InlineFormat
  *
  * @param state The state holder for this composable. See [rememberRichTextEditorState].
  * @param modifier The modifier for the layout
+ * @param style The styles to use for any customisable elements
  */
 @Composable
 fun RichTextEditor(
     state: RichTextEditorState,
     modifier: Modifier = Modifier,
+    style: RichTextEditorStyle = RichTextEditorDefaults.style(),
 ) {
     val context = LocalContext.current
 
@@ -88,5 +91,8 @@ fun RichTextEditor(
 
             view
         },
+        update = { view ->
+            view.setStyleConfig(style.toStyleConfig(view.context))
+        }
     )
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
@@ -1,0 +1,112 @@
+package io.element.android.wysiwyg.compose
+
+import io.element.android.wysiwyg.R as BaseR
+import androidx.annotation.DrawableRes
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Default config for the [RichTextEditor] composable.
+ */
+object RichTextEditorDefaults {
+
+    /**
+     * Creates the default set of style customisations for [RichTextEditor].
+     *
+     * @param bulletList A custom style for bullet lists.
+     * @param codeBlock A custom style for code blocks.
+     * @param inlineCode A custom style for inline code.
+     * @param pill A custom style for pills.
+     */
+    fun style(
+        bulletList: BulletListStyle = bulletListStyle(),
+        codeBlock: CodeBlockStyle = codeBlockStyle(),
+        inlineCode: InlineCodeStyle = inlineCodeStyle(),
+        pill: PillStyle = pillStyle(),
+    ): RichTextEditorStyle = RichTextEditorStyle(
+        bulletList = bulletList,
+        codeBlock = codeBlock,
+        inlineCode = inlineCode,
+        pill = pill,
+    )
+
+    /**
+     * Creates the default bullet list style for [RichTextEditor].
+     *
+     * @param bulletGapWidth The gap width between the bullet and the text.
+     * @param bulletRadius The radius of the bullet.
+     */
+    fun bulletListStyle(
+        bulletGapWidth: Dp = 2.dp,
+        bulletRadius: Dp = 2.dp,
+    ) = BulletListStyle(
+        bulletGapWidth = bulletGapWidth,
+        bulletRadius = bulletRadius,
+    )
+
+    /**
+     * Creates the default code block style for [RichTextEditor].
+     *
+     * @param leadingMargin The leading margin to apply
+     * @param verticalPadding The vertical padding to apply
+     * @param relativeTextSize The relative font scale to apply to code text
+     * @param backgroundDrawable The background drawable to use
+     */
+    fun codeBlockStyle(
+        leadingMargin: Dp = 16.dp,
+        verticalPadding: Dp = 8.dp,
+        relativeTextSize: Float = 0.85f,
+        @DrawableRes
+        backgroundDrawable: Int = BaseR.drawable.code_block_bg,
+    ) = CodeBlockStyle(
+        leadingMargin = leadingMargin,
+        verticalPadding = verticalPadding,
+        relativeTextSize = relativeTextSize,
+        backgroundDrawable = backgroundDrawable,
+    )
+
+    /**
+     * Creates the default inline code style for [RichTextEditor].
+     *
+     * @param horizontalPadding The horizontal padding to apply
+     * @param verticalPadding The vertical padding to apply
+     * @param relativeTextSize The relative font scale to apply to code text
+     * @param singleLineBg The background drawable to apply for single line code blocks
+     * @param multiLineBgLeft The background drawable to apply for the left side of multi line inline code
+     * @param multiLineBgMid The background drawable to apply for the middle of multi line inline code
+     * @param multiLineBgRight The background drawable to apply for the right side of multi line inline code
+     */
+    fun inlineCodeStyle(
+        horizontalPadding: Dp = 4.dp,
+        verticalPadding: Dp = 2.dp,
+        relativeTextSize: Float = 0.85f,
+        @DrawableRes
+        singleLineBg: Int = BaseR.drawable.inline_code_single_line_bg,
+        @DrawableRes
+        multiLineBgLeft: Int = BaseR.drawable.inline_code_multi_line_bg_left,
+        @DrawableRes
+        multiLineBgMid: Int = BaseR.drawable.inline_code_multi_line_bg_mid,
+        @DrawableRes
+        multiLineBgRight: Int = BaseR.drawable.inline_code_multi_line_bg_right,
+    ) = InlineCodeStyle(
+        horizontalPadding = horizontalPadding,
+        verticalPadding = verticalPadding,
+        relativeTextSize = relativeTextSize,
+        singleLineBg = singleLineBg,
+        multiLineBgLeft = multiLineBgLeft,
+        multiLineBgMid = multiLineBgMid,
+        multiLineBgRight = multiLineBgRight,
+    )
+
+    /**
+     * Creates the default pill style for [RichTextEditor].
+     *
+     * @param backgroundColor The background color to apply
+     */
+    fun pillStyle(
+        backgroundColor: Color = Color.Transparent,
+    ) = PillStyle(
+        backgroundColor = backgroundColor,
+    )
+}

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
@@ -1,0 +1,43 @@
+package io.element.android.wysiwyg.compose
+
+import androidx.annotation.DrawableRes
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+
+data class RichTextEditorStyle internal constructor(
+    val bulletList: BulletListStyle,
+    val codeBlock: CodeBlockStyle,
+    val inlineCode: InlineCodeStyle,
+    val pill: PillStyle,
+)
+
+data class BulletListStyle internal constructor(
+    val bulletGapWidth: Dp,
+    val bulletRadius: Dp,
+)
+
+data class CodeBlockStyle internal constructor(
+    val leadingMargin: Dp,
+    val verticalPadding: Dp,
+    val relativeTextSize: Float,
+    @DrawableRes
+    val backgroundDrawable: Int,
+)
+
+data class InlineCodeStyle internal constructor(
+    val horizontalPadding: Dp,
+    val verticalPadding: Dp,
+    val relativeTextSize: Float,
+    @DrawableRes
+    val singleLineBg: Int,
+    @DrawableRes
+    val multiLineBgLeft: Int,
+    @DrawableRes
+    val multiLineBgMid: Int,
+    @DrawableRes
+    val multiLineBgRight: Int,
+)
+
+data class PillStyle(
+    val backgroundColor: Color,
+)

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
@@ -1,0 +1,67 @@
+package io.element.android.wysiwyg.compose.internal
+
+import android.content.Context
+import android.content.res.Resources.NotFoundException
+import androidx.annotation.DrawableRes
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Density
+import androidx.core.content.ContextCompat
+import io.element.android.wysiwyg.compose.BulletListStyle
+import io.element.android.wysiwyg.compose.CodeBlockStyle
+import io.element.android.wysiwyg.compose.InlineCodeStyle
+import io.element.android.wysiwyg.compose.PillStyle
+import io.element.android.wysiwyg.compose.RichTextEditorStyle
+import io.element.android.wysiwyg.view.BulletListStyleConfig
+import io.element.android.wysiwyg.view.CodeBlockStyleConfig
+import io.element.android.wysiwyg.view.InlineCodeStyleConfig
+import io.element.android.wysiwyg.view.PillStyleConfig
+import io.element.android.wysiwyg.view.StyleConfig
+import kotlin.math.roundToInt
+
+internal fun RichTextEditorStyle.toStyleConfig(context: Context): StyleConfig = StyleConfig(
+    bulletList = bulletList.toStyleConfig(context),
+    inlineCode = inlineCode.toStyleConfig(context),
+    codeBlock = codeBlock.toStyleConfig(context),
+    pill = pill.toStyleConfig(),
+)
+
+internal fun BulletListStyle.toStyleConfig(context: Context): BulletListStyleConfig =
+    with(Density(context)) {
+        BulletListStyleConfig(
+            bulletGapWidth = bulletGapWidth.toPx(),
+            bulletRadius = bulletRadius.toPx(),
+        )
+    }
+
+internal fun InlineCodeStyle.toStyleConfig(context: Context): InlineCodeStyleConfig {
+    val density = Density(context)
+    return InlineCodeStyleConfig(
+        horizontalPadding = with(density) { horizontalPadding.toPx().roundToInt() },
+        verticalPadding = with(density) { verticalPadding.toPx().roundToInt() },
+        relativeTextSize = relativeTextSize,
+        singleLineBg = context.requireDrawable(singleLineBg),
+        multiLineBgLeft = context.requireDrawable(multiLineBgLeft),
+        multiLineBgMid = context.requireDrawable(multiLineBgMid),
+        multiLineBgRight = context.requireDrawable(multiLineBgRight),
+    )
+}
+
+internal fun CodeBlockStyle.toStyleConfig(context: Context): CodeBlockStyleConfig {
+    val density = Density(context)
+    return CodeBlockStyleConfig(
+        leadingMargin = with(density) { leadingMargin.toPx().roundToInt() },
+        verticalPadding = with(density) { verticalPadding.toPx().roundToInt() },
+        relativeTextSize = relativeTextSize,
+        backgroundDrawable = context.requireDrawable(backgroundDrawable),
+    )
+}
+
+internal fun PillStyle.toStyleConfig(): PillStyleConfig =
+    PillStyleConfig(
+        backgroundColor = backgroundColor.toArgb(),
+    )
+
+private fun Context.requireDrawable(
+    @DrawableRes drawable: Int
+) = ContextCompat.getDrawable(this, drawable)
+    ?: throw NotFoundException("Drawable not found")

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -25,10 +25,11 @@ class InterceptInputConnectionIntegrationTest {
         provideComposer = { newComposerModel() },
         htmlConverter = AndroidHtmlConverter(
             provideHtmlToSpansParser = { html ->
+                val styleConfig = createFakeStyleConfig()
                 HtmlToSpansParser(
                     AndroidResourcesHelper(app),
                     html,
-                    createFakeStyleConfig(),
+                    styleConfig = { styleConfig },
                     mentionDisplayHandler = null,
                 )
             },

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
@@ -141,6 +141,15 @@ internal class EditorViewModel(
         return stringToSpans(getContentAsMessageHtml())
     }
 
+    /**
+     * Get the Rust model's internal representation of it's content.
+     *
+     * Note that this should not be used for messages; instead [getContentAsMessageHtml] should be used.
+     */
+    internal fun getInternalHtml(): String {
+        return composer?.getContentAsHtml().orEmpty()
+    }
+
     fun actionStates(): Map<ComposerAction, ActionState>? {
         return composer?.actionStates()
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -43,7 +43,7 @@ import kotlin.math.roundToInt
 internal class HtmlToSpansParser(
     private val resourcesHelper: ResourcesHelper,
     private val html: String,
-    private val styleConfig: StyleConfig,
+    private val styleConfig: () -> StyleConfig,
     private val mentionDisplayHandler: MentionDisplayHandler?,
 ) : ContentHandler {
 
@@ -240,9 +240,9 @@ internal class HtmlToSpansParser(
                 }
 
                 val codeSpan = CodeBlockSpan(
-                    leadingMargin = styleConfig.codeBlock.leadingMargin,
-                    verticalPadding = styleConfig.codeBlock.verticalPadding,
-                    relativeSizeProportion = styleConfig.codeBlock.relativeTextSize,
+                    leadingMargin = styleConfig().codeBlock.leadingMargin,
+                    verticalPadding = styleConfig().codeBlock.verticalPadding,
+                    relativeSizeProportion = styleConfig().codeBlock.relativeTextSize,
                 )
                 replacePlaceholderWithPendingSpan(
                     placeholder = last.span,
@@ -299,7 +299,7 @@ internal class HtmlToSpansParser(
             InlineFormat.Underline -> UnderlineSpan()
             InlineFormat.StrikeThrough -> StrikethroughSpan()
             InlineFormat.InlineCode -> InlineCodeSpan(
-                relativeSizeProportion = styleConfig.inlineCode.relativeTextSize
+                relativeSizeProportion = styleConfig().inlineCode.relativeTextSize
             )
         }
         replacePlaceholderWithPendingSpan(last.span, span, last.start, text.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
@@ -349,7 +349,7 @@ internal class HtmlToSpansParser(
                 )
             }
             TextDisplay.Pill -> {
-                val span = PillSpan(resourcesHelper.getColor(styleConfig.pill.backgroundColor))
+                val span = PillSpan(resourcesHelper.getColor(styleConfig().pill.backgroundColor))
                 replacePlaceholderWithPendingSpan(
                     last.span,
                     span,
@@ -373,8 +373,8 @@ internal class HtmlToSpansParser(
     }
 
     private fun createListSpan(last: PlaceholderSpan.ListItem): ParagraphStyle {
-        val gapWidth = styleConfig.bulletList.bulletGapWidth.roundToInt()
-        val bulletRadius = styleConfig.bulletList.bulletRadius.roundToInt()
+        val gapWidth = styleConfig().bulletList.bulletGapWidth.roundToInt()
+        val bulletRadius = styleConfig().bulletList.bulletRadius.roundToInt()
 
         return if (last.ordered) {
             // TODO: provide typeface and textSize somehow
@@ -517,7 +517,7 @@ internal class HtmlToSpansParser(
                 val span = when (display) {
                     is TextDisplay.Custom -> CustomReplacementSpan(display.customSpan)
                     TextDisplay.Pill -> PillSpan(
-                        resourcesHelper.getColor(styleConfig.pill.backgroundColor)
+                        resourcesHelper.getColor(styleConfig().pill.backgroundColor)
                     )
                     TextDisplay.Plain -> null
                 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/StyleConfig.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/StyleConfig.kt
@@ -3,8 +3,18 @@ package io.element.android.wysiwyg.view
 import android.graphics.drawable.Drawable
 import androidx.annotation.ColorRes
 import androidx.annotation.Px
+import io.element.android.wysiwyg.EditorEditText
 
-internal data class StyleConfig(
+
+/**
+ * Style configuration for the [EditorEditText].
+ *
+ * @property bulletList A custom style for bullet lists.
+ * @property codeBlock A custom style for code blocks.
+ * @property inlineCode A custom style for inline code.
+ * @property pill A custom style for pills.
+ */
+data class StyleConfig(
     val bulletList: BulletListStyleConfig,
 
     val inlineCode: InlineCodeStyleConfig,
@@ -14,11 +24,28 @@ internal data class StyleConfig(
     val pill: PillStyleConfig,
 )
 
+/**
+ * Style configuration for the bullet list.
+ *
+ * @property bulletGapWidth The gap width between the bullet and the text.
+ * @property bulletRadius The radius of the bullet.
+ */
 data class BulletListStyleConfig(
     @Px val bulletGapWidth: Float,
     @Px val bulletRadius: Float,
 )
 
+/**
+ * Style configuration for the inline code.
+ *
+ * @property horizontalPadding The horizontal padding to apply
+ * @property verticalPadding The vertical padding to apply
+ * @property relativeTextSize The relative font scale to apply to code text
+ * @property singleLineBg The background drawable to apply for single line code blocks
+ * @property multiLineBgLeft The background drawable to apply for the left side of multi line inline code
+ * @property multiLineBgMid The background drawable to apply for the middle of multi line inline code
+ * @property multiLineBgRight The background drawable to apply for the right side of multi line inline code
+ */
 data class InlineCodeStyleConfig(
     @Px val horizontalPadding: Int,
     @Px val verticalPadding: Int,
@@ -29,6 +56,14 @@ data class InlineCodeStyleConfig(
     val multiLineBgRight: Drawable,
 )
 
+/**
+ * Style configuration for code blocks.
+ *
+ * @property leadingMargin The leading margin to apply
+ * @property verticalPadding The vertical padding to apply
+ * @property relativeTextSize The relative font scale to apply to code text
+ * @property backgroundDrawable The background drawable to use
+ */
 data class CodeBlockStyleConfig(
     @Px val leadingMargin: Int,
     @Px val verticalPadding: Int,
@@ -36,6 +71,11 @@ data class CodeBlockStyleConfig(
     val backgroundDrawable: Drawable,
 )
 
+/**
+ * Style configuration for pills.
+ *
+ * @property backgroundColor The background color to apply
+ */
 data class PillStyleConfig(
     @ColorRes
     val backgroundColor: Int,

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -5,7 +5,6 @@ import io.element.android.wysiwyg.display.TextDisplay
 import io.element.android.wysiwyg.display.MentionDisplayHandler
 import io.element.android.wysiwyg.test.fakes.createFakeStyleConfig
 import io.element.android.wysiwyg.test.utils.dumpSpans
-import io.element.android.wysiwyg.view.spans.PillSpan
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
@@ -161,10 +160,11 @@ class HtmlToSpansParserTest {
         mentionDisplayHandler: MentionDisplayHandler? = null,
     ): Spanned {
         val app = RuntimeEnvironment.getApplication()
+        val styleConfig = createFakeStyleConfig()
         return HtmlToSpansParser(
             resourcesHelper = AndroidResourcesHelper(application = app),
             html = html,
-            styleConfig = createFakeStyleConfig(),
+            styleConfig = { styleConfig },
             mentionDisplayHandler = mentionDisplayHandler,
         ).convert()
     }


### PR DESCRIPTION
## Changes

- Expose programmatic view API for setting style
- Expose compose API for setting style

## Context

Previously, the only way to apply styles was through the view XML properties.

- Part of https://github.com/matrix-org/matrix-rich-text-editor/issues/315