### PR TITLE
[Android] Expose more compose options

### DIFF
--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStyleTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStyleTest.kt
@@ -23,7 +23,8 @@ class RichTextEditorStyleTest {
     val composeTestRule = createComposeRule()
 
     private val state = createState()
-    private val styleFlow = MutableStateFlow(RichTextEditorDefaults.style())
+    private val bulletRadius = MutableStateFlow(2.dp)
+    private val codeBg = MutableStateFlow(io.element.android.wysiwyg.R.drawable.code_block_bg)
 
     @Test
     fun testContentIsStillDisplayedAfterSetStyle() = runTest {
@@ -33,13 +34,8 @@ class RichTextEditorStyleTest {
             state.setHtml("<ul><li>Hello, world</li></ul>")
         }
 
-        styleFlow.emit(
-            RichTextEditorDefaults.style(
-                bulletList = RichTextEditorDefaults.bulletListStyle(
-                    bulletRadius = 20.dp
-                )
-            )
-        )
+        bulletRadius.emit(20.dp)
+
         composeTestRule.awaitIdle()
 
         onView(isRichTextEditor())
@@ -51,25 +47,28 @@ class RichTextEditorStyleTest {
         val nonExistentDrawable = 0
         showContent()
 
-        styleFlow.emit(
-            RichTextEditorDefaults.style(
-                codeBlock = RichTextEditorDefaults.codeBlockStyle(
-                    backgroundDrawable = nonExistentDrawable
-                )
-            )
-        )
+        codeBg.emit(nonExistentDrawable)
 
         composeTestRule.awaitIdle()
     }
 
     private fun showContent() =
         composeTestRule.setContent {
-            val styleState by styleFlow.collectAsState()
+            val bulletRadius by bulletRadius.collectAsState()
+            val codeBg by codeBg.collectAsState()
+            val style = RichTextEditorDefaults.style(
+                bulletList = RichTextEditorDefaults.bulletListStyle(
+                    bulletRadius = bulletRadius
+                ),
+                codeBlock = RichTextEditorDefaults.codeBlockStyle(
+                    backgroundDrawable = codeBg
+                )
+            )
             MaterialTheme {
                 RichTextEditor(
                     state = state,
                     modifier = Modifier.fillMaxWidth(),
-                    style = styleState
+                    style = style
                 )
             }
         }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -63,6 +63,7 @@ fun RichTextEditor(
                 addTextChangedListener {
                     state.messageHtml = getContentAsMessageHtml()
                     state.messageMarkdown = getMarkdown()
+                    state.lineCount = lineCount
                 }
 
                 // Set the style closer to a BasicTextField composable

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -1,14 +1,18 @@
 package io.element.android.wysiwyg.compose
 
+import android.os.Build
+import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
 import io.element.android.wysiwyg.EditorEditText
-import io.element.android.wysiwyg.compose.internal.toStyleConfig
 import io.element.android.wysiwyg.compose.internal.ViewConnection
+import io.element.android.wysiwyg.compose.internal.toStyleConfig
 import io.element.android.wysiwyg.view.models.InlineFormat
 
 /**
@@ -102,6 +106,12 @@ fun RichTextEditor(
         },
         update = { view ->
             view.setStyleConfig(style.toStyleConfig(view.context))
+            view.setTextColor(style.text.color.toArgb())
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val cursorDrawable = ContextCompat.getDrawable(view.context, R.drawable.cursor)
+                cursorDrawable?.setTint(style.cursor.color.toArgb())
+                view.textCursorDrawable = cursorDrawable
+            }
         }
     )
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -65,6 +65,10 @@ fun RichTextEditor(
                     state.messageMarkdown = getMarkdown()
                 }
 
+                // Set the style closer to a BasicTextField composable
+                setBackgroundDrawable(null)
+                setPadding(0, 0, 0, 0)
+
                 // Restore the state of the view with the saved state
                 setHtml(state.messageHtml)
             }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -57,6 +57,8 @@ fun RichTextEditor(
                 menuActionListener = EditorEditText.OnMenuActionChangedListener { menuAction ->
                     state.menuAction = menuAction
                 }
+                onFocusChangeListener =
+                    View.OnFocusChangeListener { _, hasFocus -> state.hasFocus = hasFocus }
 
                 addTextChangedListener {
                     state.messageHtml = getContentAsMessageHtml()
@@ -87,6 +89,8 @@ fun RichTextEditor(
                 override fun toggleQuote() = view.toggleQuote()
 
                 override fun setHtml(html: String) = view.setHtml(html)
+
+                override fun requestFocus() = view.requestFocus()
             }
 
             view

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
@@ -2,6 +2,8 @@ package io.element.android.wysiwyg.compose
 
 import io.element.android.wysiwyg.R as BaseR
 import androidx.annotation.DrawableRes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -18,17 +20,25 @@ object RichTextEditorDefaults {
      * @param codeBlock A custom style for code blocks.
      * @param inlineCode A custom style for inline code.
      * @param pill A custom style for pills.
+     * @param textColor Color of the text displayed in the editor.
+     * @param cursorDrawable Color of the cursor displayed in the editor.
+     *                    Only supported on API 29 and above.
      */
+    @Composable
     fun style(
         bulletList: BulletListStyle = bulletListStyle(),
         codeBlock: CodeBlockStyle = codeBlockStyle(),
         inlineCode: InlineCodeStyle = inlineCodeStyle(),
         pill: PillStyle = pillStyle(),
+        text: TextStyle = textStyle(),
+        cursor: CursorStyle = cursorStyle(),
     ): RichTextEditorStyle = RichTextEditorStyle(
         bulletList = bulletList,
         codeBlock = codeBlock,
         inlineCode = inlineCode,
         pill = pill,
+        text = text,
+        cursor = cursor,
     )
 
     /**
@@ -108,5 +118,29 @@ object RichTextEditorDefaults {
         backgroundColor: Color = Color.Transparent,
     ) = PillStyle(
         backgroundColor = backgroundColor,
+    )
+
+    /**
+     * Creates the default text style for [RichTextEditor].
+     *
+     * @param color The text color to apply
+     */
+    @Composable
+    fun textStyle(
+        color: Color = MaterialTheme.colorScheme.onSurface,
+    ) = TextStyle(
+        color = color,
+    )
+
+    /**
+     * Creates the default cursor style for [RichTextEditor].
+     *
+     * @param color The color to apply to the cursor
+     */
+    @Composable
+    fun cursorStyle(
+        color: Color = MaterialTheme.colorScheme.primary,
+    ) = CursorStyle(
+        color = color,
     )
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
@@ -133,6 +133,12 @@ class RichTextEditorState internal constructor() {
         viewConnection?.requestFocus() ?: false
 
     /**
+     * The number of lines displayed in the editor.
+     */
+    var lineCount: Int by mutableStateOf(1)
+        internal set
+
+    /**
      * Handle any of the actions in [ComposerAction].
      *
      * Note that formatting actions simply delegate to their respective `toggleX()` functions.

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
@@ -121,6 +121,18 @@ class RichTextEditorState internal constructor() {
         internal set
 
     /**
+     * Whether the editor input field currently has focus.
+     */
+    var hasFocus: Boolean by mutableStateOf(false)
+        internal set
+
+    /**
+     * Request focus of the editor input field.
+     */
+    fun requestFocus(): Boolean =
+        viewConnection?.requestFocus() ?: false
+
+    /**
      * Handle any of the actions in [ComposerAction].
      *
      * Note that formatting actions simply delegate to their respective `toggleX()` functions.

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
@@ -9,6 +9,8 @@ data class RichTextEditorStyle internal constructor(
     val codeBlock: CodeBlockStyle,
     val inlineCode: InlineCodeStyle,
     val pill: PillStyle,
+    val text: TextStyle,
+    val cursor: CursorStyle,
 )
 
 data class BulletListStyle internal constructor(
@@ -40,4 +42,12 @@ data class InlineCodeStyle internal constructor(
 
 data class PillStyle(
     val backgroundColor: Color,
+)
+
+data class TextStyle(
+    val color: Color,
+)
+
+data class CursorStyle(
+    val color: Color,
 )

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/ViewConnection.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/ViewConnection.kt
@@ -12,4 +12,5 @@ internal interface ViewConnection {
     fun indent()
     fun unindent()
     fun setHtml(html: String)
+    fun requestFocus(): Boolean
 }

--- a/platforms/android/library-compose/src/main/res/drawable/cursor.xml
+++ b/platforms/android/library-compose/src/main/res/drawable/cursor.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size android:width="2sp" />
+    <solid android:color="?attr/colorPrimary" />
+</shape>


### PR DESCRIPTION
## Changes

- Expose focus APIs
- Remove default background and padding
- Expose line count APIs
- Expose text and cursor style settings

## Context

- Part of https://github.com/matrix-org/matrix-rich-text-editor/issues/315