### PR TITLE
Fix iOS publishing credentials

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set SwiftPM Repo credentials
         uses: de-vri-es/setup-git-credentials@v2
         with:
-          credentials: ${{secrets.GIT_CREDENTIALS}}
+          credentials: ${{secrets.PAT}}
 
       - name: Get tag
         id: tag


### PR DESCRIPTION
## Problem

The iOS library is failing to publish code to [matrix-org/matrix-wysiwyg-composer-swift](https://github.com/matrix-org/matrix-wysiwyg-composer-swift) (see [failed job](https://github.com/matrix-org/matrix-rich-text-editor/actions/runs/6109754085/job/16581401490)) with an error:

```
remote: Permission to matrix-org/matrix-wysiwyg-composer-swift.git denied to Velin92.
fatal: unable to access 'https://github.com/matrix-org/matrix-wysiwyg-composer-swift.git/': The requested URL returned error: 403
```

## Solution

Use @ElementBot access token to publish.

## To do
- [x] Provide @ElementBot with access to [matrix-org/matrix-wysiwyg-composer-swift](https://github.com/matrix-org/matrix-wysiwyg-composer-swift)
- [ ] Delete redundant `GIT_CREDENTIALS` secret