### PR TITLE
[iOS] Add workaround for the "out of bounds index" error

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -451,9 +451,16 @@ private extension WysiwygComposerViewModel {
             let attributed = try HTMLParser.parse(html: html,
                                                   style: parserStyle,
                                                   mentionReplacer: mentionReplacer)
-            // FIXME: handle error for out of bounds index
             let htmlSelection = NSRange(location: Int(start), length: Int(end - start))
-            let textSelection = try attributed.attributedRange(from: htmlSelection)
+            let textSelection: NSRange
+
+            // Workaround for the "out of bounds index" error
+            if start == end, start > attributed.length {
+                textSelection = .init(location: attributed.length, length: 0)
+            } else {
+                textSelection = try attributed.attributedRange(from: htmlSelection)
+            }
+
             attributedContent = WysiwygComposerAttributedContent(text: attributed,
                                                                  selection: textSelection,
                                                                  plainText: model.getContentAsPlainText())

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+SetContent.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+SetContent.swift
@@ -20,6 +20,7 @@ import XCTest
 
 private enum Constants {
     static let sampleHtml = "some <strong>bold</strong> text"
+    static let sampleHtmlNewline = "<p><strong>bold</strong></p>\n"
     static let sampleMarkdown = "some __bold__ text"
     static let samplePlainText = "some bold text"
     static let sampleHtml2 = "<ol><li><strong>A</strong></li><li><em>B</em></li></ol>"
@@ -35,6 +36,13 @@ extension WysiwygComposerViewModelTests {
         viewModel.setHtmlContent(Constants.sampleHtml2)
         XCTAssertEqual(viewModel.content.html, Constants.sampleHtml2)
         XCTAssertEqual(viewModel.content.markdown, Constants.sampleMarkdown2)
+    }
+
+    func testSetHtmlContentTrailingNewline() throws {
+        viewModel.setHtmlContent(Constants.sampleHtmlNewline)
+        XCTAssertEqual(viewModel.content.html, "<p><strong>bold</strong></p><p>\n</p>")
+        XCTAssertEqual(viewModel.content.markdown, "__bold__\n\n")
+        XCTAssertEqual(viewModel.attributedContent.selection, NSRange(location: 5, length: 0))
     }
 
     func testSetMarkdownContent() throws {


### PR DESCRIPTION
This PR is work around an "out of bounds index" on the `WysiwygComposerViewModel`.
It triggered when the `func setHtmlContent(_ html:)` was fed with a text like this `<p><strong>rteoff</strong></p>\n`.
The same string without a trailing `\n` worked well.

related issue: https://github.com/matrix-org/matrix-rich-text-editor/issues/818