### PR TITLE
Use `sizeThatFits` to handle composer text view's size on iOS 16.0

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -153,6 +153,11 @@ struct UITextViewWrapper: UIViewRepresentable {
                     pasteHandler: pasteHandler)
     }
 
+    @available(iOS 16.0, *)
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: WysiwygTextView, context: Context) -> CGSize? {
+        viewModel.getIdealSize(proposal)
+    }
+
     /// Coordinates UIKit communication.
     class Coordinator: NSObject, UITextViewDelegate, NSTextStorageDelegate, WysiwygTextViewDelegate {
         var replaceText: (NSRange, String) -> Bool
@@ -198,6 +203,7 @@ struct UITextViewWrapper: UIViewRepresentable {
             )
             didUpdateText()
             textView.toggleAutocorrectionIfNeeded()
+            textView.invalidateIntrinsicContentSize()
         }
 
         func textViewDidChangeSelection(_ textView: UITextView) {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -18,6 +18,7 @@ import Combine
 import Foundation
 import HTMLParser
 import OSLog
+import SwiftUI
 import UIKit
 
 // swiftlint:disable file_length
@@ -48,7 +49,9 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
     @Published public var plainTextContent = NSAttributedString()
     /// Published boolean for the composer empty content state.
     @Published public var isContentEmpty = true
-    /// Published value for the composer required height to fit entirely without scrolling.
+    /// Published value for the composer ideal height to fit.
+    /// Note: with SwiftUI & iOS > 16.0, the `UIViewRepresentable` will
+    /// use `sizeThatFits` making registering to that publisher usually unnecessary.
     @Published public var idealHeight: CGFloat = .zero
     /// Published value for the composer current action states.
     @Published public var actionStates: [ComposerAction: ActionState] = [:]
@@ -373,6 +376,18 @@ public extension WysiwygComposerViewModel {
 
     func enter() {
         applyUpdate(createEnterUpdate(), skipTextViewUpdate: false)
+    }
+
+    @available(iOS 16.0, *)
+    func getIdealSize(_ proposal: ProposedViewSize) -> CGSize {
+        guard let width = proposal.width else { return .zero }
+
+        let idealHeight = textView
+            .sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+            .height
+
+        return CGSize(width: width,
+                      height: maximised ? maxExpandedHeight : min(maxCompressedHeight, max(minHeight, idealHeight)))
     }
 }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import SwiftUI
 import UIKit
 
 public protocol WysiwygComposerViewModelProtocol: AnyObject {
@@ -44,4 +45,11 @@ public protocol WysiwygComposerViewModelProtocol: AnyObject {
 
     /// Apply an enter/return key event.
     func enter()
+
+    /// Get the ideal size for the composer's text view inside a SwiftUI context.
+    ///
+    /// - Parameter proposal: Proposed view size.
+    /// - Returns: Ideal size for current context.
+    @available(iOS 16.0, *)
+    func getIdealSize(_ proposal: ProposedViewSize) -> CGSize
 }


### PR DESCRIPTION
This removes the need to subscribe to the `idealHeight` publisher and removes the need to manage the composer height for (SwiftUI) apps with iOS > 16.0
Also fixes an issue where the ideal height might not get published after backspacing a multiple lines selection.