### PR TITLE
Version 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# [2.6.3] - 2023-08-25
+
+### Changed
+
+- iOS: Revert library back to be exposed as static
+
+### Fixed
+
+- Android: Publishing configuration for Compose library
+
 # [2.6.2] - 2023-08-23
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "uniffi",
  "uniffi_build",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "cfg-if",
  "email_address",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -7,7 +7,7 @@ description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
 name = "uniffi-wysiwyg-composer"
-version = "2.6.2"
+version = "2.6.3"
 rust-version = { workspace = true }
 
 [features]

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASM bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
 name = "wysiwyg-wasm"
-version = "2.6.2"
+version = "2.6.3"
 rust-version = { workspace = true }
 
 [package.metadata.wasm-pack.profile.profiling]

--- a/bindings/wysiwyg-wasm/package-lock.json
+++ b/bindings/wysiwyg-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wysiwyg-wasm",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^28.1.0",

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "homepage": "https://gitlab.com/andybalaam/wysiwyg-rust",
   "description": "WASM bindings for wysiwyg-rust",
   "license": "Apache-2.0",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -7,7 +7,7 @@ description = "Model code to power a rich text editor for Matrix"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
 name = "wysiwyg"
-version = "2.6.2"
+version = "2.6.3"
 rust-version = { workspace = true }
 
 [features]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,9 @@
   "name": "matrix-rich-text-editor",
   "lockfileVersion": 2,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "matrix-rich-text-editor"
+    }
+  }
 }

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -27,7 +27,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=io.element.android
 # POM_ARTIFACT_ID is configured in each module's gradle.properties
-VERSION_NAME=2.6.2
+VERSION_NAME=2.6.3
 
 POM_NAME=Matrix WYSIWYG
 POM_DESCRIPTION=Cross-platform rich text editor that generates HTML output.

--- a/platforms/ios/lib/WysiwygComposer/Package.swift
+++ b/platforms/ios/lib/WysiwygComposer/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
     products: [
         .library(
             name: "WysiwygComposer",
-            type: .dynamic,
             targets: ["WysiwygComposer"]
         ),
     ],

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-wysiwyg",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "type": "module",
     "description": "Wysiwyg composer for matrix.org using React",
     "author": "matrix.org",


### PR DESCRIPTION
Unfortunately setting up the Swift library as dynamic lead to inconsistent detection of library symbols in hosting apps targets (most notably in Unit Tests targets that try to use RTE's components).
This reverts back this change into a new version of the lib. 