### PR TITLE
[Android] Take a screenshot when instrumentation tests fail

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -92,10 +92,8 @@ jobs:
           disable-animations: true
           enable-hw-keyboard: true
           script: |
-            ./gradlew unitTestsWithCoverage ${{ env.CI_GRADLE_ARG_PROPERTIES }}
-            ./gradlew generateUnitTestCoverageReport ${{ env.CI_GRADLE_ARG_PROPERTIES }}
-            ./gradlew instrumentationTestsWithCoverage ${{ env.CI_GRADLE_ARG_PROPERTIES }}
-            ./gradlew generateInstrumentationTestCoverageReport ${{ env.CI_GRADLE_ARG_PROPERTIES }}
+            chmod +x scripts/ci_test.sh
+            scripts/ci_test.sh
 
       - name : Upload test results
         if : ${{ always() }}
@@ -105,6 +103,7 @@ jobs:
           path : |
             ./**/build/reports/tests/**
             ./**/build/reports/androidTests/connected/**
+            ./**/build/reports/screenshots/**
 
       - name: Upload unit test coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/platforms/android/gradle/libs.versions.toml
+++ b/platforms/android/gradle/libs.versions.toml
@@ -71,4 +71,5 @@ test-turbine = { module="app.cash.turbine:turbine", version="1.0.0" }
 test-androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 test-androidx-espresso = { module="androidx.test.espresso:espresso-core", version.ref="espresso" }
 test-androidx-espresso-accessibility = { module="androidx.test.espresso:espresso-accessibility", version.ref="espresso" }
+test-androidx-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 test-mockk-android = { module="io.mockk:mockk-android", version.ref="mockk" }

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -111,6 +111,7 @@ dependencies {
     androidTestImplementation libs.test.androidx.espresso
     androidTestImplementation libs.test.androidx.espresso.accessibility
     androidTestImplementation libs.test.mockk.android
+    androidTestImplementation libs.test.androidx.uiautomator
 }
 
 android.libraryVariants.all { variant ->

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
@@ -14,7 +14,9 @@ import android.view.View
 import android.widget.EditText
 import android.widget.TextView
 import androidx.core.text.getSpans
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.setFailureHandler
 import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.espresso.action.ViewActions.pressKey
 import androidx.test.espresso.action.ViewActions.replaceText
@@ -56,6 +58,13 @@ class EditorEditTextInputTests {
 
     init {
         AccessibilityChecks.enable()
+    }
+
+    @Before
+    fun setUp() {
+        setFailureHandler(
+            ScreenshotFailureHandler(ApplicationProvider.getApplicationContext())
+        )
     }
 
     @After

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/ScreenshotFailureHandler.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/ScreenshotFailureHandler.kt
@@ -1,0 +1,54 @@
+package io.element.android.wysiwyg.test.utils
+
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Environment
+import android.provider.MediaStore
+import android.view.View
+import androidx.test.espresso.FailureHandler
+import androidx.test.espresso.base.DefaultFailureHandler
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import org.hamcrest.Matcher
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Calendar
+
+class ScreenshotFailureHandler(appContext: Context) : FailureHandler {
+    private val defaultHandler: FailureHandler = DefaultFailureHandler(appContext)
+
+    override fun handle(error: Throwable, viewMatcher: Matcher<View>) {
+        getInstrumentation()
+            .uiAutomation
+            .takeScreenshot()
+            .save()
+
+        defaultHandler.handle(error, viewMatcher)
+    }
+}
+
+private fun Bitmap.save() {
+    val timestamp = timestamp()
+    val contentResolver = getInstrumentation().targetContext.applicationContext.contentResolver
+    try {
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, "$timestamp.jpeg")
+            put(MediaStore.Images.Media.RELATIVE_PATH, "${Environment.DIRECTORY_PICTURES}/UiTest")
+        }
+
+        val uri = contentResolver
+            .insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+                ?: return
+
+        contentResolver.openOutputStream(uri)?.use { outputStream ->
+            compress(Bitmap.CompressFormat.PNG, 20, outputStream)
+        }
+
+        contentResolver.update(uri, contentValues, null, null)
+    } catch (e: IOException) {
+        e.printStackTrace()
+    }
+}
+
+private fun timestamp(): String =
+    SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().time)

--- a/platforms/android/scripts/ci_test.sh
+++ b/platforms/android/scripts/ci_test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+./gradlew unitTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
+./gradlew generateUnitTestCoverageReport $CI_GRADLE_ARG_PROPERTIES
+
+# Don't exit immediately from UI test failure to collect screenshots
+set +e 
+
+./gradlew instrumentationTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
+
+UI_TEST_EXIT_CODE=$?
+if [ $UI_TEST_EXIT_CODE -ne 0 ]; then
+    echo "UI tests failed."
+    echo "Pulling screenshots from device..."
+    adb shell ls /sdcard/Pictures/UiTest/
+    mkdir build/reports/screenshots
+    adb pull /sdcard/Pictures/UiTest/ build/reports/screenshots/
+    exit $UI_TEST_EXIT_CODE
+fi
+set -e
+
+./gradlew generateInstrumentationTestCoverageReport $CI_GRADLE_ARG_PROPERTIES
+


### PR DESCRIPTION
## Changes

Take a screenshot when the core library UI tests fail.

An example of the output can be found in the [CI artifacts](https://github.com/matrix-org/matrix-rich-text-editor/actions/runs/6893260877) for https://github.com/matrix-org/matrix-rich-text-editor/pull/871/commits/04b84f5c990f41969fd7ee07b15c11d92e345c00.

## Context

To aid debugging of test failures.

- #870 