### PR TITLE
Fix background drawing when clearing quote / code block

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -72,7 +72,10 @@ public class WysiwygTextView: UITextView {
     /// - Parameters:
     ///   - content: Content to apply.
     func apply(_ content: WysiwygComposerAttributedContent) {
-        guard content.text != attributedText || content.selection != selectedRange else { return }
+        guard content.text.length == 0
+            || content.text != attributedText
+            || content.selection != selectedRange
+        else { return }
 
         performWithoutDelegate {
             self.attributedText = content.text


### PR DESCRIPTION
Fixes issue with background not always disappearing when removing a quote / code block in the Rich Text Editor. 

The issue occurred when clearing an empty quote or code block, if we backspaced the last character we update the `UITextView` attributedContent to a version without the ZWSP + attributes that should hold the information about having a quote / code block there.

This fixes this specific issue by ensuring we always trigger the redraw of the `UITextView` background layers when the model is completely empty, avoiding any remnants from previous content.

One issue remained, described in https://github.com/matrix-org/matrix-rich-text-editor/issues/830

Partial fix for https://github.com/vector-im/element-x-ios/issues/1747