### PR TITLE
[Android] Fix publication task for compose library

### DIFF
--- a/platforms/android/library-compose/build.gradle
+++ b/platforms/android/library-compose/build.gradle
@@ -14,6 +14,7 @@ if (project.hasProperty("coverage")) {
 
 mavenPublishing {
     pomFromGradleProperties()
+    publishToMavenCentral()
 
     def publishJavaDoc = false // https://github.com/Kotlin/dokka/issues/2956
     def publishSources = true


### PR DESCRIPTION
## Changes

- Configure the maven publish plugin to create Gradle tasks necessary for publishing the compose library to the remote repository (`publishAllPublicationsToMavenCentralRepository` etc).

## Context

- Part of https://github.com/matrix-org/matrix-rich-text-editor/issues/315


