### PR TITLE
Don't trim NBSP chars at the end of a container

### DIFF
--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -125,7 +125,8 @@ mod sys {
                         // Special case for code block, translate '\n' into <br /> nodes
                         let is_inside_code_block =
                             self.current_path.contains(&CodeBlock);
-                        convert_text(&text.content, node, is_inside_code_block);
+                        let is_only_child_in_parent = node.children().len() == 0;
+                        convert_text(&text.content, node, is_inside_code_block, is_only_child_in_parent);
                     }
                 }
             }
@@ -890,6 +891,23 @@ mod sys {
                 "#}
             );
         }
+
+        #[test]
+        fn parse_nbsp_after_container_keeps_it() {
+            let html = r#"<a href="https://matrix.to/#/@test:example.org">test</a>&nbsp;"#;
+            let dom: Dom<Utf16String> =
+                HtmlParser::default().parse(html).unwrap();
+            let tree = dom.to_tree().to_string();
+            assert_eq!(
+                tree,
+                indoc! {
+                r#"
+
+                  ├>mention "test", https://matrix.to/#/@test:example.org
+                  └>" "
+                "#}
+            );
+        }
     }
 }
 
@@ -1060,6 +1078,7 @@ fn convert_text<S: UnicodeString>(
     text: &str,
     node: &mut ContainerNode<S>,
     is_inside_code_block: bool,
+    is_only_child_in_parent: bool,
 ) {
     if is_inside_code_block {
         let text_nodes: Vec<_> = text.split('\n').collect();
@@ -1077,7 +1096,7 @@ fn convert_text<S: UnicodeString>(
     } else {
         let contents = text;
         let is_nbsp = contents == "\u{A0}" || contents == "&nbsp;";
-        if is_nbsp {
+        if is_nbsp && is_only_child_in_parent {
             return;
         }
 
@@ -1199,10 +1218,12 @@ mod js {
                         Some(value) => {
                             let is_inside_code_block =
                                 self.current_path.contains(&CodeBlock);
+                            let is_only_child_in_parent = number_of_nodes == 1;
                             convert_text(
                                 value.as_str(),
                                 dom,
                                 is_inside_code_block,
+                                is_only_child_in_parent,
                             );
                         }
                         _ => {}

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
@@ -1,5 +1,6 @@
 package io.element.android.wysiwyg.compose
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.collectAsState
@@ -11,6 +12,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import io.element.android.wysiwyg.utils.NBSP
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -27,12 +29,14 @@ class RichTextEditorStateTest {
         composeTestRule.setContent {
             MaterialTheme {
                 val showAlt by showAlternateEditor.collectAsState()
-                if(!showAlt) {
-                    Text("Main editor")
-                    RichTextEditor(state = state)
-                } else {
-                    Text("Alternative editor")
-                    RichTextEditor(state = state)
+                Column {
+                    if (!showAlt) {
+                        Text("Main editor")
+                        RichTextEditor(state = state)
+                    } else {
+                        Text("Alternative editor")
+                        RichTextEditor(state = state)
+                    }
                 }
             }
         }
@@ -48,6 +52,22 @@ class RichTextEditorStateTest {
 
         composeTestRule.onNodeWithText("Alternative editor").assertIsDisplayed()
         onView(withText("Hello, world")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun setHtmlWithTrailingNbspKeepsIt() = runTest {
+        val state = RichTextEditorState()
+        composeTestRule.setContent {
+            MaterialTheme {
+                RichTextEditor(state = state)
+            }
+        }
+
+        state.setHtml("<b>Hey</b>$NBSP")
+        composeTestRule.awaitIdle()
+
+        onView(withText("Hey ")).check(matches(isDisplayed()))
+        state.setSelection(4)
     }
 
     @Test

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -160,6 +160,7 @@ private fun RealEditor(
                                 is ViewAction.ReplaceSuggestionText -> replaceTextSuggestion(it.text)
                                 is ViewAction.InsertMentionAtSuggestion -> insertMentionAtSuggestion(url = it.url, text = it.text)
                                 is ViewAction.InsertAtRoomMentionAtSuggestion -> insertAtRoomMentionAtSuggestion()
+                                is ViewAction.SetSelection -> setSelection(it.start, it.end)
                             }
                         }
                     }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
@@ -143,6 +143,15 @@ class RichTextEditorState(
     }
 
     /**
+     * Sets the text selection to the provided indexes.
+     * @param start The start index of the selection
+     * @param end The end index of the selection. If not provided, the selection will be a cursor.
+     */
+    suspend fun setSelection(start: Int, end: Int = start) {
+        _viewActions.emit(ViewAction.SetSelection(start, end))
+    }
+
+    /**
      * The content of the editor as HTML formatted for sending as a message.
      */
     var messageHtml by mutableStateOf(initialHtml)

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/FakeViewConnection.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/FakeViewConnection.kt
@@ -63,6 +63,9 @@ internal class FakeViewActionCollector(
                 state.messageHtml = state.messageHtml.replaceLast(Regex("(@\\w+)"), htmlReplacement)
                 state.messageMarkdown = state.messageMarkdown.replaceLast(Regex("(@\\w+)"), "@room")
             }
+            is ViewAction.SetSelection -> {
+                state.selection = value.start to value.end
+            }
         }
     }
     private fun toggleInlineFormat(inlineFormat: InlineFormat): Boolean {

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/ViewAction.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/ViewAction.kt
@@ -19,4 +19,5 @@ internal sealed class ViewAction {
     data class ReplaceSuggestionText(val text: String): ViewAction()
     data class InsertMentionAtSuggestion(val text: String, val url: String): ViewAction()
     data object InsertAtRoomMentionAtSuggestion: ViewAction()
+    data class SetSelection(val start: Int, val end: Int): ViewAction()
 }


### PR DESCRIPTION
This was causing crashes with state restoration on Android, since something like this:

``` html
<b>test</b>&nbsp;|
```

When restored, would look like:
``` html
<b>test</b>
``` 

But the selection would be kept at the same index, so when trying to apply it to the underlying UI the apps would crash.