### PR TITLE
[iOS] Add "shouldReplaceText" API 

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -64,6 +64,11 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
         }
     }
 
+    /// Whether the composer should take any input in.
+    /// When set to `false`, the underlying text won't change.
+    /// Otherwise `replaceText(range:,replacementText:)` is evaluated.
+    public var shouldReplaceText = true
+
     /// Published value for the composer plain text mode.
     @Published public var plainTextMode = false {
         didSet {
@@ -289,6 +294,10 @@ public extension WysiwygComposerViewModel {
     }
 
     func replaceText(range: NSRange, replacementText: String) -> Bool {
+        guard shouldReplaceText else {
+            return false
+        }
+
         guard !plainTextMode else {
             return true
         }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -64,7 +64,7 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
         }
     }
 
-    /// Whether the composer should take any input in.
+    /// Whether the composer should take any keyboard input.
     /// When set to `false`, the underlying text won't change.
     /// Otherwise `replaceText(range:,replacementText:)` is evaluated.
     public var shouldReplaceText = true

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -65,8 +65,7 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
     }
 
     /// Whether the composer should take any keyboard input.
-    /// When set to `false`, the underlying text won't change.
-    /// Otherwise `replaceText(range:,replacementText:)` is evaluated.
+    /// When set to `false`, `replaceText(range:replacementText:)` returns `false` as well.
     public var shouldReplaceText = true
 
     /// Published value for the composer plain text mode.

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -27,7 +27,7 @@ public protocol WysiwygComposerViewModelProtocol: AnyObject {
     /// Update the composer compressed required height if it has changed.
     func updateCompressedHeightIfNeeded()
 
-    /// Whether the composer should take any input in.
+    /// Whether the composer should take any keyboard input.
     /// When set to `false`, the underlying text won't change.
     /// Otherwise `replaceText(range:,replacementText:)` is evaluated.
     var shouldReplaceText: Bool { get set }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -27,6 +27,11 @@ public protocol WysiwygComposerViewModelProtocol: AnyObject {
     /// Update the composer compressed required height if it has changed.
     func updateCompressedHeightIfNeeded()
 
+    /// Whether the composer should take any input in.
+    /// When set to `false`, the underlying text won't change.
+    /// Otherwise `replaceText(range:,replacementText:)` is evaluated.
+    var shouldReplaceText: Bool { get set }
+
     /// Replace text in the model.
     ///
     /// - Parameters:

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModelProtocol.swift
@@ -27,11 +27,6 @@ public protocol WysiwygComposerViewModelProtocol: AnyObject {
     /// Update the composer compressed required height if it has changed.
     func updateCompressedHeightIfNeeded()
 
-    /// Whether the composer should take any keyboard input.
-    /// When set to `false`, the underlying text won't change.
-    /// Otherwise `replaceText(range:,replacementText:)` is evaluated.
-    var shouldReplaceText: Bool { get set }
-
     /// Replace text in the model.
     ///
     /// - Parameters:

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -19,14 +19,11 @@ import Combine
 import XCTest
 
 final class WysiwygComposerViewModelTests: XCTestCase {
-    let viewModel = WysiwygComposerViewModel()
+    var viewModel: WysiwygComposerViewModel!
 
     override func setUpWithError() throws {
+        viewModel = WysiwygComposerViewModel()
         viewModel.clearContent()
-    }
-
-    override func tearDownWithError() throws {
-        viewModel.plainTextMode = false
     }
 
     func testIsContentEmpty() throws {
@@ -49,6 +46,13 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         let shouldChange = viewModel.replaceText(range: .zero,
                                                  replacementText: "A")
         XCTAssertTrue(shouldChange)
+    }
+
+    func testSimpleTextInputIsNotAccepted() throws {
+        viewModel.shouldReplaceText = false
+        let shouldChange = viewModel.replaceText(range: .zero,
+                                                 replacementText: "A")
+        XCTAssertFalse(shouldChange)
     }
 
     func testNewlineIsNotAccepted() throws {


### PR DESCRIPTION
Sometimes it's useful for the client to ignore the input from the keyboard while keeping the focus on the text view.