### PR TITLE
Fix reconciliate breaking with leading whitespaces

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
@@ -117,8 +117,17 @@ private struct StringDiff {
 private extension String {
     /// Converts all whitespaces to NBSP to avoid diffs caused by HTML translations.
     var withNBSP: String {
-        String(map { $0.isWhitespace ? Character.nbsp : $0 })
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        String(map { $0.isWhitespace ? Character.nbsp : $0 }).trailingTrimmed
+    }
+
+    var trailingTrimmed: String {
+        var view = self[...]
+
+        while view.last?.isWhitespace == true || view.last?.isNewline == true {
+            view = view.dropLast()
+        }
+
+        return String(view)
     }
 
     /// Computes the diff from provided string to self. Outputs UTF16 locations and lengths.

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
@@ -71,6 +71,16 @@ final class StringDifferTests: XCTestCase {
         XCTAssertNil(try StringDiffer.replacement(from: whitespaceString,
                                                   to: String(repeating: Character.nbsp, count: whitespaceString.utf16Length)))
     }
+
+    func testDiffingWithLeadingWhitespaces() throws {
+        XCTAssertEqual(try StringDiffer.replacement(from: " text", to: " test"),
+                       .init(location: 3, length: 1, text: "s"))
+    }
+
+    func testDiffingWithMultipleLeadingWhitespaces() throws {
+        XCTAssertEqual(try StringDiffer.replacement(from: " \u{00A0} text", to: " \u{00A0} test"),
+                       .init(location: 5, length: 1, text: "s"))
+    }
 }
 
 private extension CharacterSet {


### PR DESCRIPTION
Fix reconciliate triggering with wrong indexes when there are user created leading whitespaces

Fixes https://github.com/vector-im/element-x-ios/issues/1803