### PR TITLE
[Android] Publish compose library artifact

### DIFF
--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -1,6 +1,25 @@
-# Matrix Rich Text Editor Android Sample
+# Matrix Rich Text Editor Android
 
-## Possible issues:
+![Latest release badge](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Fs01.oss.sonatype.org%2Fcontent%2Fgroups%2Fpublic%2Fio%2Felement%2Fandroid%2Fwysiwyg%2Fmaven-metadata.xml&query=%2Fmetadata%2Fversioning%2Fversions%2Fversion%5Blast()%5D&label=Latest%20release)
+
+## Usage
+
+```kotlin
+// Base library
+implementation("io.element.android:wysiwyg:$version")
+
+// Compose support
+implementation("io.element.android:wysiwyg-compose:$version")
+```
+
+## Examples
+
+There are two example apps that show how to build an app using this library:
+
+- `<project>/platforms/android/example-compose` contains an example app which shows how to integrate the editor into a Jetpack Compose based app.
+- `<project>/platforms/android/example-view` contains an example app which shows how to integrate the editor into a traditional View / XML layout based app.
+
+## Troubleshooting
 
 ### UnsatisfiedLinkError
 When the bindings are generated, they point to the wrong library name:

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -5,7 +5,6 @@ plugins {
     alias libs.plugins.kotlin.android apply false
     alias libs.plugins.rust.android
     alias libs.plugins.sonarqube
-    alias libs.plugins.maven.publish
 }
 
 def launchTask = getGradle()

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -31,7 +31,7 @@ SONATYPE_HOST=S01
 RELEASE_SIGNING_ENABLED=true
 
 GROUP=io.element.android
-POM_ARTIFACT_ID=wysiwyg
+# POM_ARTIFACT_ID is configured in each module's gradle.properties
 VERSION_NAME=2.4.1
 
 POM_NAME=Matrix WYSIWYG

--- a/platforms/android/gradle/libs.versions.toml
+++ b/platforms/android/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ espresso = "3.5.1"
 agp = "8.1.0"
 kotlin-android = "1.9.0"
 jacoco = "0.8.8"
+maven-publish = "0.25.3"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -31,7 +32,8 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin-android" }
 rust-android = { id = "org.mozilla.rust-android-gradle.rust-android", version = "0.9.3" }
 sonarqube = { id = "org.sonarqube", version = "3.4.0.2513" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.25.3" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
+maven-publish-base = { id = "com.vanniktech.maven.publish.base", version.ref = "maven-publish" }
 jacoco-android = { id = "com.mxalbert.gradle.jacoco-android", version = "0.2.1" }
 
 [libraries]

--- a/platforms/android/gradle/libs.versions.toml
+++ b/platforms/android/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin-android" }
 rust-android = { id = "org.mozilla.rust-android-gradle.rust-android", version = "0.9.3" }
 sonarqube = { id = "org.sonarqube", version = "3.4.0.2513" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.25.3" }
 jacoco-android = { id = "com.mxalbert.gradle.jacoco-android", version = "0.2.1" }
 
 [libraries]

--- a/platforms/android/library-compose/build.gradle
+++ b/platforms/android/library-compose/build.gradle
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
@@ -7,6 +9,16 @@ plugins {
 
 if (project.hasProperty("coverage")) {
     apply plugin: 'jacoco'
+}
+
+apply plugin: "com.vanniktech.maven.publish.base"
+
+mavenPublishing {
+    pomFromGradleProperties()
+
+    def publishJavaDoc = false // https://github.com/Kotlin/dokka/issues/2956
+    def publishSources = true
+    configure(new AndroidSingleVariantLibrary("release", publishSources, publishJavaDoc))
 }
 
 android {

--- a/platforms/android/library-compose/build.gradle
+++ b/platforms/android/library-compose/build.gradle
@@ -5,13 +5,12 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 
     alias libs.plugins.jacoco.android
+    alias libs.plugins.maven.publish.base
 }
 
 if (project.hasProperty("coverage")) {
     apply plugin: 'jacoco'
 }
-
-apply plugin: "com.vanniktech.maven.publish.base"
 
 mavenPublishing {
     pomFromGradleProperties()

--- a/platforms/android/library-compose/gradle.properties
+++ b/platforms/android/library-compose/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=wysiwyg-compose

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -4,14 +4,14 @@ plugins {
 
     // Rust
     id 'org.mozilla.rust-android-gradle.rust-android'
+
     alias libs.plugins.jacoco.android
+    alias libs.plugins.maven.publish
 }
 
 if (project.hasProperty("coverage")) {
     apply plugin: 'jacoco'
 }
-
-apply plugin: "com.vanniktech.maven.publish"
 
 cargo {
     module = "../../../bindings/wysiwyg-ffi"    // The directory which contains Cargo.toml

--- a/platforms/android/library/gradle.properties
+++ b/platforms/android/library/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=wysiwyg


### PR DESCRIPTION
## Changes

- Publish the `library-compose` module as `io.element.android:wysiwyg-compose`
- Add usage documentation ([rendered](https://github.com/matrix-org/matrix-rich-text-editor/blob/jonny/publish/platforms/android/README.md)

## Context

- Part of https://github.com/matrix-org/matrix-rich-text-editor/issues/315