### PR TITLE
[Android] Add compose error callback

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -17,6 +17,7 @@ import io.element.android.wysiwyg.compose.RichTextEditorDefaults
 import io.element.android.wysiwyg.compose.rememberRichTextEditorState
 import io.element.wysiwyg.compose.ui.components.FormattingButtons
 import io.element.wysiwyg.compose.ui.theme.RichTextEditorTheme
+import timber.log.Timber
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,6 +38,7 @@ class MainActivity : ComponentActivity() {
                             state = state,
                             modifier = Modifier.fillMaxWidth(),
                             style = RichTextEditorDefaults.style(),
+                            onError = Timber::e
                         )
                         FormattingButtons(
                             onResetText = {

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -15,6 +15,7 @@ import androidx.core.widget.addTextChangedListener
 import io.element.android.wysiwyg.EditorEditText
 import io.element.android.wysiwyg.compose.internal.ViewConnection
 import io.element.android.wysiwyg.compose.internal.toStyleConfig
+import io.element.android.wysiwyg.utils.RustErrorCollector
 import io.element.android.wysiwyg.view.models.InlineFormat
 
 /**
@@ -25,12 +26,14 @@ import io.element.android.wysiwyg.view.models.InlineFormat
  * @param state The state holder for this composable. See [rememberRichTextEditorState].
  * @param modifier The modifier for the layout
  * @param style The styles to use for any customisable elements
+ * @param onError Called when an internal error occurs
  */
 @Composable
 fun RichTextEditor(
     state: RichTextEditorState,
     modifier: Modifier = Modifier,
     style: RichTextEditorStyle = RichTextEditorDefaults.style(),
+    onError: (Throwable) -> Unit = {},
 ) {
     val isPreview = LocalInspectionMode.current
 
@@ -46,6 +49,7 @@ private fun RealEditor(
     state: RichTextEditorState,
     modifier: Modifier = Modifier,
     style: RichTextEditorStyle = RichTextEditorDefaults.style(),
+    onError: (Throwable) -> Unit = {},
 ) {
     val context = LocalContext.current
     // Clean up the connection between view and state holder
@@ -121,6 +125,7 @@ private fun RealEditor(
         update = { view ->
             view.setStyleConfig(style.toStyleConfig(view.context))
             view.applyStyle(style)
+            view.rustErrorCollector = RustErrorCollector(onError)
         }
     )
 }


### PR DESCRIPTION
## Changes

- Expose an error callback for the composable

## Context

So that apps can track and log errors.

- Part of https://github.com/vector-im/element-meta/issues/1935