### PR TITLE
[Android] Fix missing link action updates in compose library

### DIFF
--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -1,6 +1,6 @@
 use widestring::Utf16String;
 
-use crate::ffi_link_actions::LinkAction;
+use crate::ffi_link_actions::LinkActionUpdate;
 use crate::ffi_menu_state::MenuState;
 use crate::ffi_text_update::TextUpdate;
 use crate::MenuAction;
@@ -30,8 +30,8 @@ impl ComposerUpdate {
         MenuAction::from(self.inner.menu_action.clone())
     }
 
-    pub fn link_action(&self) -> LinkAction {
-        LinkAction::from(self.inner.link_action.clone())
+    pub fn link_action(&self) -> LinkActionUpdate {
+        LinkActionUpdate::from(self.inner.link_action.clone())
     }
 }
 

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -1,5 +1,6 @@
 use widestring::Utf16String;
 
+use crate::ffi_link_actions::LinkAction;
 use crate::ffi_menu_state::MenuState;
 use crate::ffi_text_update::TextUpdate;
 use crate::MenuAction;
@@ -27,6 +28,10 @@ impl ComposerUpdate {
 
     pub fn menu_action(&self) -> MenuAction {
         MenuAction::from(self.inner.menu_action.clone())
+    }
+
+    pub fn link_action(&self) -> LinkAction {
+        LinkAction::from(self.inner.link_action.clone())
     }
 }
 

--- a/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
@@ -2,6 +2,7 @@ use widestring::Utf16String;
 
 #[derive(uniffi::Enum)]
 pub enum LinkAction {
+    Keep,
     CreateWithText,
     Create,
     Edit { url: String },
@@ -11,6 +12,7 @@ pub enum LinkAction {
 impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
     fn from(inner: wysiwyg::LinkAction<Utf16String>) -> Self {
         match inner {
+            wysiwyg::LinkAction::Keep => Self::Keep,
             wysiwyg::LinkAction::CreateWithText => Self::CreateWithText,
             wysiwyg::LinkAction::Create => Self::Create,
             wysiwyg::LinkAction::Edit(url) => Self::Edit {

--- a/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_link_actions.rs
@@ -2,7 +2,6 @@ use widestring::Utf16String;
 
 #[derive(uniffi::Enum)]
 pub enum LinkAction {
-    Keep,
     CreateWithText,
     Create,
     Edit { url: String },
@@ -12,13 +11,29 @@ pub enum LinkAction {
 impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
     fn from(inner: wysiwyg::LinkAction<Utf16String>) -> Self {
         match inner {
-            wysiwyg::LinkAction::Keep => Self::Keep,
             wysiwyg::LinkAction::CreateWithText => Self::CreateWithText,
             wysiwyg::LinkAction::Create => Self::Create,
             wysiwyg::LinkAction::Edit(url) => Self::Edit {
                 url: url.to_string(),
             },
             wysiwyg::LinkAction::Disabled => Self::Disabled,
+        }
+    }
+}
+
+#[derive(uniffi::Enum)]
+pub enum LinkActionUpdate {
+    Keep,
+    Update { link_action: LinkAction },
+}
+
+impl From<wysiwyg::LinkActionUpdate<Utf16String>> for LinkActionUpdate {
+    fn from(inner: wysiwyg::LinkActionUpdate<Utf16String>) -> Self {
+        match inner {
+            wysiwyg::LinkActionUpdate::Keep => Self::Keep,
+            wysiwyg::LinkActionUpdate::Update(action) => Self::Update {
+                link_action: action.into(),
+            },
         }
     }
 }

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -843,6 +843,7 @@ pub struct LinkAction {
     pub create: Option<Create>,
     pub edit_link: Option<Edit>,
     pub disabled: Option<Disabled>,
+    pub keep: Option<Keep>,
 }
 
 impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
@@ -853,12 +854,14 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
                 create: None,
                 edit_link: None,
                 disabled: None,
+                keep: None,
             },
             wysiwyg::LinkAction::Create => Self {
                 create_with_text: None,
                 create: Some(Create),
                 edit_link: None,
                 disabled: None,
+                keep: None,
             },
             wysiwyg::LinkAction::Edit(url) => {
                 let url = url.to_string();
@@ -867,6 +870,7 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
                     create: None,
                     edit_link: Some(Edit { url }),
                     disabled: None,
+                    keep: None,
                 }
             }
             wysiwyg::LinkAction::Disabled => Self {
@@ -874,6 +878,14 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
                 create: None,
                 edit_link: None,
                 disabled: Some(Disabled),
+                keep: None,
+            },
+            wysiwyg::LinkAction::Keep => Self {
+                create_with_text: None,
+                create: None,
+                edit_link: None,
+                disabled: None,
+                keep: Some(Keep),
             },
         }
     }

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -843,7 +843,6 @@ pub struct LinkAction {
     pub create: Option<Create>,
     pub edit_link: Option<Edit>,
     pub disabled: Option<Disabled>,
-    pub keep: Option<Keep>,
 }
 
 impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
@@ -854,14 +853,12 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
                 create: None,
                 edit_link: None,
                 disabled: None,
-                keep: None,
             },
             wysiwyg::LinkAction::Create => Self {
                 create_with_text: None,
                 create: Some(Create),
                 edit_link: None,
                 disabled: None,
-                keep: None,
             },
             wysiwyg::LinkAction::Edit(url) => {
                 let url = url.to_string();
@@ -870,7 +867,6 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
                     create: None,
                     edit_link: Some(Edit { url }),
                     disabled: None,
-                    keep: None,
                 }
             }
             wysiwyg::LinkAction::Disabled => Self {
@@ -878,14 +874,6 @@ impl From<wysiwyg::LinkAction<Utf16String>> for LinkAction {
                 create: None,
                 edit_link: None,
                 disabled: Some(Disabled),
-                keep: None,
-            },
-            wysiwyg::LinkAction::Keep => Self {
-                create_with_text: None,
-                create: None,
-                edit_link: None,
-                disabled: None,
-                keep: Some(Keep),
             },
         }
     }

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -19,6 +19,7 @@ use crate::dom::parser::markdown::markdown_html_parser::MarkdownHTMLParser;
 use crate::dom::parser::parse;
 use crate::dom::to_plain_text::ToPlainText;
 use crate::dom::{Dom, DomCreationError, UnicodeString};
+use crate::link_action::LinkActionUpdate;
 use crate::{
     ComposerAction, ComposerUpdate, DomHandle, Location, ToHtml, ToMarkdown,
     ToTree,
@@ -156,7 +157,7 @@ where
             self.state.end,
             menu_state,
             self.compute_menu_action(),
-            self.get_link_action(),
+            LinkActionUpdate::Update(self.get_link_action()),
         )
     }
 
@@ -170,7 +171,7 @@ where
             self.state.end,
             self.compute_menu_state(MenuStateComputeType::KeepIfUnchanged),
             self.compute_menu_action(),
-            self.get_link_action(),
+            LinkActionUpdate::Update(self.get_link_action()),
         )
     }
 
@@ -186,7 +187,7 @@ where
             self.state.end,
             self.compute_menu_state(MenuStateComputeType::AlwaysUpdate),
             self.compute_menu_action(),
-            self.get_link_action(),
+            LinkActionUpdate::Update(self.get_link_action()),
         )
     }
 

--- a/crates/wysiwyg/src/composer_model/base.rs
+++ b/crates/wysiwyg/src/composer_model/base.rs
@@ -156,6 +156,7 @@ where
             self.state.end,
             menu_state,
             self.compute_menu_action(),
+            self.get_link_action(),
         )
     }
 
@@ -169,6 +170,7 @@ where
             self.state.end,
             self.compute_menu_state(MenuStateComputeType::KeepIfUnchanged),
             self.compute_menu_action(),
+            self.get_link_action(),
         )
     }
 
@@ -184,6 +186,7 @@ where
             self.state.end,
             self.compute_menu_state(MenuStateComputeType::AlwaysUpdate),
             self.compute_menu_action(),
+            self.get_link_action(),
         )
     }
 

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -245,7 +245,8 @@ mod test {
     use crate::tests::testutils_composer_model::cm;
     use crate::tests::testutils_conversion::utf16;
     use crate::{
-        ComposerAction, ComposerUpdate, Location, MenuAction, MenuState,
+        ComposerAction, ComposerUpdate, LinkAction, Location, MenuAction,
+        MenuState,
     };
     use strum::IntoEnumIterator;
 
@@ -263,6 +264,7 @@ mod test {
                     action_states: indent_unindent_redo_disabled()
                 }),
                 MenuAction::None,
+                LinkAction::CreateWithText,
             ),
         );
     }

--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -241,6 +241,7 @@ mod test {
     use widestring::Utf16String;
 
     use crate::action_state::ActionState;
+    use crate::link_action::LinkActionUpdate;
     use crate::menu_state::MenuStateUpdate;
     use crate::tests::testutils_composer_model::cm;
     use crate::tests::testutils_conversion::utf16;
@@ -264,7 +265,7 @@ mod test {
                     action_states: indent_unindent_redo_disabled()
                 }),
                 MenuAction::None,
-                LinkAction::CreateWithText,
+                LinkActionUpdate::Update(LinkAction::CreateWithText),
             ),
         );
     }

--- a/crates/wysiwyg/src/composer_update.rs
+++ b/crates/wysiwyg/src/composer_update.rs
@@ -14,7 +14,8 @@
 
 use crate::dom::UnicodeString;
 use crate::{
-    Location, MenuAction, MenuState, ReplaceAll, Selection, TextUpdate,
+    LinkAction, Location, MenuAction, MenuState, ReplaceAll, Selection,
+    TextUpdate,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,6 +26,7 @@ where
     pub text_update: TextUpdate<S>,
     pub menu_state: MenuState,
     pub menu_action: MenuAction,
+    pub link_action: LinkAction<S>,
 }
 
 impl<S> ComposerUpdate<S>
@@ -36,6 +38,7 @@ where
             text_update: TextUpdate::<S>::Keep,
             menu_state: MenuState::Keep,
             menu_action: MenuAction::Keep,
+            link_action: LinkAction::Keep,
         }
     }
 
@@ -47,6 +50,7 @@ where
             text_update: TextUpdate::<S>::Keep,
             menu_state,
             menu_action,
+            link_action: LinkAction::Keep,
         }
     }
 
@@ -55,11 +59,13 @@ where
         end: Location,
         menu_state: MenuState,
         menu_action: MenuAction,
+        link_action: LinkAction<S>,
     ) -> Self {
         Self {
             text_update: TextUpdate::<S>::Select(Selection { start, end }),
             menu_state,
             menu_action,
+            link_action,
         }
     }
 
@@ -69,6 +75,7 @@ where
         end: Location,
         menu_state: MenuState,
         menu_action: MenuAction,
+        link_action: LinkAction<S>,
     ) -> Self {
         Self {
             text_update: TextUpdate::ReplaceAll(ReplaceAll {
@@ -78,6 +85,7 @@ where
             }),
             menu_state,
             menu_action,
+            link_action,
         }
     }
 }

--- a/crates/wysiwyg/src/composer_update.rs
+++ b/crates/wysiwyg/src/composer_update.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use crate::dom::UnicodeString;
+use crate::link_action::LinkActionUpdate;
 use crate::{
-    LinkAction, Location, MenuAction, MenuState, ReplaceAll, Selection,
-    TextUpdate,
+    Location, MenuAction, MenuState, ReplaceAll, Selection, TextUpdate,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,7 +26,7 @@ where
     pub text_update: TextUpdate<S>,
     pub menu_state: MenuState,
     pub menu_action: MenuAction,
-    pub link_action: LinkAction<S>,
+    pub link_action: LinkActionUpdate<S>,
 }
 
 impl<S> ComposerUpdate<S>
@@ -38,7 +38,7 @@ where
             text_update: TextUpdate::<S>::Keep,
             menu_state: MenuState::Keep,
             menu_action: MenuAction::Keep,
-            link_action: LinkAction::Keep,
+            link_action: LinkActionUpdate::Keep,
         }
     }
 
@@ -50,7 +50,7 @@ where
             text_update: TextUpdate::<S>::Keep,
             menu_state,
             menu_action,
-            link_action: LinkAction::Keep,
+            link_action: LinkActionUpdate::Keep,
         }
     }
 
@@ -59,7 +59,7 @@ where
         end: Location,
         menu_state: MenuState,
         menu_action: MenuAction,
-        link_action: LinkAction<S>,
+        link_action: LinkActionUpdate<S>,
     ) -> Self {
         Self {
             text_update: TextUpdate::<S>::Select(Selection { start, end }),
@@ -75,7 +75,7 @@ where
         end: Location,
         menu_state: MenuState,
         menu_action: MenuAction,
-        link_action: LinkAction<S>,
+        link_action: LinkActionUpdate<S>,
     ) -> Self {
         Self {
             text_update: TextUpdate::ReplaceAll(ReplaceAll {

--- a/crates/wysiwyg/src/lib.rs
+++ b/crates/wysiwyg/src/lib.rs
@@ -48,6 +48,7 @@ pub use crate::dom::UnicodeString;
 pub use crate::dom::{MarkdownError, ToMarkdown};
 pub use crate::format_type::InlineFormatType;
 pub use crate::link_action::LinkAction;
+pub use crate::link_action::LinkActionUpdate;
 pub use crate::list_type::ListType;
 pub use crate::location::Location;
 pub use crate::menu_action::MenuAction;

--- a/crates/wysiwyg/src/link_action.rs
+++ b/crates/wysiwyg/src/link_action.rs
@@ -14,8 +14,9 @@
 
 use crate::UnicodeString;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LinkAction<S: UnicodeString> {
+    Keep,
     CreateWithText,
     Create,
     Edit(S),

--- a/crates/wysiwyg/src/link_action.rs
+++ b/crates/wysiwyg/src/link_action.rs
@@ -15,8 +15,13 @@
 use crate::UnicodeString;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum LinkAction<S: UnicodeString> {
+pub enum LinkActionUpdate<S: UnicodeString> {
     Keep,
+    Update(LinkAction<S>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LinkAction<S: UnicodeString> {
     CreateWithText,
     Create,
     Edit(S),

--- a/platforms/android/.idea/compiler.xml
+++ b/platforms/android/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/testutils/EditorActions.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/testutils/EditorActions.kt
@@ -1,0 +1,29 @@
+package io.element.android.wysiwyg.compose.testutils
+
+import android.view.View
+import androidx.appcompat.widget.AppCompatEditText
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import org.hamcrest.Matcher
+
+object Editor {
+    class SetSelection(
+        private val start: Int,
+        private val end: Int,
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Set selection to $start, $end"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val editor = view as? AppCompatEditText ?: return
+            editor.setSelection(start, end)
+        }
+    }
+
+}
+
+object EditorActions {
+    fun setSelection(start: Int, end: Int) = Editor.SetSelection(start, end)
+}

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -81,6 +81,9 @@ private fun RealEditor(
                 menuActionListener = EditorEditText.OnMenuActionChangedListener { menuAction ->
                     state.menuAction = menuAction
                 }
+                linkActionChangedListener = EditorEditText.OnLinkActionChangedListener { linkAction ->
+                    state.linkAction = linkAction
+                }
                 onFocusChangeListener =
                     View.OnFocusChangeListener { _, hasFocus -> state.hasFocus = hasFocus }
 
@@ -89,7 +92,6 @@ private fun RealEditor(
                     state.messageHtml = getContentAsMessageHtml()
                     state.messageMarkdown = getMarkdown()
                     state.lineCount = lineCount
-                    state.linkAction = getLinkAction()
                 }
 
                 applyDefaultStyle()

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -106,6 +106,10 @@ class EditorEditText : AppCompatEditText {
         fun onMenuActionChanged(menuAction: MenuAction)
     }
 
+    fun interface OnLinkActionChangedListener {
+        fun onLinkActionChanged(linkAction: LinkAction?)
+    }
+
     /**
      * Set the mention display handler to display mentions in a custom way.
      */
@@ -128,6 +132,18 @@ class EditorEditText : AppCompatEditText {
 
             viewModel.menuActionCallback = { menuAction ->
                 value?.onMenuActionChanged(menuAction)
+            }
+        }
+
+    /**
+     * Set the link action listener to be notified when the available link action changes.
+     */
+    var linkActionChangedListener: OnLinkActionChangedListener? = null
+        set(value) {
+            field = value
+
+            viewModel.linkActionCallback = { linkAction ->
+                value?.onLinkActionChanged(linkAction)
             }
         }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/view/models/LinkActionExt.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/view/models/LinkActionExt.kt
@@ -1,0 +1,16 @@
+package io.element.android.wysiwyg.internal.view.models
+
+
+import io.element.android.wysiwyg.view.models.LinkAction
+import uniffi.wysiwyg_composer.LinkAction as InternalLinkAction
+
+internal fun InternalLinkAction.toApiModel(
+    prevAction: LinkAction?
+): LinkAction? =
+    when (this) {
+        is InternalLinkAction.Keep -> prevAction
+        is InternalLinkAction.Edit -> LinkAction.SetLink(currentUrl = url)
+        is InternalLinkAction.Create -> LinkAction.SetLink(currentUrl = null)
+        is InternalLinkAction.CreateWithText -> LinkAction.InsertLink
+        is InternalLinkAction.Disabled -> null
+    }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/view/models/LinkActionExt.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/view/models/LinkActionExt.kt
@@ -4,11 +4,8 @@ package io.element.android.wysiwyg.internal.view.models
 import io.element.android.wysiwyg.view.models.LinkAction
 import uniffi.wysiwyg_composer.LinkAction as InternalLinkAction
 
-internal fun InternalLinkAction.toApiModel(
-    prevAction: LinkAction?
-): LinkAction? =
+internal fun InternalLinkAction.toApiModel(): LinkAction? =
     when (this) {
-        is InternalLinkAction.Keep -> prevAction
         is InternalLinkAction.Edit -> LinkAction.SetLink(currentUrl = url)
         is InternalLinkAction.Create -> LinkAction.SetLink(currentUrl = null)
         is InternalLinkAction.CreateWithText -> LinkAction.InsertLink

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
@@ -13,7 +13,6 @@ import io.element.android.wysiwyg.utils.RustErrorCollector
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.models.LinkAction
 import uniffi.wysiwyg_composer.*
-import uniffi.wysiwyg_composer.LinkAction as InternalLinkAction
 
 internal class EditorViewModel(
     private val provideComposer: () -> ComposerModelInterface?,
@@ -136,9 +135,9 @@ internal class EditorViewModel(
                 menuActionCallback?.invoke(menuAction)
             }
 
-            val linkAction = update.linkAction()
-            if (linkAction !is InternalLinkAction.Keep) {
-                curLinkAction = update.linkAction().toApiModel(curLinkAction)
+            val linkActionUpdate = update.linkAction()
+            if (linkActionUpdate is LinkActionUpdate.Update) {
+                curLinkAction = linkActionUpdate.linkAction.toApiModel()
                 linkActionCallback?.invoke(curLinkAction)
             }
         }
@@ -186,7 +185,7 @@ internal class EditorViewModel(
     }
 
     fun getLinkAction(): LinkAction? =
-        composer?.getLinkAction()?.toApiModel(curLinkAction)
+        composer?.getLinkAction()?.toApiModel()
 
     private fun onComposerFailure(error: Throwable, attemptContentRecovery: Boolean = true) {
         rustErrorCollector?.onRustError(error)

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposerUpdateFactory.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposerUpdateFactory.kt
@@ -3,7 +3,7 @@ package io.element.android.wysiwyg.mocks
 import io.mockk.every
 import io.mockk.mockk
 import uniffi.wysiwyg_composer.ComposerUpdate
-import uniffi.wysiwyg_composer.LinkAction
+import uniffi.wysiwyg_composer.LinkActionUpdate
 import uniffi.wysiwyg_composer.MenuAction
 import uniffi.wysiwyg_composer.MenuState
 import uniffi.wysiwyg_composer.TextUpdate
@@ -13,7 +13,7 @@ object MockComposerUpdateFactory {
         menuAction: MenuAction = MenuAction.Keep,
         menuState: MenuState = MenuState.Keep,
         textUpdate: TextUpdate = TextUpdate.Keep,
-        linkAction: LinkAction = LinkAction.Keep,
+        linkAction: LinkActionUpdate = LinkActionUpdate.Keep,
     ): ComposerUpdate = mockk {
         every { menuAction() } returns menuAction
         every { menuState() } returns menuState

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposerUpdateFactory.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposerUpdateFactory.kt
@@ -3,6 +3,7 @@ package io.element.android.wysiwyg.mocks
 import io.mockk.every
 import io.mockk.mockk
 import uniffi.wysiwyg_composer.ComposerUpdate
+import uniffi.wysiwyg_composer.LinkAction
 import uniffi.wysiwyg_composer.MenuAction
 import uniffi.wysiwyg_composer.MenuState
 import uniffi.wysiwyg_composer.TextUpdate
@@ -12,9 +13,11 @@ object MockComposerUpdateFactory {
         menuAction: MenuAction = MenuAction.Keep,
         menuState: MenuState = MenuState.Keep,
         textUpdate: TextUpdate = TextUpdate.Keep,
+        linkAction: LinkAction = LinkAction.Keep,
     ): ComposerUpdate = mockk {
         every { menuAction() } returns menuAction
         every { menuState() } returns menuState
         every { textUpdate() } returns textUpdate
+        every { linkAction() } returns linkAction
     }
 }


### PR DESCRIPTION
## Problem

When moving the cursor/selection to a new position, the compose state does not update the available link action.

## Solution

Previously the Android compose library only updated the available link action when the editor text changed. However, this misses any updates that result from changing the selection. To solve this:

- Rust lib: return link action changes along with composer updates
- Android view lib: Add a listener API to the to allow registering for link action updates
- Android compose lib: Use the listener API to listen for state changes and update the compose state