### PR TITLE
Exclude DerivedData from linting

### DIFF
--- a/platforms/ios/example/.swiftlint.yml
+++ b/platforms/ios/example/.swiftlint.yml
@@ -1,3 +1,7 @@
+# paths to ignore during linting. Takes precedence over `included`.
+excluded:
+  - DerivedData
+
 # rule identifiers to exclude from running
 disabled_rules:
   - todo


### PR DESCRIPTION
Should fix this kind of failure (when Xcode / CL tools use local `DerivedData` folder): https://github.com/matrix-org/matrix-rich-text-editor/actions/runs/6584730655/job/17890374579?pr=850