### PR TITLE
Disable SwiftFormat's `redundantStaticSelf`

### DIFF
--- a/platforms/ios/example/.swiftformat
+++ b/platforms/ios/example/.swiftformat
@@ -1,5 +1,6 @@
 --swiftversion 5.6
 
+--disable redundantStaticSelf
 --disable wrapMultiLineStatementBraces
 --disable hoistPatternLet
 

--- a/platforms/ios/example/.swiftformat
+++ b/platforms/ios/example/.swiftformat
@@ -1,8 +1,10 @@
 --swiftversion 5.6
 
---disable redundantStaticSelf
 --disable wrapMultiLineStatementBraces
 --disable hoistPatternLet
+
+# Disabled until https://github.com/nicklockwood/SwiftFormat/issues/1510 is fixed
+--disable redundantStaticSelf
 
 --ifdef no-indent
 --nospaceoperators ...,..<

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests.swift
@@ -17,7 +17,7 @@
 import XCTest
 
 class WysiwygUITests: XCTestCase {
-    internal let app = XCUIApplication(bundleIdentifier: "org.matrix.Wysiwyg")
+    let app = XCUIApplication(bundleIdentifier: "org.matrix.Wysiwyg")
 
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -69,7 +69,7 @@ class WysiwygUITests: XCTestCase {
     }
 }
 
-internal extension WysiwygUITests {
+extension WysiwygUITests {
     /// Returns the text view component of the composer.
     var textView: XCUIElement {
         app.textViews[rawIdentifier(.composerTextView)]
@@ -178,7 +178,7 @@ internal extension WysiwygUITests {
     }
 }
 
-internal extension XCUIElement {
+extension XCUIElement {
     /// Types a text inside the UI element character by character.
     /// This is especially useful to avoid missing some characters on
     /// UI tests running on a rather slow CI.

--- a/platforms/ios/lib/WysiwygComposer/.swiftformat
+++ b/platforms/ios/lib/WysiwygComposer/.swiftformat
@@ -1,5 +1,6 @@
 --swiftversion 5.6
 
+--disable redundantStaticSelf
 --disable wrapMultiLineStatementBraces
 --disable hoistPatternLet
 

--- a/platforms/ios/lib/WysiwygComposer/.swiftformat
+++ b/platforms/ios/lib/WysiwygComposer/.swiftformat
@@ -1,8 +1,10 @@
 --swiftversion 5.6
 
---disable redundantStaticSelf
 --disable wrapMultiLineStatementBraces
 --disable hoistPatternLet
+
+# Disabled until https://github.com/nicklockwood/SwiftFormat/issues/1510 is fixed
+--disable redundantStaticSelf
 
 --ifdef no-indent
 --nospaceoperators ...,..<


### PR DESCRIPTION
Needed until https://github.com/nicklockwood/SwiftFormat/issues/1510 is fixed