### PR TITLE
[Android] Allow selection context menu customisation in compose

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.element.wysiwyg.compose
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.BorderStroke
@@ -19,11 +20,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.element.android.wysiwyg.compose.RichTextEditor
 import io.element.android.wysiwyg.compose.RichTextEditorDefaults
 import io.element.android.wysiwyg.compose.rememberRichTextEditorState
+import io.element.android.wysiwyg.compose.selection.SelectionAction
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.models.LinkAction
 import io.element.wysiwyg.compose.ui.components.FormattingButtons
@@ -42,7 +45,7 @@ class MainActivity : ComponentActivity() {
 
                 var linkDialogAction by remember { mutableStateOf<LinkAction?>(null) }
                 val coroutineScope = rememberCoroutineScope()
-
+                val context = LocalContext.current
 
                 linkDialogAction?.let { linkAction ->
                     LinkDialog(
@@ -84,7 +87,13 @@ class MainActivity : ComponentActivity() {
                                 state = state,
                                 modifier = Modifier.fillMaxWidth(),
                                 style = RichTextEditorDefaults.style(),
-                                onError = Timber::e
+                                onError = Timber::e,
+                                customSelectionActions = listOf(
+                                    SelectionAction(R.id.custom_action, getString(R.string.custom_action))
+                                ),
+                                onCustomSelectionActionSelected = {
+                                    Toast.makeText(context, getString(R.string.custom_action_clicked), Toast.LENGTH_SHORT).show()
+                                },
                             )
                         }
                         FormattingButtons(

--- a/platforms/android/example-compose/src/main/res/values/ids.xml
+++ b/platforms/android/example-compose/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="id" name="custom_action" />
+</resources>

--- a/platforms/android/example-compose/src/main/res/values/strings.xml
+++ b/platforms/android/example-compose/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="link_insert">Insert link</string>
     <string name="link_text">Text</string>
     <string name="link_url">Link</string>
+    <string name="custom_action">Custom action</string>
+    <string name="custom_action_clicked">Custom action clicked</string>
 </resources>

--- a/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/MainActivity.kt
+++ b/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/MainActivity.kt
@@ -58,5 +58,4 @@ class MainActivity : AppCompatActivity() {
             }
         }
     }
-
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/selection/SelectionAction.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/selection/SelectionAction.kt
@@ -1,0 +1,19 @@
+package io.element.android.wysiwyg.compose.selection
+
+import android.view.ActionMode
+import android.widget.EditText
+import androidx.compose.runtime.Immutable
+
+/**
+ * An action to be added to the selection context menu.
+ *
+ * @see [EditText.setCustomSelectionActionModeCallback] and [ActionMode.Callback]
+ *
+ * @param id A unique ID for the action.
+ * @param title The title of the action which should be short.
+ */
+@Immutable
+data class SelectionAction(
+    val id: Int,
+    val title: String,
+)


### PR DESCRIPTION
## Changes

Allow customisation of the selection context menu in compose.


### Screen recording

[Screen_recording_20230929_120916.webm](https://github.com/matrix-org/matrix-rich-text-editor/assets/4940864/4b36e3f2-4a46-4ba7-bb8e-c762ade83299)

## Context

- Part of vector-im/element-meta#2045