### PR TITLE
[Android] Make some spans clickable (pills, links) in TextView

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -93,7 +93,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background
                 ) {
                     Column(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.SpaceBetween
                     ) {
                         Surface(

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.element.wysiwyg.compose
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.BorderStroke
@@ -122,6 +123,9 @@ class MainActivity : ComponentActivity() {
                                 .padding(16.dp),
                             resolveMentionDisplay = { _,_ -> TextDisplay.Pill },
                             resolveRoomMentionDisplay = { TextDisplay.Pill },
+                            onLinkClickedListener = { url ->
+                                Toast.makeText(this@MainActivity, "Clicked: $url", Toast.LENGTH_SHORT).show()
+                            }
                         )
 
                         Spacer(modifier = Modifier.weight(1f))

--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/SuggestionsView.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/SuggestionsView.kt
@@ -41,9 +41,6 @@ fun SuggestionView(
                                 is Mention.SlashCommand -> {
                                     onReplaceSuggestion(item.text)
                                 }
-                                is Mention.Room -> {
-                                    // TODO Handle room mention
-                                }
                                 else -> {
                                     onInsertMentionAtSuggestion(item.text, item.link)
                                 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
@@ -32,6 +32,7 @@ fun EditorStyledText(
     modifier: Modifier = Modifier,
     resolveMentionDisplay: (text: String, url: String) -> TextDisplay = RichTextEditorDefaults.MentionDisplay,
     resolveRoomMentionDisplay: () -> TextDisplay = RichTextEditorDefaults.RoomMentionDisplay,
+    onLinkClickedListener: ((String) -> Unit) = {},
     style: RichTextEditorStyle = RichTextEditorDefaults.style(),
 ) {
     val typeface by style.text.rememberTypeface()
@@ -54,7 +55,7 @@ fun EditorStyledText(
         // The `update` lambda is called when the view is first created, and then again whenever the actual `update` lambda changes. That is, it's replaced with
         // a new lambda capturing different variables from the surrounding scope. However, there seems to be an issue that causes the `update` lambda to change
         // more than it's strictly necessary. To avoid this, we can use a `remember` block to cache the `update` lambda, and only update it when needed.
-        update = remember(style, typeface, mentionDisplayHandler, text) {
+        update = remember(style, typeface, mentionDisplayHandler, text, onLinkClickedListener) {
             { view ->
                 view.applyStyleInCompose(style)
                 view.typeface = typeface
@@ -64,6 +65,7 @@ fun EditorStyledText(
                 } else {
                     view.setHtml(text.toString())
                 }
+                view.onLinkClickedListener = onLinkClickedListener
             }
         }
     )

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
@@ -1,6 +1,13 @@
 package io.element.android.wysiwyg
 
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.text.style.ReplacementSpan
+import android.widget.TextView
+import androidx.core.text.buildSpannedString
+import androidx.core.text.inSpans
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -8,6 +15,10 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import io.element.android.wysiwyg.test.R
 import io.element.android.wysiwyg.test.utils.TestActivity
 import io.element.android.wysiwyg.test.utils.TextViewActions
+import io.element.android.wysiwyg.view.spans.CustomMentionSpan
+import io.element.android.wysiwyg.view.spans.LinkSpan
+import io.element.android.wysiwyg.view.spans.PillSpan
+import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 
@@ -22,4 +33,80 @@ internal class EditorStyledTextViewTest {
             .perform(TextViewActions.setText("Hello, world"))
             .check(matches(withText("Hello, world")))
     }
+
+    @Test
+    fun testLinkClicks() {
+        var pass = false
+        scenarioRule.scenario.onActivity {
+            it.findViewById<EditorStyledTextView>(R.id.styledTextView).apply {
+                val spanned = buildSpannedString {
+                    inSpans(LinkSpan("")) {
+                        append("Hello, world")
+                    }
+                }
+                setText(spanned, TextView.BufferType.SPANNABLE)
+                onLinkClickedListener = {
+                    pass = true
+                }
+            }
+        }
+        onView(ViewMatchers.withId(R.id.styledTextView))
+            .check(matches(withText("Hello, world")))
+            .perform(ViewActions.click())
+
+        Assert.assertTrue(pass)
+    }
+
+    @Test
+    fun testPillSpanClicks() {
+        var pass = false
+        scenarioRule.scenario.onActivity {
+            it.findViewById<EditorStyledTextView>(R.id.styledTextView).apply {
+                val spanned = buildSpannedString {
+                    inSpans(PillSpan(backgroundColor = 0, url = "")) {
+                        append("Hello, world")
+                    }
+                }
+                setText(spanned, TextView.BufferType.SPANNABLE)
+                onLinkClickedListener = {
+                    pass = true
+                }
+            }
+        }
+        onView(ViewMatchers.withId(R.id.styledTextView))
+            .check(matches(withText("Hello, world")))
+            .perform(ViewActions.click())
+
+        Assert.assertTrue(pass)
+    }
+
+    @Test
+    fun testCustomMentionSpanClicks() {
+        var pass = false
+        scenarioRule.scenario.onActivity {
+            it.findViewById<EditorStyledTextView>(R.id.styledTextView).apply {
+                val spanned = buildSpannedString {
+                    inSpans(CustomMentionSpan(DummyReplacementSpan, url = "")) {
+                        append("Hello, world")
+                    }
+                }
+                setText(spanned, TextView.BufferType.SPANNABLE)
+                onLinkClickedListener = {
+                    pass = true
+                }
+            }
+        }
+        onView(ViewMatchers.withId(R.id.styledTextView))
+            .check(matches(withText("Hello, world")))
+            .perform(ViewActions.click())
+
+        Assert.assertTrue(pass)
+    }
+}
+
+object DummyReplacementSpan : ReplacementSpan() {
+    override fun getSize(paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int = 1
+
+    override fun draw(canvas: Canvas, text: CharSequence?, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint)  = Unit
+
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -16,7 +16,7 @@ import io.element.android.wysiwyg.view.StyleConfig
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.spans.BlockSpan
 import io.element.android.wysiwyg.view.spans.CodeBlockSpan
-import io.element.android.wysiwyg.view.spans.CustomReplacementSpan
+import io.element.android.wysiwyg.view.spans.CustomMentionSpan
 import io.element.android.wysiwyg.view.spans.ExtraCharacterSpan
 import io.element.android.wysiwyg.view.spans.InlineCodeSpan
 import io.element.android.wysiwyg.view.spans.LinkSpan
@@ -352,7 +352,7 @@ internal class HtmlToSpansParser(
 
         when (textDisplay) {
             is TextDisplay.Custom -> {
-                val span = CustomReplacementSpan(textDisplay.customSpan)
+                val span = CustomMentionSpan(textDisplay.customSpan, url)
                 replacePlaceholderWithPendingSpan(
                     last.span, span, last.start, text.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
                 )
@@ -360,7 +360,7 @@ internal class HtmlToSpansParser(
 
             TextDisplay.Pill -> {
                 val pillBackground = styleConfig.pill.backgroundColor
-                val span = PillSpan(pillBackground)
+                val span = PillSpan(pillBackground, url)
                 replacePlaceholderWithPendingSpan(
                     last.span, span, last.start, text.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
                 )
@@ -510,7 +510,7 @@ internal class HtmlToSpansParser(
                 return@eachMatch
             }
             val span = when (display) {
-                is TextDisplay.Custom -> CustomReplacementSpan(display.customSpan)
+                is TextDisplay.Custom -> CustomMentionSpan(display.customSpan)
                 TextDisplay.Pill -> PillSpan(
                     styleConfig.pill.backgroundColor
                 )
@@ -544,7 +544,7 @@ internal class HtmlToSpansParser(
             // Links
             LinkSpan::class.java,
             PillSpan::class.java,
-            CustomReplacementSpan::class.java,
+            CustomMentionSpan::class.java,
 
             // Lists
             UnorderedListSpan::class.java,

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/CustomMentionSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/CustomMentionSpan.kt
@@ -10,8 +10,9 @@ import android.text.style.ReplacementSpan
  * It is used to allow reuse of the same underlying span across multiple ranges
  * of a spanned text.
  */
-internal class CustomReplacementSpan(
-    private val providedSpan: ReplacementSpan
+internal class CustomMentionSpan(
+    private val providedSpan: ReplacementSpan,
+    val url: String? = null,
 ) : ReplacementSpan() {
     override fun draw(
         canvas: Canvas,

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/PillSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/PillSpan.kt
@@ -10,6 +10,7 @@ import kotlin.math.roundToInt
 internal class PillSpan(
     @ColorInt
     val backgroundColor: Int,
+    val url: String? = null,
 ) : ReplacementSpan() {
     override fun getSize(
         paint: Paint,


### PR DESCRIPTION
- Add an associated `url` to `PillSpan` and `CustomReplacementSpan`.
- Rename `CustomReplacementSpan` to `CustomMentionSpan`.
- Override `EditorStyledTextView.onTouchEvent` to detect clicks in these clickable spans.
- Add `onLinkClickedListener` to get notified when they are clicked.