### PR TITLE
MentionDisplayHelper to allow to inject context to properly display mentions in RTE

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -40,8 +40,8 @@ protocol WysiwygTextViewDelegate: AnyObject {
     func textView(_ textView: UITextView, didReceivePasteWith provider: NSItemProvider)
 }
 
-/// A markdown protocol used to provide additional context to the text view when handling mentions through the text attachment provider
-public protocol MentionContext: AnyObject { }
+/// A markdown protocol used to provide additional context to the text view when displaying mentions through the text attachment provider
+public protocol MentionDisplayHelper {}
 
 public class WysiwygTextView: UITextView {
     /// Internal delegate for the text view.
@@ -49,7 +49,7 @@ public class WysiwygTextView: UITextView {
     
     private let flusher = WysiwygPillsFlusher()
     
-    public weak var mentionContext: MentionContext?
+    public var mentionDisplayHelper: MentionDisplayHelper?
 
     override public init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
@@ -67,6 +67,10 @@ public class WysiwygTextView: UITextView {
     /// - Parameter pillView: View to register.
     public func registerPillView(_ pillView: UIView) {
         flusher.registerPillView(pillView)
+    }
+    
+    public func flushPills() {
+        flusher.flush()
     }
 
     /// Apply given content to the text view. This will temporary disrupt the text view

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -40,11 +40,16 @@ protocol WysiwygTextViewDelegate: AnyObject {
     func textView(_ textView: UITextView, didReceivePasteWith provider: NSItemProvider)
 }
 
+/// A markdown protocol used to provide additional context to the text view when handling mentions through the text attachment provider
+public protocol MentionContext: AnyObject { }
+
 public class WysiwygTextView: UITextView {
     /// Internal delegate for the text view.
     weak var wysiwygDelegate: WysiwygTextViewDelegate?
-
+    
     private let flusher = WysiwygPillsFlusher()
+    
+    public weak var mentionContext: MentionContext?
 
     override public init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)


### PR DESCRIPTION
Since the NSTextAttachmentProvider can only see the text view, and the pill might require a context that holds various data and helpful functions to make the pill render correctly, this is just a markdown protocol that can be injected as a weak var to get such context.

For example on Element X this context could be the room context, useful to get all the informations of the already fetched members, and the image provider.

The using application will already know what type the context is and just type unwrap it.

Also added a flushPills function on the textview