### PR TITLE
[Android] Revert Java toolchain JDK

### DIFF
--- a/platforms/android/example-compose/build.gradle
+++ b/platforms/android/example-compose/build.gradle
@@ -26,8 +26,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     buildFeatures {
         compose true
@@ -43,7 +43,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(11)
 }
 
 dependencies {

--- a/platforms/android/example-view/build.gradle
+++ b/platforms/android/example-view/build.gradle
@@ -23,8 +23,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     viewBinding {
@@ -33,7 +33,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(11)
 }
 
 dependencies {

--- a/platforms/android/library-compose/build.gradle
+++ b/platforms/android/library-compose/build.gradle
@@ -44,8 +44,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     testCoverage {
@@ -64,7 +64,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(11)
 }
 
 dependencies {

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -45,8 +45,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -76,7 +76,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(11)
 }
 
 dependencies {


### PR DESCRIPTION
## Problem

Updating Gradle and AGP to version 8 (#757), it was necessary to update the JDK used to run Gradle to 17. However, during this update, the toolchain JDK used to compile the source code was also updated to 17 which is not compatible with Android SDK API 33.

## Solution

Revert to Java toolchain JDK to version 11.