### PR TITLE
[Android] Update failing test

### DIFF
--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorTest.kt
@@ -41,7 +41,7 @@ class RichTextEditorTest {
         assertEquals(MenuAction.None, state.menuAction)
         assertEquals(12 to 12, state.selection)
         assertEquals("Hello, world", state.messageHtml)
-        assertEquals("Hello, world", state.messageMarkdown)
+        assertEquals("Hello\\, world", state.messageMarkdown)
     }
 
     @Test
@@ -59,7 +59,7 @@ class RichTextEditorTest {
         assertEquals(12 to 12, state.selection)
         assertEquals(MenuAction.None, state.menuAction)
         assertEquals("Hello, world", state.messageHtml)
-        assertEquals("Hello, world", state.messageMarkdown)
+        assertEquals("Hello\\, world", state.messageMarkdown)
     }
 
     @Test
@@ -84,6 +84,6 @@ class RichTextEditorTest {
         assertEquals(12 to 12, state.selection)
         assertEquals(MenuAction.None, state.menuAction)
         assertEquals("Hello, <b><i>world</i></b>", state.messageHtml)
-        assertEquals("Hello, __*world*__", state.messageMarkdown)
+        assertEquals("Hello\\, __*world*__", state.messageMarkdown)
     }
 }


### PR DESCRIPTION
## Problem

Markdown behaviour changed due to https://github.com/matrix-org/matrix-rich-text-editor/pull/770 and Android tests were not updated to reflect this.

## Solution

Update the tests.

Note that this particular failure is caused by a comma `,` being escaped in the markdown output. Although we could probably leave commas unescaped, in absence of a proper strategy for which characters to escape and under what conditions, we're escaping all ASCII punctuation characters: https://github.com/matrix-org/matrix-rich-text-editor/pull/770#discussion_r1297304953