### PR TITLE
[Android] Add preview support for compose

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import io.element.android.wysiwyg.compose.RichTextEditor
 import io.element.android.wysiwyg.compose.RichTextEditorDefaults
 import io.element.android.wysiwyg.compose.rememberRichTextEditorState
@@ -47,6 +49,18 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+}
+
+@Preview
+@Composable
+fun EditorPreview() {
+    RichTextEditorTheme {
+        val state = rememberRichTextEditorState("Hello, world")
+        RichTextEditor(
+            state = state,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
@@ -22,7 +22,19 @@ import uniffi.wysiwyg_composer.MenuAction
  * multiple [RichTextEditor] composables.
  */
 @Stable
-class RichTextEditorState internal constructor() {
+class RichTextEditorState internal constructor(
+    initialHtml: String = "",
+) {
+    /**
+     * The content of the editor as HTML formatted for sending as a message.
+     */
+    var messageHtml by mutableStateOf("")
+        internal set
+
+    init {
+        messageHtml = initialHtml
+    }
+
     internal var viewConnection: ViewConnection? = null
 
     /**
@@ -88,13 +100,9 @@ class RichTextEditorState internal constructor() {
     /**
      * Set the HTML content of the editor.
      */
-    fun setHtml(html: String) = viewConnection?.setHtml(html)
-
-    /**
-     * The content of the editor as HTML formatted for sending as a message.
-     */
-    var messageHtml by mutableStateOf("")
-        internal set
+    fun setHtml(html: String) {
+        viewConnection?.setHtml(html)
+    }
 
     /**
      * The content of the editor as markdown formatted for sending as a message.
@@ -172,16 +180,16 @@ class RichTextEditorState internal constructor() {
  * Create an instance of the [RichTextEditorState].
  */
 @Composable
-fun rememberRichTextEditorState(): RichTextEditorState =
+fun rememberRichTextEditorState(
+    initialHtml: String = "",
+): RichTextEditorState =
     rememberSaveable(saver = RichTextEditorStateSaver) {
-        RichTextEditorState()
+        RichTextEditorState(initialHtml = initialHtml)
     }
 
 object RichTextEditorStateSaver : Saver<RichTextEditorState, String> {
     override fun restore(value: String): RichTextEditorState {
-        return RichTextEditorState().apply {
-            messageHtml = value
-        }
+        return RichTextEditorState(initialHtml = value)
     }
 
     override fun SaverScope.save(value: RichTextEditorState): String {


### PR DESCRIPTION
## Changes

- Allow state to be created with an initial value
- Add preview to the example app
- Support compose preview by replacing the rich text editor with a plain EditText when in preview mode

## Context

- Part of https://github.com/matrix-org/matrix-rich-text-editor/issues/315