### PR TITLE
[Android] Fix performance issue in recomposition

### DIFF
--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
@@ -1,11 +1,8 @@
 package io.element.android.wysiwyg.compose.internal
 
 import android.content.Context
-import android.content.res.Resources.NotFoundException
-import androidx.annotation.DrawableRes
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.Density
-import androidx.core.content.ContextCompat
 import io.element.android.wysiwyg.compose.BulletListStyle
 import io.element.android.wysiwyg.compose.CodeBlockStyle
 import io.element.android.wysiwyg.compose.InlineCodeStyle
@@ -39,10 +36,10 @@ internal fun InlineCodeStyle.toStyleConfig(context: Context): InlineCodeStyleCon
         horizontalPadding = with(density) { horizontalPadding.toPx().roundToInt() },
         verticalPadding = with(density) { verticalPadding.toPx().roundToInt() },
         relativeTextSize = relativeTextSize,
-        singleLineBg = context.requireDrawable(singleLineBg),
-        multiLineBgLeft = context.requireDrawable(multiLineBgLeft),
-        multiLineBgMid = context.requireDrawable(multiLineBgMid),
-        multiLineBgRight = context.requireDrawable(multiLineBgRight),
+        singleLineBg = singleLineBg,
+        multiLineBgLeft = multiLineBgLeft,
+        multiLineBgMid = multiLineBgMid,
+        multiLineBgRight = multiLineBgRight,
     )
 }
 
@@ -52,7 +49,7 @@ internal fun CodeBlockStyle.toStyleConfig(context: Context): CodeBlockStyleConfi
         leadingMargin = with(density) { leadingMargin.toPx().roundToInt() },
         verticalPadding = with(density) { verticalPadding.toPx().roundToInt() },
         relativeTextSize = relativeTextSize,
-        backgroundDrawable = context.requireDrawable(backgroundDrawable),
+        backgroundDrawable = backgroundDrawable,
     )
 }
 
@@ -60,8 +57,3 @@ internal fun PillStyle.toStyleConfig(): PillStyleConfig =
     PillStyleConfig(
         backgroundColor = backgroundColor.toArgb(),
     )
-
-private fun Context.requireDrawable(
-    @DrawableRes drawable: Int
-) = ContextCompat.getDrawable(this, drawable)
-    ?: throw NotFoundException("Drawable not found")

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/fakes/FakeStyleConfig.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/fakes/FakeStyleConfig.kt
@@ -1,14 +1,11 @@
 package io.element.android.wysiwyg.fakes
 
-import android.graphics.drawable.ColorDrawable
 import io.element.android.wysiwyg.test.R
 import io.element.android.wysiwyg.view.BulletListStyleConfig
 import io.element.android.wysiwyg.view.CodeBlockStyleConfig
 import io.element.android.wysiwyg.view.InlineCodeStyleConfig
 import io.element.android.wysiwyg.view.PillStyleConfig
 import io.element.android.wysiwyg.view.StyleConfig
-
-private val fakeDrawable = ColorDrawable()
 
 internal fun createFakeStyleConfig() = StyleConfig(
     bulletList = BulletListStyleConfig(
@@ -19,16 +16,16 @@ internal fun createFakeStyleConfig() = StyleConfig(
         horizontalPadding = 2,
         verticalPadding = 2,
         relativeTextSize = 1f,
-        singleLineBg = fakeDrawable,
-        multiLineBgLeft = fakeDrawable,
-        multiLineBgMid = fakeDrawable,
-        multiLineBgRight = fakeDrawable,
+        singleLineBg = R.color.fake_color,
+        multiLineBgLeft = R.color.fake_color,
+        multiLineBgMid = R.color.fake_color,
+        multiLineBgRight = R.color.fake_color,
     ),
     codeBlock = CodeBlockStyleConfig(
         leadingMargin = 0,
         verticalPadding = 0,
         relativeTextSize = 1f,
-        backgroundDrawable = fakeDrawable,
+        backgroundDrawable = R.color.fake_color,
     ),
     pill = PillStyleConfig(
         R.color.fake_color

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -262,9 +262,18 @@ class EditorEditText : AppCompatEditText {
      * Apply custom style. This overrides any style set in the layout XML.
      */
     fun setStyleConfig(styleConfig: StyleConfig) {
+        if (this::styleConfig.isInitialized && styleConfig == this.styleConfig) {
+            return
+        }
         this.styleConfig = styleConfig
-        inlineCodeBgHelper = SpanBackgroundHelperFactory.createInlineCodeBackgroundHelper(styleConfig.inlineCode)
-        codeBlockBgHelper = SpanBackgroundHelperFactory.createCodeBlockBackgroundHelper(styleConfig.codeBlock)
+        inlineCodeBgHelper = SpanBackgroundHelperFactory.createInlineCodeBackgroundHelper(
+            styleConfig.inlineCode,
+            context
+        )
+        codeBlockBgHelper = SpanBackgroundHelperFactory.createCodeBlockBackgroundHelper(
+            styleConfig.codeBlock,
+            context
+        )
 
         rerender()
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -20,10 +20,10 @@ open class EditorStyledTextView : AppCompatTextView {
     private lateinit var codeBlockStyleConfig: CodeBlockStyleConfig
     private var styleAttributesReady = false
     private val inlineCodeBgHelper: SpanBackgroundHelper by lazy {
-        SpanBackgroundHelperFactory.createInlineCodeBackgroundHelper(inlineCodeStyleConfig)
+        SpanBackgroundHelperFactory.createInlineCodeBackgroundHelper(inlineCodeStyleConfig, context)
     }
     private val codeBlockBgHelper: SpanBackgroundHelper by lazy {
-        SpanBackgroundHelperFactory.createCodeBlockBackgroundHelper(codeBlockStyleConfig)
+        SpanBackgroundHelperFactory.createCodeBlockBackgroundHelper(codeBlockStyleConfig, context)
     }
 
     constructor(context: Context) : super(context)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/view/EditorEditTextAttributeReader.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/view/EditorEditTextAttributeReader.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.core.content.res.getDimensionOrThrow
 import androidx.core.content.res.getDimensionPixelSizeOrThrow
-import androidx.core.content.res.getDrawableOrThrow
 import androidx.core.content.res.getFloatOrThrow
 import androidx.core.content.res.getResourceIdOrThrow
 import io.element.android.wysiwyg.R
@@ -33,17 +32,17 @@ internal class EditorEditTextAttributeReader(context: Context, attrs: AttributeS
                 horizontalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_inlineCodeHorizontalPadding),
                 verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_inlineCodeVerticalPadding),
                 relativeTextSize = typedArray.getFloatOrThrow(R.styleable.EditorEditText_inlineCodeRelativeTextSize),
-                singleLineBg = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeSingleLineBg),
-                multiLineBgLeft = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgLeft),
-                multiLineBgMid = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgMid),
-                multiLineBgRight = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgRight),
+                singleLineBg = typedArray.getResourceIdOrThrow(R.styleable.EditorEditText_inlineCodeSingleLineBg),
+                multiLineBgLeft = typedArray.getResourceIdOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgLeft),
+                multiLineBgMid = typedArray.getResourceIdOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgMid),
+                multiLineBgRight = typedArray.getResourceIdOrThrow(R.styleable.EditorEditText_inlineCodeMultiLineBgRight),
 
             ),
             codeBlock = CodeBlockStyleConfig(
                 leadingMargin = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockLeadingMargin),
                 verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorEditText_codeBlockVerticalPadding),
                 relativeTextSize = typedArray.getFloatOrThrow(R.styleable.EditorEditText_codeBlockRelativeTextSize),
-                backgroundDrawable = typedArray.getDrawableOrThrow(R.styleable.EditorEditText_codeBlockBackgroundDrawable),
+                backgroundDrawable = typedArray.getResourceIdOrThrow(R.styleable.EditorEditText_codeBlockBackgroundDrawable),
             ),
             pill = PillStyleConfig(
                 backgroundColor = typedArray.getResourceIdOrThrow(R.styleable.EditorEditText_pillBackgroundColor),

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/view/EditorStyledTextViewAttributeReader.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/view/EditorStyledTextViewAttributeReader.kt
@@ -3,8 +3,8 @@ package io.element.android.wysiwyg.internal.view
 import android.content.Context
 import android.util.AttributeSet
 import androidx.core.content.res.getDimensionPixelSizeOrThrow
-import androidx.core.content.res.getDrawableOrThrow
 import androidx.core.content.res.getFloatOrThrow
+import androidx.core.content.res.getResourceIdOrThrow
 import io.element.android.wysiwyg.R
 import io.element.android.wysiwyg.view.CodeBlockStyleConfig
 import io.element.android.wysiwyg.view.InlineCodeStyleConfig
@@ -24,16 +24,16 @@ internal class EditorStyledTextViewAttributeReader(context: Context, attrs: Attr
             horizontalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorStyledTextView_inlineCodeHorizontalPadding),
             verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorStyledTextView_inlineCodeVerticalPadding),
             relativeTextSize = typedArray.getFloatOrThrow(R.styleable.EditorStyledTextView_inlineCodeRelativeTextSize),
-            singleLineBg = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeSingleLineBg),
-            multiLineBgLeft = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgLeft),
-            multiLineBgMid = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgMid),
-            multiLineBgRight = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgRight),
+            singleLineBg = typedArray.getResourceIdOrThrow(R.styleable.EditorStyledTextView_inlineCodeSingleLineBg),
+            multiLineBgLeft = typedArray.getResourceIdOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgLeft),
+            multiLineBgMid = typedArray.getResourceIdOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgMid),
+            multiLineBgRight = typedArray.getResourceIdOrThrow(R.styleable.EditorStyledTextView_inlineCodeMultiLineBgRight),
         )
         codeBlockStyleConfig = CodeBlockStyleConfig(
             leadingMargin = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorStyledTextView_codeBlockLeadingMargin),
             verticalPadding = typedArray.getDimensionPixelSizeOrThrow(R.styleable.EditorStyledTextView_codeBlockVerticalPadding),
             relativeTextSize = typedArray.getFloatOrThrow(R.styleable.EditorStyledTextView_codeBlockRelativeTextSize),
-            backgroundDrawable = typedArray.getDrawableOrThrow(R.styleable.EditorStyledTextView_codeBlockBackgroundDrawable),
+            backgroundDrawable = typedArray.getResourceIdOrThrow(R.styleable.EditorStyledTextView_codeBlockBackgroundDrawable),
         )
         typedArray.recycle()
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/StyleConfig.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/StyleConfig.kt
@@ -1,7 +1,7 @@
 package io.element.android.wysiwyg.view
 
-import android.graphics.drawable.Drawable
 import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
 import androidx.annotation.Px
 import io.element.android.wysiwyg.EditorEditText
 
@@ -50,10 +50,10 @@ data class InlineCodeStyleConfig(
     @Px val horizontalPadding: Int,
     @Px val verticalPadding: Int,
     val relativeTextSize: Float,
-    val singleLineBg: Drawable,
-    val multiLineBgLeft: Drawable,
-    val multiLineBgMid: Drawable,
-    val multiLineBgRight: Drawable,
+    @DrawableRes val singleLineBg: Int,
+    @DrawableRes val multiLineBgLeft: Int,
+    @DrawableRes val multiLineBgMid: Int,
+    @DrawableRes val multiLineBgRight: Int,
 )
 
 /**
@@ -68,7 +68,7 @@ data class CodeBlockStyleConfig(
     @Px val leadingMargin: Int,
     @Px val verticalPadding: Int,
     val relativeTextSize: Float,
-    val backgroundDrawable: Drawable,
+    @DrawableRes val backgroundDrawable: Int,
 )
 
 /**

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/inlinebg/SpanBackgroundHelperFactory.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/inlinebg/SpanBackgroundHelperFactory.kt
@@ -1,29 +1,37 @@
 package io.element.android.wysiwyg.view.inlinebg
 
-import io.element.android.wysiwyg.view.spans.CodeBlockSpan
-import io.element.android.wysiwyg.view.spans.InlineCodeSpan
+import android.content.Context
+import androidx.core.content.ContextCompat
 import io.element.android.wysiwyg.view.CodeBlockStyleConfig
 import io.element.android.wysiwyg.view.InlineCodeStyleConfig
+import io.element.android.wysiwyg.view.spans.CodeBlockSpan
+import io.element.android.wysiwyg.view.spans.InlineCodeSpan
 
 object SpanBackgroundHelperFactory {
-    fun createInlineCodeBackgroundHelper(styleConfig: InlineCodeStyleConfig): SpanBackgroundHelper {
+    fun createInlineCodeBackgroundHelper(
+        styleConfig: InlineCodeStyleConfig,
+        context: Context
+    ): SpanBackgroundHelper {
         return SpanBackgroundHelper(
             spanType = InlineCodeSpan::class.java,
             horizontalPadding = styleConfig.horizontalPadding,
             verticalPadding = styleConfig.verticalPadding,
-            drawable = styleConfig.singleLineBg,
-            drawableLeft = styleConfig.multiLineBgLeft,
-            drawableMid = styleConfig.multiLineBgMid,
-            drawableRight = styleConfig.multiLineBgRight,
+            drawable = ContextCompat.getDrawable(context, styleConfig.singleLineBg),
+            drawableLeft = ContextCompat.getDrawable(context, styleConfig.multiLineBgLeft),
+            drawableMid = ContextCompat.getDrawable(context, styleConfig.multiLineBgMid),
+            drawableRight = ContextCompat.getDrawable(context, styleConfig.multiLineBgRight),
         )
     }
 
-    fun createCodeBlockBackgroundHelper(styleConfig: CodeBlockStyleConfig): SpanBackgroundHelper {
+    fun createCodeBlockBackgroundHelper(
+        styleConfig: CodeBlockStyleConfig,
+        context: Context
+    ): SpanBackgroundHelper {
         return SpanBackgroundHelper(
             spanType = CodeBlockSpan::class.java,
             horizontalPadding = 0,
             verticalPadding = 0,
-            drawable = styleConfig.backgroundDrawable,
+            drawable = ContextCompat.getDrawable(context, styleConfig.backgroundDrawable)
         )
     }
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/test/fakes/FakeStyleConfig.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/test/fakes/FakeStyleConfig.kt
@@ -1,14 +1,11 @@
 package io.element.android.wysiwyg.test.fakes
 
-import android.graphics.drawable.ColorDrawable
-import io.element.android.wysiwyg.test.R
 import io.element.android.wysiwyg.view.BulletListStyleConfig
 import io.element.android.wysiwyg.view.CodeBlockStyleConfig
 import io.element.android.wysiwyg.view.InlineCodeStyleConfig
 import io.element.android.wysiwyg.view.PillStyleConfig
 import io.element.android.wysiwyg.view.StyleConfig
 
-private val fakeDrawable = ColorDrawable()
 
 internal fun createFakeStyleConfig() = StyleConfig(
     bulletList = BulletListStyleConfig(
@@ -19,16 +16,16 @@ internal fun createFakeStyleConfig() = StyleConfig(
         horizontalPadding = 2,
         verticalPadding = 2,
         relativeTextSize = 1f,
-        singleLineBg = fakeDrawable,
-        multiLineBgLeft = fakeDrawable,
-        multiLineBgMid = fakeDrawable,
-        multiLineBgRight = fakeDrawable,
+        singleLineBg = 0,
+        multiLineBgLeft = 0,
+        multiLineBgMid = 0,
+        multiLineBgRight = 0,
     ),
     codeBlock = CodeBlockStyleConfig(
         leadingMargin = 0,
         verticalPadding = 0,
         relativeTextSize = 1f,
-        backgroundDrawable = fakeDrawable,
+        backgroundDrawable = 0,
     ),
     pill = PillStyleConfig(
         android.R.color.white


### PR DESCRIPTION
## Problem

Setting the style of the underlying `EditText` is an expensive operation due to the fact that it forces a re-render. In a traditional view-based app this isn't a problem however, in compose, the wrapper's `update` block may be called frequently regardless of whether the `style` argument has changed, causing the the expensive operation to be triggered frequently.

## Solution

This change ensures that setting the style in the underlying `EditText` only takes effect and triggers an expensive re-render if the new style is different to the old style.