### PR TITLE
[Android] Add customisation options for links and code

### DIFF
--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias libs.plugins.android.application apply false
@@ -16,3 +18,25 @@ def launchTask = getGradle()
 if (launchTask.containsIgnoreCase("coverage")) {
     apply from: 'coverage.gradle'
 }
+
+subprojects {
+    tasks.withType(KotlinCompile).configureEach {
+        compilerOptions {
+            if (project.findProperty("composeCompilerReports") == "true") {
+                freeCompilerArgs.addAll([
+                        "-P",
+                        "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                                project.buildDir.absolutePath + "/compose_compiler"
+                ])
+            }
+            if (project.findProperty("composeCompilerMetrics") == "true") {
+                freeCompilerArgs.addAll([
+                        "-P",
+                        "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                                project.buildDir.absolutePath + "/compose_compiler"
+                ])
+            }
+        }
+    }
+}
+

--- a/platforms/android/example-compose/build.gradle
+++ b/platforms/android/example-compose/build.gradle
@@ -62,5 +62,6 @@ dependencies {
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
+    implementation libs.kotlin.collections.immutable
     debugImplementation "androidx.compose.ui:ui-tooling"
 }

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -27,6 +27,7 @@ import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.models.LinkAction
 import io.element.wysiwyg.compose.ui.components.FormattingButtons
 import io.element.wysiwyg.compose.ui.theme.RichTextEditorTheme
+import kotlinx.collections.immutable.toPersistentMap
 import timber.log.Timber
 import uniffi.wysiwyg_composer.ComposerAction
 
@@ -77,7 +78,7 @@ class MainActivity : ComponentActivity() {
                             onResetText = {
                                 state.setHtml("")
                             },
-                            actionStates = state.actions,
+                            actionStates = state.actions.toPersistentMap(),
                             onActionClick = {
                                 when (it) {
                                     ComposerAction.BOLD -> state.toggleInlineFormat(InlineFormat.Bold)

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/ui/components/FormattingButtons.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/ui/components/FormattingButtons.kt
@@ -17,14 +17,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import io.element.android.wysiwyg.view.models.LinkAction
 import io.element.wysiwyg.compose.R
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentMapOf
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
 
 @Composable
 fun FormattingButtons(
-    actionStates: Map<ComposerAction, ActionState>,
+    actionStates: ImmutableMap<ComposerAction, ActionState>,
     modifier: Modifier = Modifier,
     onResetText: () -> Unit = {},
     onActionClick: (ComposerAction) -> Unit = {},
@@ -214,7 +215,7 @@ private fun FormattingButton(
 @Composable
 private fun FormattingButtonsPreview() =
     FormattingButtons(
-        actionStates = mapOf(
+        actionStates = persistentMapOf(
             ComposerAction.BOLD to ActionState.ENABLED,
             ComposerAction.ITALIC to ActionState.REVERSED,
             ComposerAction.UNDERLINE to ActionState.DISABLED,
@@ -225,6 +226,6 @@ private fun FormattingButtonsPreview() =
 @Composable
 private fun FormattingButtonsDefaultPreview() =
     FormattingButtons(
-        actionStates = emptyMap()
+        actionStates = persistentMapOf()
     )
 

--- a/platforms/android/gradle/libs.versions.toml
+++ b/platforms/android/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-core-ktx-1_10_1 = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
 kotlin-coroutines = { module="org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref="coroutines" }
 kotlin-coroutines-android = { module="org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref="coroutines" }
+kotlin-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.3.5" }
 
 # Android / Google
 androidx-appcompat = { module="androidx.appcompat:appcompat", version.ref="appcompat" }

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStyleTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStyleTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
 import androidx.test.espresso.Espresso.onView
@@ -24,7 +25,7 @@ class RichTextEditorStyleTest {
 
     private val state = createState()
     private val bulletRadius = MutableStateFlow(2.dp)
-    private val codeBg = MutableStateFlow(io.element.android.wysiwyg.R.drawable.code_block_bg)
+    private val codeBgColor = MutableStateFlow(Color.Blue)
 
     @Test
     fun testContentIsStillDisplayedAfterSetStyle() = runTest {
@@ -44,10 +45,9 @@ class RichTextEditorStyleTest {
 
     @Test(expected = NotFoundException::class)
     fun testBadResourceThrows() = runTest {
-        val nonExistentDrawable = 0
         showContent()
 
-        codeBg.emit(nonExistentDrawable)
+        codeBgColor.emit(Color.Red)
 
         composeTestRule.awaitIdle()
     }
@@ -55,13 +55,15 @@ class RichTextEditorStyleTest {
     private fun showContent() =
         composeTestRule.setContent {
             val bulletRadius by bulletRadius.collectAsState()
-            val codeBg by codeBg.collectAsState()
+            val codeBgColor by codeBgColor.collectAsState()
             val style = RichTextEditorDefaults.style(
                 bulletList = RichTextEditorDefaults.bulletListStyle(
                     bulletRadius = bulletRadius
                 ),
                 codeBlock = RichTextEditorDefaults.codeBlockStyle(
-                    backgroundDrawable = codeBg
+                    background = RichTextEditorDefaults.codeBlockBackgroundStyle(
+                        color = codeBgColor
+                    )
                 )
             )
             MaterialTheme {

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -176,6 +176,7 @@ private fun AppCompatEditText.applyStyle(style: RichTextEditorStyle) {
         val cursorDrawable = ContextCompat.getDrawable(context, R.drawable.cursor)
         cursorDrawable?.setTint(style.cursor.color.toArgb())
         textCursorDrawable = cursorDrawable
+        setLinkTextColor(style.link.color.toArgb())
     }
 }
 

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
@@ -1,12 +1,15 @@
 package io.element.android.wysiwyg.compose
 
-import io.element.android.wysiwyg.R as BaseR
-import androidx.annotation.DrawableRes
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+
+private val defaultCodeCornerRadius = 4.dp
+private val defaultCodeBorderWidth = 1.dp
+
 
 /**
  * Default config for the [RichTextEditor] composable.
@@ -63,19 +66,19 @@ object RichTextEditorDefaults {
      * @param leadingMargin The leading margin to apply
      * @param verticalPadding The vertical padding to apply
      * @param relativeTextSize The relative font scale to apply to code text
-     * @param backgroundDrawable The background drawable to use
+     * @param background The background style to apply
      */
+    @Composable
     fun codeBlockStyle(
         leadingMargin: Dp = 16.dp,
         verticalPadding: Dp = 8.dp,
         relativeTextSize: Float = 0.85f,
-        @DrawableRes
-        backgroundDrawable: Int = BaseR.drawable.code_block_bg,
+        background: CodeBackgroundStyle = codeBlockBackgroundStyle(),
     ) = CodeBlockStyle(
         leadingMargin = leadingMargin,
         verticalPadding = verticalPadding,
         relativeTextSize = relativeTextSize,
-        backgroundDrawable = backgroundDrawable,
+        background = background,
     )
 
     /**
@@ -84,31 +87,19 @@ object RichTextEditorDefaults {
      * @param horizontalPadding The horizontal padding to apply
      * @param verticalPadding The vertical padding to apply
      * @param relativeTextSize The relative font scale to apply to code text
-     * @param singleLineBg The background drawable to apply for single line code blocks
-     * @param multiLineBgLeft The background drawable to apply for the left side of multi line inline code
-     * @param multiLineBgMid The background drawable to apply for the middle of multi line inline code
-     * @param multiLineBgRight The background drawable to apply for the right side of multi line inline code
+     * @param background The background style to apply for single line code blocks
      */
+    @Composable
     fun inlineCodeStyle(
         horizontalPadding: Dp = 4.dp,
         verticalPadding: Dp = 2.dp,
         relativeTextSize: Float = 0.85f,
-        @DrawableRes
-        singleLineBg: Int = BaseR.drawable.inline_code_single_line_bg,
-        @DrawableRes
-        multiLineBgLeft: Int = BaseR.drawable.inline_code_multi_line_bg_left,
-        @DrawableRes
-        multiLineBgMid: Int = BaseR.drawable.inline_code_multi_line_bg_mid,
-        @DrawableRes
-        multiLineBgRight: Int = BaseR.drawable.inline_code_multi_line_bg_right,
+        background: InlineCodeBackgroundStyle = inlineCodeBackgroundStyle(),
     ) = InlineCodeStyle(
         horizontalPadding = horizontalPadding,
         verticalPadding = verticalPadding,
         relativeTextSize = relativeTextSize,
-        singleLineBg = singleLineBg,
-        multiLineBgLeft = multiLineBgLeft,
-        multiLineBgMid = multiLineBgMid,
-        multiLineBgRight = multiLineBgRight,
+        background = background,
     )
 
     /**
@@ -157,4 +148,79 @@ object RichTextEditorDefaults {
     ) = LinkStyle(
         color = color,
     )
+
+    /**
+     * Creates a default code block background.
+     */
+    @Composable
+    fun codeBlockBackgroundStyle(
+        color: Color = MaterialTheme.colorScheme.secondaryContainer,
+        borderColor: Color = MaterialTheme.colorScheme.onSecondaryContainer,
+        cornerRadius: Dp = defaultCodeCornerRadius,
+        borderWidth: Dp = defaultCodeBorderWidth,
+    ): CodeBackgroundStyle = CodeBackgroundStyle(
+        density = LocalDensity.current,
+        color = color,
+        borderColor = borderColor,
+        borderWidth = borderWidth,
+        cornerRadiusTopLeft = cornerRadius,
+        cornerRadiusTopRight = cornerRadius,
+        cornerRadiusBottomRight = cornerRadius,
+        cornerRadiusBottomLeft = cornerRadius,
+    )
+
+    /**
+     * Creates a default inline code background.
+     */
+    @Composable
+    fun inlineCodeBackgroundStyle(
+        color: Color = MaterialTheme.colorScheme.secondaryContainer,
+        borderColor: Color = MaterialTheme.colorScheme.onSecondaryContainer,
+        cornerRadius: Dp = defaultCodeCornerRadius,
+        borderWidth: Dp = defaultCodeBorderWidth
+    ): InlineCodeBackgroundStyle {
+        val density = LocalDensity.current
+        return InlineCodeBackgroundStyle(
+            singleLine = CodeBackgroundStyle(
+                density = density,
+                color = color,
+                borderColor = borderColor,
+                borderWidth = borderWidth,
+                cornerRadiusTopLeft = cornerRadius,
+                cornerRadiusTopRight = cornerRadius,
+                cornerRadiusBottomRight = cornerRadius,
+                cornerRadiusBottomLeft = cornerRadius,
+            ),
+            multiLineLeft = CodeBackgroundStyle(
+                density = density,
+                color = color,
+                borderColor = borderColor,
+                borderWidth = borderWidth,
+                cornerRadiusTopLeft = cornerRadius,
+                cornerRadiusTopRight = 0.dp,
+                cornerRadiusBottomRight = 0.dp,
+                cornerRadiusBottomLeft = cornerRadius,
+            ),
+            multiLineRight = CodeBackgroundStyle(
+                density = density,
+                color = color,
+                borderColor = borderColor,
+                borderWidth = borderWidth,
+                cornerRadiusTopLeft = 0.dp,
+                cornerRadiusTopRight = cornerRadius,
+                cornerRadiusBottomRight = cornerRadius,
+                cornerRadiusBottomLeft = 0.dp,
+            ),
+            multiLineMiddle = CodeBackgroundStyle(
+                density = density,
+                color = color,
+                borderColor = borderColor,
+                borderWidth = borderWidth,
+                cornerRadiusTopLeft = 0.dp,
+                cornerRadiusTopRight = 0.dp,
+                cornerRadiusBottomRight = 0.dp,
+                cornerRadiusBottomLeft = 0.dp,
+            ),
+        )
+    }
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
@@ -20,9 +20,9 @@ object RichTextEditorDefaults {
      * @param codeBlock A custom style for code blocks.
      * @param inlineCode A custom style for inline code.
      * @param pill A custom style for pills.
-     * @param textColor Color of the text displayed in the editor.
-     * @param cursorDrawable Color of the cursor displayed in the editor.
-     *                    Only supported on API 29 and above.
+     * @param text A custom style for text displayed in the editor.
+     * @param cursor A custom style for the cursor for API 29 and above.
+     * @param link A custom style for links.
      */
     @Composable
     fun style(
@@ -32,6 +32,7 @@ object RichTextEditorDefaults {
         pill: PillStyle = pillStyle(),
         text: TextStyle = textStyle(),
         cursor: CursorStyle = cursorStyle(),
+        link: LinkStyle = linkStyle(),
     ): RichTextEditorStyle = RichTextEditorStyle(
         bulletList = bulletList,
         codeBlock = codeBlock,
@@ -39,6 +40,7 @@ object RichTextEditorDefaults {
         pill = pill,
         text = text,
         cursor = cursor,
+        link = link,
     )
 
     /**
@@ -141,6 +143,18 @@ object RichTextEditorDefaults {
     fun cursorStyle(
         color: Color = MaterialTheme.colorScheme.primary,
     ) = CursorStyle(
+        color = color,
+    )
+
+    /**
+     * Creates the default link style for [RichTextEditor].
+     *
+     * @param color The color to apply
+     */
+    @Composable
+    fun linkStyle(
+        color: Color = MaterialTheme.colorScheme.scrim,
+    ) = LinkStyle(
         color = color,
     )
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
@@ -1,8 +1,12 @@
 package io.element.android.wysiwyg.compose
 
-import androidx.annotation.DrawableRes
+import android.graphics.drawable.GradientDrawable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import kotlin.math.roundToInt
 
 data class RichTextEditorStyle internal constructor(
     val bulletList: BulletListStyle,
@@ -23,22 +27,14 @@ data class CodeBlockStyle internal constructor(
     val leadingMargin: Dp,
     val verticalPadding: Dp,
     val relativeTextSize: Float,
-    @DrawableRes
-    val backgroundDrawable: Int,
+    val background: CodeBackgroundStyle,
 )
 
 data class InlineCodeStyle internal constructor(
     val horizontalPadding: Dp,
     val verticalPadding: Dp,
     val relativeTextSize: Float,
-    @DrawableRes
-    val singleLineBg: Int,
-    @DrawableRes
-    val multiLineBgLeft: Int,
-    @DrawableRes
-    val multiLineBgMid: Int,
-    @DrawableRes
-    val multiLineBgRight: Int,
+    val background: InlineCodeBackgroundStyle,
 )
 
 data class PillStyle(
@@ -55,4 +51,42 @@ data class CursorStyle(
 
 data class LinkStyle(
     val color: Color,
+)
+
+@Immutable
+data class CodeBackgroundStyle(
+    val density: Density,
+    val color: Color,
+    val borderColor: Color,
+    val cornerRadiusTopLeft: Dp,
+    val cornerRadiusTopRight: Dp,
+    val cornerRadiusBottomLeft: Dp,
+    val cornerRadiusBottomRight: Dp,
+    val borderWidth: Dp,
+) {
+    internal val drawable by lazy {
+        GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            setColor(this@CodeBackgroundStyle.color.toArgb())
+            setStroke(
+                with(density) { borderWidth.toPx() }.roundToInt(),
+                borderColor.toArgb()
+            )
+            cornerRadii = with(density) {
+                floatArrayOf(
+                    cornerRadiusTopLeft.toPx(), cornerRadiusTopLeft.toPx(),
+                    cornerRadiusTopRight.toPx(), cornerRadiusTopRight.toPx(),
+                    cornerRadiusBottomRight.toPx(), cornerRadiusBottomRight.toPx(),
+                    cornerRadiusBottomLeft.toPx(), cornerRadiusBottomLeft.toPx()
+                )
+            }
+        }
+    }
+}
+
+data class InlineCodeBackgroundStyle(
+    val singleLine: CodeBackgroundStyle,
+    val multiLineLeft: CodeBackgroundStyle,
+    val multiLineMiddle: CodeBackgroundStyle,
+    val multiLineRight: CodeBackgroundStyle,
 )

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
@@ -11,6 +11,7 @@ data class RichTextEditorStyle internal constructor(
     val pill: PillStyle,
     val text: TextStyle,
     val cursor: CursorStyle,
+    val link: LinkStyle,
 )
 
 data class BulletListStyle internal constructor(
@@ -49,5 +50,9 @@ data class TextStyle(
 )
 
 data class CursorStyle(
+    val color: Color,
+)
+
+data class LinkStyle(
     val color: Color,
 )

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
@@ -1,11 +1,8 @@
 package io.element.android.wysiwyg.compose.internal
 
 import android.content.Context
-import android.content.res.Resources.NotFoundException
-import androidx.annotation.DrawableRes
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.Density
-import androidx.core.content.ContextCompat
 import io.element.android.wysiwyg.compose.BulletListStyle
 import io.element.android.wysiwyg.compose.CodeBlockStyle
 import io.element.android.wysiwyg.compose.InlineCodeStyle
@@ -39,10 +36,10 @@ internal fun InlineCodeStyle.toStyleConfig(context: Context): InlineCodeStyleCon
         horizontalPadding = with(density) { horizontalPadding.toPx().roundToInt() },
         verticalPadding = with(density) { verticalPadding.toPx().roundToInt() },
         relativeTextSize = relativeTextSize,
-        singleLineBg = context.requireDrawable(singleLineBg),
-        multiLineBgLeft = context.requireDrawable(multiLineBgLeft),
-        multiLineBgMid = context.requireDrawable(multiLineBgMid),
-        multiLineBgRight = context.requireDrawable(multiLineBgRight),
+        singleLineBg = background.singleLine.drawable,
+        multiLineBgLeft = background.multiLineLeft.drawable,
+        multiLineBgMid = background.multiLineMiddle.drawable,
+        multiLineBgRight = background.multiLineRight.drawable
     )
 }
 
@@ -52,7 +49,7 @@ internal fun CodeBlockStyle.toStyleConfig(context: Context): CodeBlockStyleConfi
         leadingMargin = with(density) { leadingMargin.toPx().roundToInt() },
         verticalPadding = with(density) { verticalPadding.toPx().roundToInt() },
         relativeTextSize = relativeTextSize,
-        backgroundDrawable = context.requireDrawable(backgroundDrawable),
+        backgroundDrawable = background.drawable,
     )
 }
 
@@ -61,7 +58,3 @@ internal fun PillStyle.toStyleConfig(): PillStyleConfig =
         backgroundColor = backgroundColor.toArgb(),
     )
 
-private fun Context.requireDrawable(
-    @DrawableRes drawable: Int
-) = ContextCompat.getDrawable(this, drawable)
-    ?: throw NotFoundException("Drawable not found")

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -51,6 +51,11 @@ android {
 
     buildFeatures {
         buildConfig = true
+        compose true // Enable classes to be marked as stable
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.1'
     }
 
     testOptions {
@@ -96,6 +101,8 @@ dependencies {
     implementation libs.androidx.lifecycle.viewmodel
     api libs.google.material
     implementation libs.androidx.constraintlayout
+    implementation platform(libs.androidx.compose.bom)
+    implementation 'androidx.compose.runtime:runtime'
     testImplementation libs.test.junit
     testImplementation libs.test.robolectric
     testImplementation libs.test.mockk


### PR DESCRIPTION
## Changes

There are a few semi-related changes in this PR which can be reviewed commit by commit (or split into separate PRs if needed).

- Allow customisation of link color
- Allow customisation of code and inline code backgrounds
- Refactor code and inline code background styles (so that apps do not need to handle drawables directly)
- Add useful compose debugging config
- Fix a few mutability/instability issues in the example app and core view library

## Context

- https://github.com/vector-im/element-x-android/issues/1315