### PR TITLE
Add a log level override

### DIFF
--- a/platforms/ios/example/Wysiwyg/AppDelegate.swift
+++ b/platforms/ios/example/Wysiwyg/AppDelegate.swift
@@ -14,11 +14,13 @@
 // limitations under the License.
 //
 
+import OSLog
 import UIKit
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        Logger.wysywygLogLevel = .debug
         if #available(iOS 15.0, *) {
             NSTextAttachment.registerViewProviderClass(WysiwygAttachmentViewProvider.self,
                                                        forFileType: WysiwygAttachmentViewProvider.pillUTType)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/Logger.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Extensions/Logger.swift
@@ -22,6 +22,21 @@ import UIKit
 extension Logger {
     // MARK: Internal
 
+    /// Describes a log level for the library.
+    public enum LogLevel: Int {
+        /// Every log is reported
+        case debug = 0
+        /// Warning and errors are reported
+        case warning
+        /// Only errors are reported
+        case error
+        /// No logs are reported
+        case none
+    }
+
+    /// Current log level reported to OSLog. Default: only errors are reported.
+    public static var wysywygLogLevel: LogLevel = .error
+
     static var subsystem = "org.matrix.WysiwygComposer"
 
     /// Creates a customized log for debug.
@@ -30,6 +45,7 @@ extension Logger {
     ///   - elements: Elements to log.
     ///   - functionName: Name from the function where it is called.
     func logDebug(_ elements: [String], functionName: String) {
+        guard Logger.wysywygLogLevel == .debug else { return }
         debug("\(customLog(elements, functionName: functionName))")
     }
 
@@ -39,6 +55,7 @@ extension Logger {
     ///   - elements: Elements to log.
     ///   - functionName: Name from the function where it is called.
     func logError(_ elements: [String], functionName: String) {
+        guard Logger.wysywygLogLevel.rawValue <= LogLevel.error.rawValue else { return }
         error("\(customLog(elements, functionName: functionName))")
     }
 
@@ -48,6 +65,7 @@ extension Logger {
     ///   - elements: Elements to log.
     ///   - functionName: Name from the function where it is called.
     func logWarning(_ elements: [String], functionName: String) {
+        guard Logger.wysywygLogLevel.rawValue <= LogLevel.warning.rawValue else { return }
         warning("\(customLog(elements, functionName: functionName))")
     }
 


### PR DESCRIPTION
By default OSLog requires to run `log config` as admin (and doesn't seem 100% reliable). This provides a simple solution for the hosting app to override the log level of the iOS library.
Default is errors only, the sample application does use it to set it to everything for RTE debug purposes. 