### PR TITLE
[Android] Add workarounds for ignoring state restoration and invalid line count

### DIFF
--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
@@ -35,10 +35,10 @@ class RichTextEditorStateTest {
                 Column {
                     if (!showAlt) {
                         Text("Main editor")
-                        RichTextEditor(state = state)
+                        RichTextEditor(state = state, modifier = Modifier.fillMaxWidth())
                     } else {
                         Text("Alternative editor")
-                        RichTextEditor(state = state)
+                        RichTextEditor(state = state, modifier = Modifier.fillMaxWidth())
                     }
                 }
             }
@@ -64,7 +64,7 @@ class RichTextEditorStateTest {
         composeTestRule.setContent {
             MaterialTheme {
                 val hide by hideEditor.collectAsState()
-                Column() {
+                Column {
                     if (!hide) {
                         Text("Editor")
                         RichTextEditor(modifier = Modifier.fillMaxWidth(), state = state)
@@ -73,19 +73,21 @@ class RichTextEditorStateTest {
             }
         }
 
-        state.setHtml("Hello, world")
+        state.setHtml("Hello<br/>world")
+        composeTestRule.awaitIdle()
         // Ensure line count is set
-        Assert.assertEquals(1, state.lineCount)
+        Assert.assertEquals(2, state.lineCount)
 
         // Hide and show the editor to simulate a configuration change
         hideEditor.emit(true)
+        composeTestRule.awaitIdle()
         hideEditor.emit(false)
         composeTestRule.awaitIdle()
 
         // If the text is found, the state was restored
-        onView(withText("Hello, world")).check(matches(isDisplayed()))
+        onView(withText("Hello\nworld")).check(matches(isDisplayed()))
         // Line count is kept
-        Assert.assertEquals(1, state.lineCount)
+        Assert.assertEquals(2, state.lineCount)
     }
 
     @Test

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
@@ -1,10 +1,12 @@
 package io.element.android.wysiwyg.compose
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -62,10 +64,10 @@ class RichTextEditorStateTest {
         composeTestRule.setContent {
             MaterialTheme {
                 val hide by hideEditor.collectAsState()
-                Column {
+                Column() {
                     if (!hide) {
                         Text("Editor")
-                        RichTextEditor(state = state)
+                        RichTextEditor(modifier = Modifier.fillMaxWidth(), state = state)
                     }
                 }
             }

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
@@ -74,6 +74,7 @@ class RichTextEditorStateTest {
         }
 
         state.setHtml("Hello<br/>world")
+        state.setSelection(4)
         composeTestRule.awaitIdle()
         // Ensure line count is set
         Assert.assertEquals(2, state.lineCount)
@@ -86,6 +87,7 @@ class RichTextEditorStateTest {
 
         // If the text is found, the state was restored
         onView(withText("Hello\nworld")).check(matches(isDisplayed()))
+        Assert.assertEquals(state.selection, 4 to 4)
         // Line count is kept
         Assert.assertEquals(2, state.lineCount)
     }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -118,7 +118,7 @@ private fun RealEditor(
                         state.internalHtml = getInternalHtml()
                         state.messageHtml = getContentAsMessageHtml()
                         state.messageMarkdown = getMarkdown()
-                        // Prevent the line count from being reset before onRestoreInstanceState
+                        // Prevent the line count from being reset when the text Layout is not set
                         if (lineCount > 0) {
                             state.lineCount = lineCount
                         }
@@ -138,11 +138,9 @@ private fun RealEditor(
 
                 applyDefaultStyle()
 
-                // Set initial HTML and selection, state will be restored automatically in the view
-                if (editableText.isEmpty()) {
-                    setHtml(state.internalHtml)
-                    setSelection(state.selection.first, state.selection.second)
-                }
+                // Set initial HTML and selection based on the provided state
+                setHtml(state.internalHtml)
+                setSelection(state.selection.first, state.selection.second)
 
                 // Only start listening for text changes after the initial state has been restored
                 if (registerStateUpdates) {

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -118,7 +118,10 @@ private fun RealEditor(
                         state.internalHtml = getInternalHtml()
                         state.messageHtml = getContentAsMessageHtml()
                         state.messageMarkdown = getMarkdown()
-                        state.lineCount = lineCount
+                        // Prevent the line count from being reset before onRestoreInstanceState
+                        if (lineCount > 0) {
+                            state.lineCount = lineCount
+                        }
                     }
                     val shouldRestoreFocus = state.hasFocus
                     if (shouldRestoreFocus) {
@@ -135,9 +138,11 @@ private fun RealEditor(
 
                 applyDefaultStyle()
 
-                // Restore the state of the view with the saved state
-                setHtml(state.internalHtml)
-                setSelection(state.selection.first, state.selection.second)
+                // Set initial HTML and selection, state will be restored automatically in the view
+                if (editableText.isEmpty()) {
+                    setHtml(state.internalHtml)
+                    setSelection(state.selection.first, state.selection.second)
+                }
 
                 // Only start listening for text changes after the initial state has been restored
                 if (registerStateUpdates) {


### PR DESCRIPTION
I found 2 more bugs in the interop between Compose and the AndroidView:

1. ~~When restoring state in `RealEditor`'s `AndroidView`, for some reason if there is a single NSBP char at the end of the HTML it'll just remove it, and it can cause crashes because the selection may become invalid.~~ - this was [fixed in Rust](https://github.com/matrix-org/matrix-rich-text-editor/pull/865). In any case, I believe this state restoration is not needed because the state is kept at the `ComposerModel` and the text and selection are restored in the `EditorEditText.onRestoreInstanceState` method. This should fix the crashes we're seeing in EXA when a mention is added.
2. Related to the previous issue, the `factory` contents run before this `onRestoreInstanceState` runs, so there's no way to know if we're dealing with a restoration, AFAICT, so by the time we're adding the text changed listener on the factory the state hasn't been restored and the `lineCount` will always be 0, which in turn will trigger a recomposition of the whole component, and then another one once we have the right `lineCount = 1` value. I changed the code to only take into account `lineCount` if it's > 0, which should fit our usage since we don't care about value 0 (the edittext being empty).