### PR TITLE
Fix crash on pressing enter after emoji

### DIFF
--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -354,6 +354,13 @@ mod test {
     }
 
     #[test]
+    fn test_new_line_after_emoji() {
+        let mut model = cm("🤗|");
+        model.enter();
+        assert_eq!(tx(&model), "<p>🤗</p><p>&nbsp;|</p>");
+    }
+
+    #[test]
     fn test_new_line_in_formatted_text() {
         let mut model = cm("<b>Test| lines</b>");
         model.enter();

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -17,7 +17,6 @@
 
 use crate::dom::nodes::dom_node::DomNodeKind::{Generic, ListItem, Paragraph};
 use crate::dom::range::DomLocationPosition::After;
-use crate::dom::unicode_string::UnicodeStr;
 use crate::dom::DomLocation;
 use crate::{DomHandle, DomNode, UnicodeString};
 
@@ -1019,7 +1018,7 @@ where
         if (cur_handle == *from_handle
             || (from_handle.is_ancestor_of(&cur_handle)
                 && cur_handle.index_in_parent() == 0))
-            && (1..=text_node.data().chars().count()).contains(&start_offset)
+            && (1..=text_node.data().len()).contains(&start_offset)
         {
             let left_data = text_node.data()[..start_offset].to_owned();
             let right_data = text_node.data()[start_offset..].to_owned();
@@ -1029,7 +1028,7 @@ where
             }
         } else if to_handle.is_some()
             && cur_handle == to_handle.unwrap()
-            && (1..=text_node.data().chars().count()).contains(&end_offset)
+            && (1..=text_node.data().len()).contains(&end_offset)
         {
             let left_data = text_node.data()[..end_offset].to_owned();
             let right_data = text_node.data()[end_offset..].to_owned();
@@ -1163,6 +1162,18 @@ mod test {
         );
         assert_eq!(model.state.dom.to_html(), "Text<b>bo</b>");
         assert_eq!(ret.to_html().to_string(), "<b>ld</b><i>italic</i>");
+    }
+
+    #[test]
+    fn split_dom_with_emojis() {
+        let mut model = cm("👍👍|<b>👍👍</b><i>👍👍</i>");
+        let ret = model.state.dom.split_sub_tree_from(
+            &DomHandle::from_raw(vec![1, 0]),
+            2,
+            0,
+        );
+        assert_eq!(model.state.dom.to_html(), "👍👍<b>👍</b>");
+        assert_eq!(ret.to_html().to_string(), "<b>👍</b><i>👍👍</i>");
     }
 
     #[test]

--- a/crates/wysiwyg/src/dom/find_range.rs
+++ b/crates/wysiwyg/src/dom/find_range.rs
@@ -352,6 +352,32 @@ mod test {
     }
 
     #[test]
+    fn finding_a_node_within_a_single_text_node_with_emoji_is_found() {
+        let d = dom(&[tn("🤗")]);
+        assert_eq!(
+            find_pos(&d, &d.document_handle(), 2, 2),
+            FindResult::Found(vec![
+                make_single_location(
+                    DomHandle::from_raw(vec![0]),
+                    0,
+                    2,
+                    2,
+                    2,
+                    DomNodeKind::Text
+                ),
+                make_single_location(
+                    DomHandle::root(),
+                    0,
+                    2,
+                    2,
+                    2,
+                    DomNodeKind::Generic
+                ),
+            ])
+        );
+    }
+
+    #[test]
     fn finding_first_node_within_flat_text_nodes_is_found() {
         let d = dom(&[tn("foo"), tn("bar")]);
         assert_eq!(

--- a/crates/wysiwyg/src/dom/range.rs
+++ b/crates/wysiwyg/src/dom/range.rs
@@ -38,7 +38,7 @@ pub struct DomLocation {
     pub node_handle: DomHandle,
 
     /// The position inside this node of the start of the range. In a text
-    /// node this will be the number of code points through the text to
+    /// node this will be the number of code units through the text to
     /// get to the start of the range. In a container node this will be how
     /// far through children nodes you need to count to get to the start.
     /// In a text-like node like a line break, this will be 0 or 1.
@@ -46,7 +46,7 @@ pub struct DomLocation {
     pub start_offset: usize,
 
     /// The position inside this node of the end of the range. In a text
-    /// node this will be the number of code points through the text to
+    /// node this will be the number of code units through the text to
     /// get to the end of the range. In a container node this will be how
     /// far through children nodes you need to count to get to the end.
     /// In a text-like node like a line break, this will be 0 or 1.

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
@@ -39,6 +39,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Description
 import org.junit.*
 import org.junit.runner.RunWith
@@ -121,6 +122,17 @@ class EditorEditTextInputTests {
             .perform(AnyViewAction { view -> (view as EditText).setSelection(0) })
             .perform(pressKey(KeyEvent.KEYCODE_FORWARD_DEL))
             .check(matches(withText("")))
+    }
+
+    @Test
+    fun testEnterAfterEmoji() {
+        val emoji = "\uD83E\uDD17"
+        onView(withId(R.id.rich_text_edit_text))
+            // pressKey doesn't seem to work if no `typeText` is used before
+            .perform(pressKey(KeyEvent.KEYCODE_A))
+            .perform(replaceText(emoji))
+            .perform(pressKey(KeyEvent.KEYCODE_ENTER))
+            .check(matches(withText(containsString(emoji + "\n"))))
     }
 
     @Test

--- a/platforms/android/library/src/androidTest/res/layout/activity_test.xml
+++ b/platforms/android/library/src/androidTest/res/layout/activity_test.xml
@@ -29,7 +29,7 @@
         android:id="@id/rich_text_edit_text"
         android:layout_width="match_parent"
         android:layout_height="48dp"
-        android:inputType="text|textNoSuggestions"
+        android:inputType="textMultiLine|textNoSuggestions"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/label" />


### PR DESCRIPTION
## Problem

Pressing enter after an emoji code point composed of multiple code units (for example :hugs:) causes a crash.

See the following issues for more details
- #644
- https://github.com/vector-im/element-x-android/issues/1394
- https://github.com/vector-im/element-ios/issues/7681


## Solution

The problem is caused by a bug in the dom splitting logic used by the enter/new line functionality. When counting the length of a text node, we used `chars()` which returns the number of code points. However, the units used for selection indices and offsets are in code _units_. As emoji code points can be formed of multiple code units, this causes calculation errors.


- Fixes #644