### PR TITLE
[Android] Remove workaround for excessive calls to `AndroidView` `update`

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -111,7 +111,7 @@ class MainActivity : ComponentActivity() {
                                 state = state,
                                 modifier = Modifier.fillMaxWidth().padding(10.dp),
                                 style = RichTextEditorDefaults.style(),
-                                onError = Timber::e,
+                                onError = { Timber.e(it) },
                                 resolveMentionDisplay = { _,_ -> TextDisplay.Pill },
                                 resolveRoomMentionDisplay = { TextDisplay.Pill },
                             )

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
@@ -52,21 +52,16 @@ fun EditorStyledText(
         factory = { context ->
             EditorStyledTextView(context)
         },
-        // The `update` lambda is called when the view is first created, and then again whenever the actual `update` lambda changes. That is, it's replaced with
-        // a new lambda capturing different variables from the surrounding scope. However, there seems to be an issue that causes the `update` lambda to change
-        // more than it's strictly necessary. To avoid this, we can use a `remember` block to cache the `update` lambda, and only update it when needed.
-        update = remember(style, typeface, mentionDisplayHandler, text, onLinkClickedListener) {
-            { view ->
-                view.applyStyleInCompose(style)
-                view.typeface = typeface
-                view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
-                if (text is Spanned) {
-                    view.setText(text, TextView.BufferType.SPANNABLE)
-                } else {
-                    view.setHtml(text.toString())
-                }
-                view.onLinkClickedListener = onLinkClickedListener
+        update = { view ->
+            view.applyStyleInCompose(style)
+            view.typeface = typeface
+            view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
+            if (text is Spanned) {
+                view.setText(text, TextView.BufferType.SPANNABLE)
+            } else {
+                view.setHtml(text.toString())
             }
+            view.onLinkClickedListener = onLinkClickedListener
         }
     )
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -22,6 +22,7 @@ import io.element.android.wysiwyg.display.TextDisplay
 import io.element.android.wysiwyg.utils.RustErrorCollector
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 
 /**
@@ -168,16 +169,12 @@ private fun RealEditor(
 
             view
         },
-        // The `update` lambda is called when the view is first created, and then again whenever the actual `update` lambda changes. That is, it's replaced with
-        // a new lambda capturing different variables from the surrounding scope. However, there seems to be an issue that causes the `update` lambda to change
-        // more than it's strictly necessary. To avoid this, we can use a `remember` block to cache the `update` lambda, and only update it when needed.
-        update = remember(style, typeface, mentionDisplayHandler, onError) {
-            { view ->
-                view.applyStyleInCompose(style)
-                view.typeface = typeface
-                view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
-                view.rustErrorCollector = RustErrorCollector(onError)
-            }
+        update = { view ->
+            Timber.i("RichTextEditor update() called")
+            view.applyStyleInCompose(style)
+            view.typeface = typeface
+            view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
+            view.rustErrorCollector = RustErrorCollector(onError)
         }
     )
 }


### PR DESCRIPTION
## Problem

The `update` block of the composable `AndroidView` is run on every key press, whereas it should only run when a variable used inside the block is changed.

See https://github.com/matrix-org/matrix-rich-text-editor/issues/856 for more details.

## Solution

There is currently a workaround in place for this bug but after some investigation using the Compose inspection tools available in AS Hedgehog, I found that the recomposition is triggered by the value of `onError` being detected as changed despite it being a static function reference.

<img src="https://github.com/matrix-org/matrix-rich-text-editor/assets/4940864/49a31ae0-49a8-4c7b-abf8-cd3e7e4d56a9" width="300px" />

I don't know why this causes the recomposition but replacing the function reference with a lambda function fixes the problem.

- Fixes https://github.com/matrix-org/matrix-rich-text-editor/issues/856