### PR TITLE
[iOS] expose the set at room mention function

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
@@ -139,6 +139,10 @@ final class ComposerModelWrapper: ComposerModelWrapperProtocol {
     func insertMentionAtSuggestion(url: String, text: String, suggestion: SuggestionPattern, attributes: [Attribute]) -> ComposerUpdate {
         execute { try $0.insertMentionAtSuggestion(url: url, text: text, suggestion: suggestion, attributes: attributes) }
     }
+    
+    func insertAtRoomMentionAtSuggestion(_ suggestion: SuggestionPattern) -> ComposerUpdate {
+        execute { try $0.insertAtRoomMentionAtSuggestion(suggestion: suggestion) }
+    }
 
     func removeLinks() -> ComposerUpdate {
         execute { try $0.removeLinks() }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/ComposerModelWrapper.swift
@@ -140,6 +140,10 @@ final class ComposerModelWrapper: ComposerModelWrapperProtocol {
         execute { try $0.insertMentionAtSuggestion(url: url, text: text, suggestion: suggestion, attributes: attributes) }
     }
     
+    func insertAtRoomMention() -> ComposerUpdate {
+        execute { try $0.insertAtRoomMention() }
+    }
+    
     func insertAtRoomMentionAtSuggestion(_ suggestion: SuggestionPattern) -> ComposerUpdate {
         execute { try $0.insertAtRoomMentionAtSuggestion(suggestion: suggestion) }
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -251,6 +251,13 @@ public extension WysiwygComposerViewModel {
         applyUpdate(update)
         hasPendingFormats = true
     }
+    
+    /// Sets the @room mention at the suggestion position
+    func setAtRoomMention() {
+        guard let suggestionPattern, suggestionPattern.key == .at else { return }
+        applyUpdate(model.insertAtRoomMentionAtSuggestion(suggestionPattern))
+        hasPendingFormats = true
+    }
 
     /// Set a command with `Slash` pattern.
     ///

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -254,8 +254,13 @@ public extension WysiwygComposerViewModel {
     
     /// Sets the @room mention at the suggestion position
     func setAtRoomMention() {
-        guard let suggestionPattern, suggestionPattern.key == .at else { return }
-        applyUpdate(model.insertAtRoomMentionAtSuggestion(suggestionPattern))
+        let update: ComposerUpdate
+        if let suggestionPattern, suggestionPattern.key == .at {
+            update = model.insertAtRoomMentionAtSuggestion(suggestionPattern)
+        } else {
+            update = model.insertAtRoomMention()
+        }
+        applyUpdate(update)
         hasPendingFormats = true
     }
 

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Suggestions.swift
@@ -58,6 +58,17 @@ extension WysiwygComposerViewModelTests {
             """
         )
     }
+    
+    func testAtRoomSuggestionCanBeUsed() {
+        _ = viewModel.replaceText(range: .zero, replacementText: "@ro")
+        viewModel.setAtRoomMention()
+        XCTAssertEqual(
+            viewModel.content.html,
+            """
+            @room\u{00A0}
+            """
+        )
+    }
 
     func testAtMentionWithNoSuggestion() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
@@ -72,6 +83,21 @@ extension WysiwygComposerViewModelTests {
             """
         )
     }
+    
+    func testAtRoomMentionWithNoSuggestion() {
+        _ = viewModel.replaceText(range: .zero, replacementText: "Text")
+        viewModel.select(range: .init(location: 0, length: 4))
+        viewModel.setAtRoomMention()
+        // Text is not removed, and the
+        // mention is added after the text
+        XCTAssertEqual(
+            viewModel.content.html,
+            """
+            Text@room\u{00A0}
+            """
+        )
+    }
+    
 
     func testAtMentionWithNoSuggestionAtLeading() {
         _ = viewModel.replaceText(range: .zero, replacementText: "Text")
@@ -82,6 +108,19 @@ extension WysiwygComposerViewModelTests {
             viewModel.content.html,
             """
             <a href="https://matrix.to/#/@alice:matrix.org">Alice</a>Text
+            """
+        )
+    }
+    
+    func testAtRoomMentionWithNoSuggestionAtLeading() {
+        _ = viewModel.replaceText(range: .zero, replacementText: "Text")
+        viewModel.select(range: .init(location: 0, length: 0))
+        viewModel.setAtRoomMention()
+        // Text is not removed, and the mention is added before the text
+        XCTAssertEqual(
+            viewModel.content.html,
+            """
+            @roomText
             """
         )
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/WysiwygComposerTests+Suggestions.swift
@@ -75,6 +75,40 @@ extension WysiwygComposerTests {
             )
             .assertSelection(start: 8, end: 8)
     }
+    
+    func testSuggestionForAtRoomPattern() {
+        let model = ComposerModelWrapper()
+        let update = model.replaceText(newText: "@roo")
+
+        guard case .suggestion(suggestionPattern: let suggestionPattern) = update.menuAction() else {
+            XCTFail("No user suggestion found")
+            return
+        }
+
+        model
+            .action {
+                $0.insertAtRoomMentionAtSuggestion(suggestionPattern)
+            }
+            .assertHtml("<a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a> ")
+            .assertSelection(start: 2, end: 2)
+    }
+    
+    func testForNonLeadingSuggestionForAtRoomPattern() {
+        let model = ComposerModelWrapper()
+        let update = model.replaceText(newText: "Hello @roo")
+
+        guard case .suggestion(suggestionPattern: let suggestionPattern) = update.menuAction() else {
+            XCTFail("No user suggestion found")
+            return
+        }
+
+        model
+            .action {
+                $0.insertAtRoomMentionAtSuggestion(suggestionPattern)
+            }
+            .assertHtml("Hello <a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a> ")
+            .assertSelection(start: 8, end: 8)
+    }
 
     func testSuggestionForHashPattern() {
         let model = ComposerModelWrapper()


### PR DESCRIPTION
This was missing a function exposure from the view model, in this way now we have an easy and simple way to set at the current suggestion pattern the @room mention on iOS