### PR TITLE
[iOS] Handle paste and key commands

### DIFF
--- a/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
+++ b/platforms/ios/example/Wysiwyg.xcodeproj/project.pbxproj
@@ -147,9 +147,9 @@
 				A6472CAA2886CF830021A0E8 /* WysiwygApp.swift */,
 				A6472CAE2886CF840021A0E8 /* Assets.xcassets */,
 				A6F3FC0228D4659E00C170E8 /* Extensions */,
+				A6E13E4629A7AB3600A85A55 /* Mocks */,
 				A6F4D0CD29AE0BE100087A3E /* Pills */,
 				A6472CB02886CF840021A0E8 /* Preview Content */,
-				A6E13E4629A7AB3600A85A55 /* Mocks */,
 				A6C2157A28C0F63400C8E727 /* Views */,
 			);
 			path = Wysiwyg;

--- a/platforms/ios/example/Wysiwyg/Views/Composer.swift
+++ b/platforms/ios/example/Wysiwyg/Views/Composer.swift
@@ -21,6 +21,9 @@ import WysiwygComposer
 /// that grows to a max height.
 struct Composer: View {
     @ObservedObject var viewModel: WysiwygComposerViewModel
+    let itemProviderHelper: WysiwygItemProviderHelper?
+    let keyCommandHandler: KeyCommandHandler?
+    let pasteHandler: PasteHandler?
     let minTextViewHeight: CGFloat = 20
     let borderHeight: CGFloat = 40
     @State var focused = false
@@ -34,7 +37,10 @@ struct Composer: View {
             HStack {
                 WysiwygComposerView(
                     focused: $focused,
-                    viewModel: viewModel
+                    viewModel: viewModel,
+                    itemProviderHelper: itemProviderHelper,
+                    keyCommandHandler: keyCommandHandler,
+                    pasteHandler: pasteHandler
                 )
                 .tintColor(.green)
                 .placeholder("Placeholder", color: .gray)
@@ -75,6 +81,9 @@ struct Composer: View {
 struct Composer_Previews: PreviewProvider {
     static let viewModel = WysiwygComposerViewModel()
     static var previews: some View {
-        Composer(viewModel: viewModel)
+        Composer(viewModel: viewModel,
+                 itemProviderHelper: nil,
+                 keyCommandHandler: nil,
+                 pasteHandler: nil)
     }
 }

--- a/platforms/ios/example/Wysiwyg/Views/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/Views/ContentView.swift
@@ -34,7 +34,19 @@ struct ContentView: View {
     var body: some View {
         Spacer()
             .frame(width: nil, height: 50, alignment: .center)
-        Composer(viewModel: viewModel)
+        Composer(viewModel: viewModel,
+                 itemProviderHelper: nil,
+                 keyCommandHandler: { keyCommand in
+                     switch keyCommand {
+                     case .enter:
+                         sentMessage = viewModel.content
+                         viewModel.clearContent()
+                         return true
+                     case .shiftEnter:
+                         return false
+                     }
+                 },
+                 pasteHandler: { _ in })
         Button("Force crash") {
             viewModel.setHtmlContent("<//strong>")
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -301,16 +301,7 @@ public extension WysiwygComposerViewModel {
             update = model.backspace()
             shouldAcceptChange = false
         } else if replacementText.count == 1, replacementText[String.Index(utf16Offset: 0, in: replacementText)].isNewline {
-            update = model.enter()
-            // Pending formats need to be reapplied to the
-            // NSAttributedString upon next character input if we
-            // are in a structure that might add non-formatted
-            // representation chars to it (e.g. NBSP/ZWSP, list prefixes)
-            if !model
-                .reversedActions
-                .isDisjoint(with: [.codeBlock, .quote, .orderedList, .unorderedList]) {
-                hasPendingFormats = true
-            }
+            update = createEnterUpdate()
             shouldAcceptChange = false
         } else {
             update = model.replaceText(newText: replacementText)
@@ -385,6 +376,10 @@ public extension WysiwygComposerViewModel {
     
     func getLinkAction() -> LinkAction {
         model.getLinkAction()
+    }
+
+    func enter() {
+        applyUpdate(createEnterUpdate(), skipTextViewUpdate: false)
     }
 }
 
@@ -584,6 +579,20 @@ private extension WysiwygComposerViewModel {
         }
 
         return markdownContent
+    }
+
+    func createEnterUpdate() -> ComposerUpdate {
+        let update = model.enter()
+        // Pending formats need to be reapplied to the
+        // NSAttributedString upon next character input if we
+        // are in a structure that might add non-formatted
+        // representation chars to it (e.g. NBSP/ZWSP, list prefixes)
+        if !model
+            .reversedActions
+            .isDisjoint(with: [.codeBlock, .quote, .orderedList, .unorderedList]) {
+            hasPendingFormats = true
+        }
+        return update
     }
 }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -38,4 +38,7 @@ public protocol WysiwygComposerViewModelProtocol: AnyObject {
 
     /// Notify that the text view content has changed.
     func didUpdateText()
+
+    /// Apply an enter/return key event.
+    func enter()
 }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygKeyCommand.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygKeyCommand.swift
@@ -1,0 +1,48 @@
+//
+// Copyright 2023 The Matrix.org Foundation C.I.C
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+/// An enum describing key commands that can be handled by the hosting application.
+/// This can be done by providing a `KeyCommandHandler` to the `WysiwygComposerView`.
+/// If handler is nil, or if the handler returns false, a default behaviour will be applied (see cases description).
+public enum WysiwygKeyCommand: CaseIterable {
+    /// User pressed `enter`. Default behaviour: a line feed is created.
+    /// Note: in the context of a messaging app, this is usually used to send a message.
+    case enter
+    /// User pressed `shift` + `enter`. Default behaviour: a line feed is created.
+    case shiftEnter
+
+    var input: String {
+        switch self {
+        case .enter, .shiftEnter:
+            return "\r"
+        }
+    }
+
+    var modifierFlags: UIKeyModifierFlags {
+        switch self {
+        case .enter:
+            return []
+        case .shiftEnter:
+            return .shift
+        }
+    }
+
+    static func from(_ keyCommand: UIKeyCommand) -> WysiwygKeyCommand? {
+        WysiwygKeyCommand.allCases.first(where: { $0.input == keyCommand.input && $0.modifierFlags == keyCommand.modifierFlags })
+    }
+}

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerSnapshotTests/SnapshotTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerSnapshotTests/SnapshotTests.swift
@@ -28,7 +28,11 @@ class SnapshotTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         let binding: Binding<Bool> = .init(get: { true }, set: { _ in })
-        let composerView = WysiwygComposerView(focused: binding, viewModel: viewModel)
+        let composerView = WysiwygComposerView(focused: binding,
+                                               viewModel: viewModel,
+                                               itemProviderHelper: nil,
+                                               keyCommandHandler: nil,
+                                               pasteHandler: nil)
             .placeholder("Placeholder")
         hostingController = UIHostingController(rootView: composerView)
     }


### PR DESCRIPTION
* Add an API to delegate items paste handling to the hosting application.
* Add an API to allow the hosting application to override some key commands behaviour (e.g. press `enter` to send a message) => This could be expanded further in order to handle delete word / delete line for iOS user using a physical keyboard if the default behaviour needs improvement.

Unfortunately I couldn't build some UITests for this bit because the key input API for XCTest is only available for a MacOS environment and not for iOS. Will come back with some tests for this later if I find something useful. 