### PR TITLE
[Android] Fix selection state restoration

### DIFF
--- a/platforms/android/library-compose/build.gradle
+++ b/platforms/android/library-compose/build.gradle
@@ -4,6 +4,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-parcelize'
 
     alias libs.plugins.jacoco.android
     alias libs.plugins.maven.publish.base

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -103,6 +103,7 @@ private fun RealEditor(
 
                 // Restore the state of the view with the saved state
                 setHtml(state.internalHtml)
+                setSelection(state.selection.first, state.selection.second)
 
                 // Only start listening for text changes after the initial state has been restored
                 if (registerStateUpdates) {

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
@@ -19,6 +19,7 @@ object RichTextEditorDefaults {
     internal const val initialLineCount = 1
     internal const val initialHtml = ""
     internal const val initialFocus = false
+    internal val initialSelection = 0 to 0
 
     /**
      * Creates the default set of style customisations for [RichTextEditor].


### PR DESCRIPTION
## Problem

The selection position is not preserved when sharing state between two composable editors (which represent the same editor but exist at different call sites).

## Solution

- When creating a new editor, apply the selection position found in the state
- Also, save the selection when saving state