### PR TITLE
Fix unwanted extra paragraphs after HTML parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "mime"
@@ -920,9 +920,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.2"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -931,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "ruma-common"
@@ -1849,6 +1861,7 @@ dependencies = [
  "matrix_mentions",
  "once_cell",
  "pulldown-cmark",
+ "regex",
  "speculoos",
  "strum",
  "strum_macros",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -31,6 +31,7 @@ widestring = "1.0.2"
 indoc = "1.0"
 url="2.3.1"
 email_address="0.2.4"
+regex="1.9.5"
 matrix_mentions = { path = "../matrix_mentions" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use regex::Regex;
+
 use crate::dom::dom_creation_error::HtmlParseError;
 use crate::dom::nodes::dom_node::DomNodeKind::CodeBlock;
 use crate::dom::nodes::ContainerNode;
@@ -709,6 +711,15 @@ fn convert_text<S: UnicodeString>(
         if is_nbsp {
             return;
         }
+
+        // Trim any surrounding indentation
+        let surrounding_indent =
+            Regex::new(r"^(\s*\n\s*)+|(\s*\n\s*)+$").unwrap();
+        let contents = &surrounding_indent.replace_all(contents, "");
+
+        // Replace any internal indentation with a single space
+        let internal_indent = Regex::new(r"s*\n\s*").unwrap();
+        let contents = &internal_indent.replace_all(contents, " ");
 
         for (i, part) in contents.split("@room").enumerate() {
             if i > 0 {

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
@@ -423,6 +423,13 @@ class EditorEditTextInputTests {
     }
 
     @Test
+    fun testSetHtml() {
+        onView(withId(R.id.rich_text_edit_text))
+            .perform(EditorActions.setHtml("<p><strong>hello</strong></p>\n"))
+            .check(matches(withText("hello")))
+    }
+
+    @Test
     fun testMenuStateChangedListener() {
         var isItalicHighlighted = false
         scenarioRule.scenario.onActivity {


### PR DESCRIPTION
## Problem

The editor may be initialised with arbitrary HTML content however, it currently misbehaves when supplied HTML that contains new lines and indentation.

For example, consider the following HTML snippet:

```html
<p>
  Hello, how are you doing?
</p>

<p>
  I'm fine thanks.
  And you?
</p>
```

This is valid HTML but the editor would not understand that the new lines and and spacing are for formatting and indenting the markup, rather than to be displayed as text characters.

The resulting AST contains lots of stray paragraphs and new line characters in the text, which is not correct:

```
├>p
│ └>"
│   "
├>p
│ └>"
│     Hello, how are you doing?
│   "
├>p
│ └>"
│
│   "
├>p
│ └>"
│     I'm fine thanks.
│     And you?
│   "
└>p
  └>"
            "
```

## Solution

Instead of treating new lines as text, treat new lines (and adjacent spacing) within HTML as indentation:
- Trim surrounding indentation from text
- Replace internal indentation with a single space

After this change, the AST now looks like:

```
└>p
  └>"Hello, how are you doing?"
└>p
  └>"I'm fine thanks. And you?"

```

See this [JSFiddle example](https://jsfiddle.net/d9Lwnu7o/) where the same behaviour is shown.

- Fixes https://github.com/matrix-org/matrix-rich-text-editor/issues/795