### PR TITLE
Fix invalid markdown output caused by special characters

### DIFF
--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -953,7 +953,7 @@ where
             }
 
             CodeBlock => {
-                fmt_code_block(self, buffer, &options, as_message)?;
+                fmt_code_block(self, buffer, &mut options, as_message)?;
             }
 
             Quote => {
@@ -1109,6 +1109,7 @@ where
             buffer.push("`` ");
 
             options.insert(MarkdownOptions::IGNORE_LINE_BREAK);
+            options.insert(MarkdownOptions::NO_ESCAPE);
             fmt_children(this, buffer, options, as_message)?;
 
             buffer.push(" ``");
@@ -1306,13 +1307,14 @@ where
         fn fmt_code_block<S>(
             this: &ContainerNode<S>,
             buffer: &mut S,
-            options: &MarkdownOptions,
+            options: &mut MarkdownOptions,
             as_message: bool,
         ) -> Result<(), MarkdownError<S>>
         where
             S: UnicodeString,
         {
             buffer.push("```\n");
+            options.insert(MarkdownOptions::NO_ESCAPE);
             fmt_children(this, buffer, options, as_message)?;
             buffer.push("\n```\n");
 

--- a/crates/wysiwyg/src/dom/nodes/text_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/text_node.rs
@@ -293,10 +293,31 @@ where
     fn fmt_markdown(
         &self,
         buffer: &mut S,
-        _options: &MarkdownOptions,
+        options: &MarkdownOptions,
         _as_message: bool,
     ) -> Result<(), MarkdownError<S>> {
-        buffer.push(self.data.to_owned());
+        if options.contains(MarkdownOptions::NO_ESCAPE) {
+            buffer.push(self.data());
+            return Ok(());
+        }
+
+        let mut escaped = S::default();
+
+        for c in self.data().chars() {
+            match c {
+                // https://spec.commonmark.org/0.30/#ascii-punctuation-character
+                '!' | '"' | '#' | '$' | '%' | '&' | '\'' | '(' | ')' | '*'
+                | '+' | ',' | '-' | '.' | '/' | ':' | ';' | '<' | '=' | '>'
+                | '?' | '@' | '[' | '\\' | ']' | '^' | '_' | '`' | '{'
+                | '|' | '}' | '~' => {
+                    escaped.push('\\');
+                    escaped.push(c);
+                }
+                _ => escaped.push(c),
+            }
+        }
+
+        buffer.push(escaped);
 
         Ok(())
     }

--- a/crates/wysiwyg/src/dom/to_markdown.rs
+++ b/crates/wysiwyg/src/dom/to_markdown.rs
@@ -70,6 +70,7 @@ pub struct MarkdownOptions {
 
 impl MarkdownOptions {
     pub const IGNORE_LINE_BREAK: Self = Self { bits: 0b0001 };
+    pub const NO_ESCAPE: Self = Self { bits: 0b0010 };
 
     pub const fn empty() -> Self {
         Self { bits: 0 }

--- a/crates/wysiwyg/src/tests/test_to_markdown.rs
+++ b/crates/wysiwyg/src/tests/test_to_markdown.rs
@@ -29,6 +29,15 @@ fn text() {
 }
 
 #[test]
+fn text_with_ascii_punctuation() {
+    assert_to_message_md(r"<em>**b**</em>", r"*\*\*b\*\**");
+    assert_to_message_md(
+        r##"!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~"##,
+        r##"\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~"##,
+    );
+}
+
+#[test]
 fn text_with_linebreaks() {
     // One new line.
     assert_to_message_md(
@@ -149,6 +158,14 @@ fn text_with_inline_code() {
 }
 
 #[test]
+fn text_with_code_block() {
+    assert_to_message_md(
+        "<pre><code>**abc**</code></pre>",
+        "```\n**abc**\n```\n",
+    );
+}
+
+#[test]
 fn link() {
     assert_to_message_md(r#"<a href="url">abc</a>"#, "[abc](<url>)");
     // Empty link.
@@ -243,7 +260,7 @@ fn room_mention_for_composer() {
 
 #[test]
 fn at_room_mention_for_message() {
-    assert_to_message_md("@room hello!", "@room hello!");
+    assert_to_message_md("@room hello!", "@room hello\\!");
 }
 
 #[test]
@@ -252,8 +269,8 @@ fn at_room_mention_for_composer() {
 
     assert_eq!(tx(&model), "<a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a> hello!|");
 
-    assert_eq!(model.get_content_as_markdown(), "<a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a> hello!");
-    assert_eq!(model.get_content_as_message_markdown(), "@room hello!");
+    assert_eq!(model.get_content_as_markdown(), "<a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a> hello\\!");
+    assert_eq!(model.get_content_as_message_markdown(), "@room hello\\!");
 }
 
 fn assert_to_md_no_roundtrip(html: &str, expected_markdown: &str) {


### PR DESCRIPTION
## Problem

Invalid markdown is generated if a user types special characters.

For example, it would be impossible to create the following formatted text because the underscores would be interpreted as markdown special characters:

_italic\_ italic \_italic_

## Solution

Escape special characters in markdown output.

|        | Before | After |
|--------|--------|-------|
Markdown | `_italic_ italic _italic_` | `_italic\_ italic \_italic_` |
Rendered | _italic_ italic _italic_ | _italic\_ italic \_italic_






