### PR TITLE
Exit build xcframework if swiftformat is unavailable

### DIFF
--- a/build_xcframework.sh
+++ b/build_xcframework.sh
@@ -40,6 +40,14 @@ rm -f $SWIFT_BINDINGS_FILE_PATH
 rm -rf $GENERATION_PATH
 
 # Generate headers & Swift bindings
+#
+# Note: swiftformat is automatically run by uniffi-bindgen if available
+# and mandatory for the `sed` tweaks below to work properly.
+if ! command -v swiftformat &> /dev/null
+then
+    echo "swiftformat could not be found"
+    exit 1
+fi
 mkdir -p $GENERATION_PATH
 cargo uniffi-bindgen generate --library $ARM64_LIB_PATH -l swift --out-dir $GENERATION_PATH
 


### PR DESCRIPTION
On setup on a machine with no version of `swiftformat` available, the `sed` workaround to catch Rust panics will not be executed properly due to the Swift file not being formatted as expected by the script, leaving the resulting library in a state where Rust panics would crash the hosting application instead of recovering.
This change ensures that `make ios` or `./build_xcframework.sh` fails explicitly if the tool is not installed. 