### PR TITLE
Android: second iteration for mentions

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -66,8 +66,6 @@ class MainActivity : ComponentActivity() {
 
                 val state = rememberRichTextEditorState(initialFocus = true)
 
-                Timber.d("Mentions state: ${state.mentionsState}")
-
                 LaunchedEffect(state.menuAction) {
                     processMenuAction(state.menuAction, roomMemberSuggestions)
                 }
@@ -130,7 +128,7 @@ class MainActivity : ComponentActivity() {
                         SuggestionView(
                             modifier = Modifier.heightIn(max = 320.dp),
                             roomMemberSuggestions = roomMemberSuggestions,
-                            onReplaceSuggestionText = { text ->
+                            onReplaceSuggestion = { text ->
                                 coroutineScope.launch {
                                     state.replaceSuggestion(text)
                                 }

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -66,6 +66,8 @@ class MainActivity : ComponentActivity() {
 
                 val state = rememberRichTextEditorState(initialFocus = true)
 
+                Timber.d("Mentions state: ${state.mentionsState}")
+
                 LaunchedEffect(state.menuAction) {
                     processMenuAction(state.menuAction, roomMemberSuggestions)
                 }
@@ -128,9 +130,14 @@ class MainActivity : ComponentActivity() {
                         SuggestionView(
                             modifier = Modifier.heightIn(max = 320.dp),
                             roomMemberSuggestions = roomMemberSuggestions,
-                            onReplaceSuggestionText = {
+                            onReplaceSuggestionText = { text ->
                                 coroutineScope.launch {
-                                    state.replaceSuggestion(it)
+                                    state.replaceSuggestion(text)
+                                }
+                            },
+                            onInsertAtRoomMentionAtSuggestion = {
+                                coroutineScope.launch {
+                                    state.insertAtRoomMentionAtSuggestion()
                                 }
                             },
                             onInsertMentionAtSuggestion = { text, link ->

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/SuggestionsView.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/SuggestionsView.kt
@@ -20,7 +20,7 @@ import uniffi.wysiwyg_composer.PatternKey
 fun SuggestionView(
     modifier: Modifier = Modifier,
     roomMemberSuggestions: SnapshotStateList<Mention>,
-    onReplaceSuggestionText: (String) -> Unit,
+    onReplaceSuggestion: (String) -> Unit,
     onInsertMentionAtSuggestion: (text: String, link: String) -> Unit,
     onInsertAtRoomMentionAtSuggestion: () -> Unit,
 ) {
@@ -38,8 +38,8 @@ fun SuggestionView(
                                 Mention.NotifyEveryone -> {
                                     onInsertAtRoomMentionAtSuggestion()
                                 }
-                                is Mention.Command -> {
-                                    onReplaceSuggestionText(item.text)
+                                is Mention.SlashCommand -> {
+                                    onReplaceSuggestion(item.text)
                                 }
                                 is Mention.Room -> {
                                     // TODO Handle room mention
@@ -75,12 +75,12 @@ private fun processSuggestion(suggestion: MenuAction.Suggestion, roomMemberSugge
     val text = suggestion.suggestionPattern.text
     val people = listOf("alice", "bob", "carol", "dan").map(Mention::User)
     val rooms = listOf("matrix", "element").map(Mention::Room)
-    val commands = listOf("leave", "shrug").map(Mention::Command)
+    val slashCommands = listOf("leave", "shrug").map(Mention::SlashCommand)
     val everyone = Mention.NotifyEveryone
     val names = when (suggestion.suggestionPattern.key) {
         PatternKey.AT -> people + everyone
         PatternKey.HASH -> rooms
-        PatternKey.SLASH -> commands
+        PatternKey.SLASH -> slashCommands
     }
     val suggestions = names
         .filter { it.display.contains(text) }

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/SuggestionsView.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/SuggestionsView.kt
@@ -22,6 +22,7 @@ fun SuggestionView(
     roomMemberSuggestions: SnapshotStateList<Mention>,
     onReplaceSuggestionText: (String) -> Unit,
     onInsertMentionAtSuggestion: (text: String, link: String) -> Unit,
+    onInsertAtRoomMentionAtSuggestion: () -> Unit,
 ) {
     LazyColumn(
         modifier = modifier.fillMaxWidth()
@@ -33,10 +34,19 @@ fun SuggestionView(
                     modifier = Modifier.fillMaxWidth()
                         .padding(10.dp)
                         .clickable {
-                            if (item == Mention.NotifyEveryone) {
-                                onReplaceSuggestionText(item.text)
-                            } else {
-                                onInsertMentionAtSuggestion(item.text, item.link)
+                            when (item) {
+                                Mention.NotifyEveryone -> {
+                                    onInsertAtRoomMentionAtSuggestion()
+                                }
+                                is Mention.Command -> {
+                                    onReplaceSuggestionText(item.text)
+                                }
+                                is Mention.Room -> {
+                                    // TODO Handle room mention
+                                }
+                                else -> {
+                                    onInsertMentionAtSuggestion(item.text, item.link)
+                                }
                             }
                         })
                 Divider(modifier = Modifier.fillMaxWidth())
@@ -65,12 +75,12 @@ private fun processSuggestion(suggestion: MenuAction.Suggestion, roomMemberSugge
     val text = suggestion.suggestionPattern.text
     val people = listOf("alice", "bob", "carol", "dan").map(Mention::User)
     val rooms = listOf("matrix", "element").map(Mention::Room)
+    val commands = listOf("leave", "shrug").map(Mention::Command)
     val everyone = Mention.NotifyEveryone
     val names = when (suggestion.suggestionPattern.key) {
         PatternKey.AT -> people + everyone
         PatternKey.HASH -> rooms
-        PatternKey.SLASH ->
-            emptyList() // TODO
+        PatternKey.SLASH -> commands
     }
     val suggestions = names
         .filter { it.display.contains(text) }

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/matrix/Mention.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/matrix/Mention.kt
@@ -23,7 +23,7 @@ sealed class Mention(
         override val key: String = "@"
     }
 
-    class Command(
+    class SlashCommand(
         display: String
     ): Mention(display) {
         override val key: String = "/"

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/matrix/Mention.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/matrix/Mention.kt
@@ -23,6 +23,12 @@ sealed class Mention(
         override val key: String = "@"
     }
 
+    class Command(
+        display: String
+    ): Mention(display) {
+        override val key: String = "/"
+    }
+
     object NotifyEveryone: Mention("room") {
         override val key: String = "@"
     }

--- a/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
+++ b/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
@@ -176,7 +176,6 @@ class RichTextEditor : LinearLayout {
                                 item.link, item.text
                             )
                         }
-                        Timber.d("Mentions state: ${binding.richTextEditText.getMentionsState()}}")
                     }
             }
         }

--- a/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
+++ b/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
@@ -16,6 +16,7 @@ import io.element.android.wysiwyg.poc.matrix.MatrixMentionMentionDisplayHandler
 import io.element.android.wysiwyg.poc.matrix.Mention
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.models.LinkAction
+import timber.log.Timber
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
 import uniffi.wysiwyg_composer.MenuAction
@@ -168,13 +169,14 @@ class RichTextEditor : LinearLayout {
                 binding.menuSuggestion.onItemClickListener =
                     OnItemClickListener { _, _, position, _ ->
                         val item = suggestions[position]
-                        if(item == Mention.NotifyEveryone) {
-                            binding.richTextEditText.replaceTextSuggestion(item.text)
+                        if (item == Mention.NotifyEveryone) {
+                            binding.richTextEditText.insertAtRoomMentionAtSuggestion()
                         } else {
                             binding.richTextEditText.insertMentionAtSuggestion(
                                 item.link, item.text
                             )
                         }
+                        Timber.d("Mentions state: ${binding.richTextEditText.getMentionsState()}}")
                     }
             }
         }

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorActionsTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorActionsTest.kt
@@ -5,6 +5,7 @@ import io.element.android.wysiwyg.compose.testutils.ComposerActions
 import io.element.android.wysiwyg.compose.testutils.StateFactory
 import io.element.android.wysiwyg.compose.testutils.copy
 import io.element.android.wysiwyg.compose.testutils.showContent
+import io.element.android.wysiwyg.utils.NBSP
 import io.element.android.wysiwyg.view.models.InlineFormat
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -12,6 +13,7 @@ import org.junit.Rule
 import org.junit.Test
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
+import uniffi.wysiwyg_composer.MentionsState
 
 class RichTextEditorActionsTest {
     @get:Rule
@@ -302,6 +304,67 @@ class RichTextEditorActionsTest {
                 )
             ), state.actions)
 
+    }
+
+    @Test
+    fun testReplaceSuggestionText() = runTest {
+        val state = StateFactory.createState()
+
+        composeTestRule.showContent(state)
+
+        state.setHtml("/")
+        composeTestRule.awaitIdle()
+
+        state.replaceSuggestion("/shrug")
+        composeTestRule.awaitIdle()
+
+        assertEquals("/shrug$NBSP", state.messageHtml)
+    }
+
+    @Test
+    fun testInsertMentionAtSuggestion() = runTest {
+        val state = StateFactory.createState()
+
+        composeTestRule.showContent(state)
+
+        state.setHtml("@")
+        composeTestRule.awaitIdle()
+
+        state.insertMentionAtSuggestion("@jonny", "https://matrix.to/#/@jonny:matrix.org")
+        composeTestRule.awaitIdle()
+
+        assertEquals(
+            MentionsState(
+                userIds = listOf("@jonny:matrix.org"),
+                roomIds = emptyList(),
+                roomAliases = emptyList(),
+                hasAtRoomMention = false,
+            ),
+            state.mentionsState
+        )
+    }
+
+    @Test
+    fun testInsertAtRoomMentionAtSuggestion() = runTest {
+        val state = StateFactory.createState()
+
+        composeTestRule.showContent(state)
+
+        state.setHtml("@")
+        composeTestRule.awaitIdle()
+
+        state.insertAtRoomMentionAtSuggestion()
+        composeTestRule.awaitIdle()
+
+        assertEquals(
+            MentionsState(
+                userIds = emptyList(),
+                roomIds = emptyList(),
+                roomAliases = emptyList(),
+                hasAtRoomMention = true
+            ),
+            state.mentionsState
+        )
     }
 
 }

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/testutils/ComposeTestRuleExt.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/testutils/ComposeTestRuleExt.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import io.element.android.wysiwyg.compose.RichTextEditor
 import io.element.android.wysiwyg.compose.RichTextEditorState
+import io.element.android.wysiwyg.display.TextDisplay
 
 fun ComposeContentTestRule.showContent(
     state: RichTextEditorState,

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -128,6 +128,10 @@ private fun RealEditor(
                     onFocusChangeListener = View.OnFocusChangeListener { view, hasFocus ->
                         state.onFocusChanged(view.hashCode(), hasFocus)
                     }
+
+                    mentionsStateChangedListener = EditorEditText.OnMentionsStateChangedListener { mentionsState ->
+                        state.mentionsState = mentionsState
+                    }
                 }
 
                 applyDefaultStyle()
@@ -156,6 +160,7 @@ private fun RealEditor(
                                 is ViewAction.InsertLink -> insertLink(it.url, it.text)
                                 is ViewAction.ReplaceSuggestionText -> replaceTextSuggestion(it.text)
                                 is ViewAction.InsertMentionAtSuggestion -> insertMentionAtSuggestion(url = it.url, text = it.text)
+                                is ViewAction.InsertAtRoomMentionAtSuggestion -> insertAtRoomMentionAtSuggestion()
                             }
                         }
                     }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -22,7 +22,6 @@ import io.element.android.wysiwyg.display.TextDisplay
 import io.element.android.wysiwyg.utils.RustErrorCollector
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 
 /**
@@ -174,7 +173,6 @@ private fun RealEditor(
         // more than it's strictly necessary. To avoid this, we can use a `remember` block to cache the `update` lambda, and only update it when needed.
         update = remember(style, typeface, mentionDisplayHandler, onError) {
             { view ->
-                Timber.d("RealEditor's update block called, recomposing!")
                 view.applyStyleInCompose(style)
                 view.typeface = typeface
                 view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.parcelize.Parcelize
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
+import uniffi.wysiwyg_composer.MentionsState
 import uniffi.wysiwyg_composer.MenuAction
 
 /**
@@ -218,6 +219,13 @@ class RichTextEditorState(
     }
 
     /**
+     * Inserts an `@room` mention at the current mention suggestion.
+     */
+    suspend fun insertAtRoomMentionAtSuggestion() {
+        _viewActions.emit(ViewAction.InsertAtRoomMentionAtSuggestion)
+    }
+
+    /**
      * The number of lines displayed in the editor.
      */
     var lineCount: Int by mutableIntStateOf(initialLineCount)
@@ -225,6 +233,11 @@ class RichTextEditorState(
 
     var linkAction: LinkAction? by mutableStateOf(null)
         internal set
+
+    /**
+     * The current [MentionsState] of the editor.
+     */
+    var mentionsState: MentionsState? by mutableStateOf(null)
 
 }
 

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/FakeViewConnection.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/FakeViewConnection.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.launch
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
-import uniffi.wysiwyg_composer.MenuAction
 
 /**
  * Fake behaviour for use in preview and test environments.
@@ -52,12 +51,17 @@ internal class FakeViewActionCollector(
             ViewAction.Undo -> undo()
             ViewAction.Unindent -> unindent()
             is ViewAction.ReplaceSuggestionText -> {
-                state.messageHtml = state.messageHtml.replaceLast(Regex("(@\\w+)"), value.text)
-                state.messageMarkdown = state.messageMarkdown.replaceLast(Regex("(@\\w+)"), value.text)
+                state.messageHtml = state.messageHtml.replaceLast(Regex("(/\\w+)"), value.text)
+                state.messageMarkdown = state.messageMarkdown.replaceLast(Regex("(/\\w+)"), value.text)
             }
             is ViewAction.InsertMentionAtSuggestion -> {
                 state.messageHtml = state.messageHtml.replaceLast(Regex("(@\\w+)"), "<a href='${value.url}'>${value.text}</a>")
                 state.messageMarkdown = state.messageMarkdown.replaceLast(Regex("(@\\w+)"), "[${value.text}](${value.url})")
+            }
+            is ViewAction.InsertAtRoomMentionAtSuggestion -> {
+                val htmlReplacement = "<a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a>"
+                state.messageHtml = state.messageHtml.replaceLast(Regex("(@\\w+)"), htmlReplacement)
+                state.messageMarkdown = state.messageMarkdown.replaceLast(Regex("(@\\w+)"), "@room")
             }
         }
     }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/ViewAction.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/ViewAction.kt
@@ -18,4 +18,5 @@ internal sealed class ViewAction {
     data class InsertLink(val url: String, val text: String): ViewAction()
     data class ReplaceSuggestionText(val text: String): ViewAction()
     data class InsertMentionAtSuggestion(val text: String, val url: String): ViewAction()
+    data object InsertAtRoomMentionAtSuggestion: ViewAction()
 }

--- a/platforms/android/library-compose/src/test/java/io/element/android/wysiwyg/compose/FakeRichTextEditorStateTest.kt
+++ b/platforms/android/library-compose/src/test/java/io/element/android/wysiwyg/compose/FakeRichTextEditorStateTest.kt
@@ -266,13 +266,27 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `replaceSuggestion updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
+            val state = rememberRichTextEditorState(initialHtml = "/shr", initialSelection = 3 to 3, fake = true)
+            remember(state.messageHtml, state.messageMarkdown) { state }
+        }.test {
+            val initialState = awaitItem()
+            initialState.replaceSuggestion("/shrug")
+            val nextState = awaitItem()
+            assertThat(nextState.messageHtml, equalTo("/shrug"))
+        }
+    }
+
+    @Test
+    fun `insertAtRoomMentionAtSuggestion updates the state`() = runTest {
+        val htmlReplacement = "<a data-mention-type=\"at-room\" href=\"#\" contenteditable=\"false\">@room</a>"
+        moleculeFlow(RecompositionMode.Immediate) {
             val state = rememberRichTextEditorState(initialHtml = "@ro", initialSelection = 2 to 2, fake = true)
             remember(state.messageHtml, state.messageMarkdown) { state }
         }.test {
             val initialState = awaitItem()
-            initialState.replaceSuggestion("@room")
+            initialState.insertAtRoomMentionAtSuggestion()
             val nextState = awaitItem()
-            assertThat(nextState.messageHtml, equalTo("@room"))
+            assertThat(nextState.messageHtml, equalTo(htmlReplacement))
         }
     }
 

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
@@ -287,7 +287,7 @@ class EditorEditTextInputTests {
     }
 
     @Test
-    fun testSettingLinkSuggestion() {
+    fun testSettingUserMentionSuggestion() {
         onView(withId(R.id.rich_text_edit_text))
             .perform(ImeActions.setComposingText("@jonny"))
             .perform(EditorActions.setMentionDisplayHandler(TestMentionDisplayHandler(TextDisplay.Pill)))
@@ -298,7 +298,7 @@ class EditorEditTextInputTests {
     }
 
     @Test
-    fun testSettingMultipleLinkSuggestionWithCustomReplacements() {
+    fun testSettingMultipleUserMentionSuggestionsWithCustomReplacements() {
         onView(withId(R.id.rich_text_edit_text))
             .perform(ImeActions.setComposingText("@jonny"))
             .perform(EditorActions.setMentionDisplayHandler(
@@ -314,6 +314,17 @@ class EditorEditTextInputTests {
             .perform(EditorActions.insertMentionAtSuggestion("jonny", "https://matrix.to/#/@test:matrix.org"))
             .check(matches(TextViewMatcher {
                 it.editableText.getSpans<ReplacementSpan>().count() == 2
+            }))
+    }
+
+    @Test
+    fun testSettingAtRoomMentionAtSuggestion() {
+        onView(withId(R.id.rich_text_edit_text))
+            .perform(ImeActions.setComposingText("@room"))
+            .perform(EditorActions.setMentionDisplayHandler(TestMentionDisplayHandler(TextDisplay.Pill)))
+            .perform(EditorActions.insertAtRoomMentionAtSuggestion())
+            .check(matches(TextViewMatcher {
+                it.editableText.getSpans<PillSpan>().isNotEmpty()
             }))
     }
 

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/EditorActions.kt
@@ -94,6 +94,17 @@ object Editor {
         }
     }
 
+    class InsertAtRoomMentionAtSuggestion() : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Set @room mention at suggestion"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val editor = view as? EditorEditText ?: return
+            editor.insertAtRoomMentionAtSuggestion()
+        }
+    }
+
     class SetMentionDisplayHandler(
         private val mentionDisplayHandler: MentionDisplayHandler,
     ) : ViewAction {
@@ -234,6 +245,7 @@ object EditorActions {
     fun insertLink(text: String, url: String) = Editor.InsertLink(text, url)
     fun removeLink() = Editor.RemoveLink
     fun insertMentionAtSuggestion(text: String, url: String) = Editor.InsertMentionAtSuggestion(text, url)
+    fun insertAtRoomMentionAtSuggestion() = Editor.InsertAtRoomMentionAtSuggestion()
     fun setMentionDisplayHandler(mentionDisplayHandler: MentionDisplayHandler) = Editor.SetMentionDisplayHandler(mentionDisplayHandler)
     fun replaceTextSuggestion(text: String) = Editor.ReplaceTextSuggestion(text)
     fun toggleList(ordered: Boolean) = Editor.ToggleList(ordered)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -117,6 +117,10 @@ class EditorEditText : AppCompatEditText {
         fun onLinkActionChanged(linkAction: LinkAction?)
     }
 
+    fun interface OnMentionsStateChangedListener {
+        fun onMentionsStateChanged(mentionsState: MentionsState?)
+    }
+
     var selectionChangeListener: OnSelectionChangeListener? = null
     var actionStatesChangedListener: OnActionStatesChangedListener? = null
         set(value) {
@@ -144,6 +148,18 @@ class EditorEditText : AppCompatEditText {
 
             viewModel.linkActionCallback = { linkAction ->
                 value?.onLinkActionChanged(linkAction)
+            }
+        }
+
+    /**
+     * Set the [MentionsState] change listener to be notified when the state of mentions in the composer changes.
+     */
+    var mentionsStateChangedListener: OnMentionsStateChangedListener? = null
+        set(value) {
+            field = value
+
+            viewModel.setMentionsStateCallback { mentionsState ->
+                value?.onMentionsStateChanged(mentionsState)
             }
         }
 
@@ -475,6 +491,20 @@ class EditorEditText : AppCompatEditText {
     }
 
     /**
+     * Set a mention link that applies to the current suggestion range
+     *
+     * @param url The url of the new link
+     * @param text The text to insert into the current suggestion range
+     */
+    fun insertAtRoomMentionAtSuggestion() {
+        val result = viewModel.processInput(
+            EditorInputAction.InsertAtRoomMentionAtSuggestion
+        ) ?: return
+        setTextFromComposerUpdate(result.text)
+        setSelectionFromComposerUpdate(result.selection.last)
+    }
+
+    /**
      * Replace text in the current suggestion range
      *
      * @param text The text to insert into the current suggestion range
@@ -487,6 +517,13 @@ class EditorEditText : AppCompatEditText {
         ) ?: return
         setTextFromComposerUpdate(result.text)
         setSelectionFromComposerUpdate(result.selection.last)
+    }
+
+    /**
+     * Get the current [MentionsState] of the editor.
+     */
+    fun getMentionsState(): MentionsState? {
+        return viewModel.getMentionsState()
     }
 
     @VisibleForTesting

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorInputAction.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorInputAction.kt
@@ -96,6 +96,11 @@ internal sealed interface EditorInputAction {
     ): EditorInputAction
 
     /**
+     * Replaces the suggesetion with an `@room` mention
+     */
+    object InsertAtRoomMentionAtSuggestion : EditorInputAction
+
+    /**
      * Creates a list, [ordered] if true or unordered in the current selection.
      */
     data class ToggleList(val ordered: Boolean): EditorInputAction

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/mocks/MockComposer.kt
@@ -7,6 +7,7 @@ import uniffi.wysiwyg_composer.ComposerModelInterface
 import uniffi.wysiwyg_composer.ComposerState
 import uniffi.wysiwyg_composer.ComposerUpdate
 import uniffi.wysiwyg_composer.LinkAction
+import uniffi.wysiwyg_composer.MentionsState
 
 class MockComposer {
     val instance = mockk<ComposerModelInterface>()
@@ -16,6 +17,7 @@ class MockComposer {
         givenActionStates()
         givenDummyToExampleFormat()
         givenGetContentAsPlainText()
+        givenMentionsState(MentionsState(userIds = emptyList(), roomIds = emptyList(), roomAliases = emptyList(), hasAtRoomMention = false))
     }
 
     fun givenCurrentDomState(
@@ -93,6 +95,10 @@ class MockComposer {
         update: ComposerUpdate = MockComposerUpdateFactory.create(),
     ) = every { instance.insertMentionAtSuggestion(url = link, attributes = emptyList(), text = name, suggestion = any()) } returns update
 
+    fun givenInsertAtMentionFromSuggestionResult(
+        update: ComposerUpdate = MockComposerUpdateFactory.create(),
+    ) = every { instance.insertAtRoomMentionAtSuggestion(suggestion = any()) } returns update
+
     fun givenReplaceAllHtmlResult(
         html: String,
         update: ComposerUpdate = MockComposerUpdateFactory.create(),
@@ -144,4 +150,6 @@ class MockComposer {
     ) = every { instance.getContentAsPlainText() } returns plainText
 
     fun givenDummyToExampleFormat() = every { instance.toExampleFormat() } returns ""
+
+    fun givenMentionsState(mentionsState: MentionsState) = every { instance.getMentionsState() } returns mentionsState
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/viewmodel/EditorViewModelTest.kt
@@ -313,6 +313,24 @@ internal class EditorViewModelTest {
     }
 
     @Test
+    fun `when process insert @room mention at suggestion action, it returns a text update`() {
+        val suggestionPattern =
+            SuggestionPattern(PatternKey.AT, text = "room", 0.toUInt(), 4.toUInt())
+        composer.givenReplaceTextResult(MockComposerUpdateFactory.create(
+            menuAction = MenuAction.Suggestion(suggestionPattern)
+        ))
+        viewModel.processInput(EditorInputAction.ReplaceText("@room"))
+
+        composer.givenInsertAtMentionFromSuggestionResult(composerStateUpdate)
+        val result = viewModel.processInput(EditorInputAction.InsertAtRoomMentionAtSuggestion)
+
+        verify {
+            composer.instance.insertAtRoomMentionAtSuggestion(suggestion = suggestionPattern)
+        }
+        assertThat(result, equalTo(replaceTextResult))
+    }
+
+    @Test
     fun `when process replace all html action, it returns a text update`() {
         composer.givenReplaceAllHtmlResult("new html", composerStateUpdate)
 


### PR DESCRIPTION
- Add `insertAtRoomMentionAtSuggestion` method to be able to insert properly formatted `@room` mentions.
- Add a way to track `MentionsState`.
- Add better examples for `replaceSuggestionText`.