### PR TITLE
[Android] Fix performance issue caused by excessive recomposition

### DIFF
--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
@@ -31,7 +31,7 @@ class RichTextEditorState(
     initialHtml: String = "",
     fake: Boolean = false,
 ) {
-    internal var viewConnection: ViewConnection? = null
+    internal var viewConnection: ViewConnection? by mutableStateOf(null)
 
     init {
         if (fake) {


### PR DESCRIPTION
## Problem

The `update` block of the `RichTextEditor` composable is called regardless of whether the style argument has changed, causing an expensive operation to be triggered frequently, reducing performance.

## Solution

The root cause is that the `RichTextEditorState` class is not stable due to the instability of its `viewConnection` property, causing the `RichTextEditor` composable to recompose more than is necessary. The solution is to make the `viewConnection` property stable by wrapping it in `MutableState`.

### Compose compiler reports

#### Before
```
unstable class RichTextEditorState {
  runtime var viewConnection: ViewConnection?
  ...
  <runtime stability> = Unstable
}
```

#### After
```
stable class RichTextEditorState {
  stable var viewConnection$delegate: MutableState<ViewConnection?>
  ...
  <runtime stability> = Stable
}
```
