### PR TITLE
[Android] Add fake mode for compose state for testing

### DIFF
--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -40,7 +40,7 @@ fun RichTextEditor(
     if (isPreview) {
         PreviewEditor(state, modifier, style)
     } else {
-        RealEditor(state, modifier, style)
+        RealEditor(state, modifier, style, onError)
     }
 }
 

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/FakeViewConnection.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/FakeViewConnection.kt
@@ -1,0 +1,89 @@
+package io.element.android.wysiwyg.compose.internal
+
+import io.element.android.wysiwyg.compose.RichTextEditorState
+import io.element.android.wysiwyg.view.models.InlineFormat
+import uniffi.wysiwyg_composer.ActionState
+import uniffi.wysiwyg_composer.ComposerAction
+
+/**
+ * Fake implementation of [ViewConnection] for use in preview and test environments.
+ * This implementation does not actually connect to a view, but instead updates the state
+ * in _some_ way. The changes made to the state are not guaranteed to be the same as the
+ * real implementation.
+ */
+internal class FakeViewConnection(
+    val state: RichTextEditorState
+) : ViewConnection {
+
+    override fun toggleInlineFormat(inlineFormat: InlineFormat): Boolean {
+        updateActionState(inlineFormat.toComposerAction())
+        return true
+    }
+
+    override fun toggleList(ordered: Boolean) {
+        updateActionState(
+            if (ordered) {
+                ComposerAction.ORDERED_LIST
+            } else {
+                ComposerAction.UNORDERED_LIST
+            }
+        )
+    }
+
+    override fun toggleCodeBlock(): Boolean {
+        updateActionState(ComposerAction.CODE_BLOCK)
+        return true
+    }
+
+    override fun toggleQuote(): Boolean {
+        updateActionState(ComposerAction.QUOTE)
+        return true
+    }
+
+    override fun undo() {
+        updateActionState(ComposerAction.UNDO)
+    }
+
+    override fun redo() {
+        updateActionState(ComposerAction.REDO)
+    }
+
+    override fun indent() {
+        updateActionState(ComposerAction.INDENT)
+    }
+
+    override fun unindent() {
+        updateActionState(ComposerAction.UNINDENT)
+    }
+
+    override fun setHtml(html: String) {
+        state.messageHtml = html
+        state.messageMarkdown = html
+    }
+
+    override fun requestFocus(): Boolean {
+        state.hasFocus = true
+        return true
+    }
+
+    private fun updateActionState(action: ComposerAction) {
+        val actions = state.actions.toMutableMap()
+        val currentState: ActionState =
+            actions[action] ?: ActionState.ENABLED
+        val newAction = if (currentState == ActionState.ENABLED) {
+            ActionState.REVERSED
+        } else {
+            ActionState.ENABLED
+        }
+        actions[action] = newAction
+        state.actions = actions
+    }
+}
+
+private fun InlineFormat.toComposerAction() = when (this) {
+    InlineFormat.Bold -> ComposerAction.BOLD
+    InlineFormat.Italic -> ComposerAction.ITALIC
+    InlineFormat.StrikeThrough -> ComposerAction.STRIKE_THROUGH
+    InlineFormat.InlineCode -> ComposerAction.INLINE_CODE
+    InlineFormat.Underline -> ComposerAction.UNDERLINE
+}

--- a/platforms/android/library-compose/src/test/java/io/element/android/wysiwyg/compose/FakeRichTextEditorStateTest.kt
+++ b/platforms/android/library-compose/src/test/java/io/element/android/wysiwyg/compose/FakeRichTextEditorStateTest.kt
@@ -1,0 +1,118 @@
+package io.element.android.wysiwyg.compose
+
+import io.element.android.wysiwyg.view.models.InlineFormat
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import uniffi.wysiwyg_composer.ActionState
+import uniffi.wysiwyg_composer.ComposerAction
+
+
+class FakeRichTextEditorStateTest {
+    private val state = RichTextEditorState(initialHtml = "", fake = true)
+
+    @Test
+    fun `toggleInlineFormat(bold) updates the state`() {
+        state.toggleInlineFormat(inlineFormat = InlineFormat.Bold)
+        assertThat(state.actions[ComposerAction.BOLD], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `toggleInlineFormat(italic) updates the state`() {
+        state.toggleInlineFormat(inlineFormat = InlineFormat.Italic)
+        assertThat(state.actions[ComposerAction.ITALIC], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `toggleInlineFormat(underline) updates the state`() {
+        state.toggleInlineFormat(inlineFormat = InlineFormat.Underline)
+        assertThat(state.actions[ComposerAction.UNDERLINE], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `toggleInlineFormat(strikethrough) updates the state`() {
+        state.toggleInlineFormat(inlineFormat = InlineFormat.StrikeThrough)
+        assertThat(state.actions[ComposerAction.STRIKE_THROUGH], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `toggleInlineFormat(inlinecode) updates the state`() {
+        state.toggleInlineFormat(inlineFormat = InlineFormat.InlineCode)
+        assertThat(state.actions[ComposerAction.INLINE_CODE], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `toggleList(ordered) updates the state`() {
+        state.toggleList(ordered = true)
+        assertThat(state.actions[ComposerAction.ORDERED_LIST], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `toggleList(unordered) updates the state`() {
+        state.toggleList(ordered = false)
+        assertThat(state.actions[ComposerAction.UNORDERED_LIST], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `toggleCodeBlock updates the state`() {
+        state.toggleCodeBlock()
+        assertThat(state.actions[ComposerAction.CODE_BLOCK], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `toggleQuote updates the state`() {
+        state.toggleQuote()
+        assertThat(state.actions[ComposerAction.QUOTE], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `undo updates the state`() {
+        state.undo()
+        assertThat(state.actions[ComposerAction.UNDO], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `redo updates the state`() {
+        state.redo()
+        assertThat(state.actions[ComposerAction.REDO], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `indent updates the state`() {
+        state.indent()
+        assertThat(state.actions[ComposerAction.INDENT], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `unindent updates the state`() {
+        state.unindent()
+        assertThat(state.actions[ComposerAction.UNINDENT], equalTo(ActionState.REVERSED))
+    }
+
+    @Test
+    fun `toggling multiple times toggles state`() {
+        assertThat(state.actions[ComposerAction.BOLD], equalTo(null))
+        state.toggleInlineFormat(InlineFormat.Bold)
+        assertThat(state.actions[ComposerAction.BOLD], equalTo(ActionState.REVERSED))
+        state.toggleInlineFormat(InlineFormat.Bold)
+        assertThat(state.actions[ComposerAction.BOLD], equalTo(ActionState.ENABLED))
+        state.toggleInlineFormat(InlineFormat.Bold)
+        assertThat(state.actions[ComposerAction.BOLD], equalTo(ActionState.REVERSED))
+        state.toggleInlineFormat(InlineFormat.Bold)
+        assertThat(state.actions[ComposerAction.BOLD], equalTo(ActionState.ENABLED))
+    }
+
+    @Test
+    fun `setHtml updates the state`() {
+        state.setHtml("<b>new html</b>")
+        assertThat(state.messageHtml, equalTo("<b>new html</b>"))
+        assertThat(state.messageMarkdown, equalTo("<b>new html</b>"))
+    }
+
+    @Test
+    fun `requestFocus updates the state`() {
+        assertThat(state.hasFocus, equalTo(false))
+        state.requestFocus()
+        assertThat(state.hasFocus, equalTo(true))
+    }
+}


### PR DESCRIPTION
## Changes

- Add fake mode for the compose state for testing and preview purposes
- Relax visibility of the compose state constructor

## Context

As this library inherently requires the underlying Rust model to function properly, it makes testing in a JVM environment difficult. A simple fake implementation allows unit tests to observe some simple state changes after calling functions on the state holder.

- See https://github.com/vector-im/element-x-android/pull/1172#discussion_r1317449784