### PR TITLE
Set Swift library to be dynamic

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Package.swift
+++ b/platforms/ios/lib/WysiwygComposer/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     products: [
         .library(
             name: "WysiwygComposer",
+            type: .dynamic,
             targets: ["WysiwygComposer"]
         ),
     ],


### PR DESCRIPTION
Setting the Swift library as dynamic should avoid having issues with duplicated symbols. 

Note: we are though still using a fork of `uniffi-rs` that solves that issue through renaming, because it also contains https://github.com/mozilla/uniffi-rs/pull/1671 that we currently need in order to build in library mode without library size issues (see https://github.com/matrix-org/matrix-rich-text-editor/pull/768). I'll create an issue to replace that fork when a version of uniffi containing the fix lands. 