### PR TITLE
[iOS] Fix for dictation not working properly

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -88,7 +88,7 @@ public struct WysiwygComposerView: View {
 
     @ViewBuilder
     private var placeholderView: some View {
-        if viewModel.isContentEmpty {
+        if viewModel.isContentEmpty, !viewModel.textView.isDictationRunning {
             Text(placeholder)
                 .font(Font(UIFont.preferredFont(forTextStyle: .body)))
                 .foregroundColor(placeholderColor)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -556,7 +556,8 @@ private extension WysiwygComposerViewModel {
     /// Reconciliate the content of the model with the content of the text view.
     func reconciliateIfNeeded() {
         do {
-            guard let replacement = try StringDiffer.replacement(from: attributedContent.text.htmlChars,
+            guard !textView.isDictationRunning,
+                  let replacement = try StringDiffer.replacement(from: attributedContent.text.htmlChars,
                                                                  to: textView.attributedText.htmlChars) else {
                 return
             }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -72,8 +72,12 @@ public class WysiwygTextView: UITextView {
     }
     
     @objc private func textInputCurrentInputModeDidChange(notification: Notification) {
-        guard isFirstResponder,
-              let inputMode = textInputMode?.primaryLanguage,
+        // We don't care about the input mode if this is not the first responder
+        guard isFirstResponder else {
+            return
+        }
+        
+        guard let inputMode = textInputMode?.primaryLanguage,
               inputMode == "dictation" else {
             isDictationRunning = false
             return

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -44,10 +44,7 @@ protocol WysiwygTextViewDelegate: AnyObject {
 public protocol MentionDisplayHelper { }
 
 public class WysiwygTextView: UITextView {
-    private var inputMode: String?
-    var isDictationRunning: Bool {
-        inputMode == "dictation"
-    }
+    private(set) var isDictationRunning = false
     
     /// Internal delegate for the text view.
     weak var wysiwygDelegate: WysiwygTextViewDelegate?
@@ -76,23 +73,20 @@ public class WysiwygTextView: UITextView {
     
     @objc private func textInputCurrentInputModeDidChange(notification: Notification) {
         guard isFirstResponder,
-              let inputMode = textInputMode?.primaryLanguage else {
-            self.inputMode = nil
+              let inputMode = textInputMode?.primaryLanguage,
+              inputMode == "dictation" else {
+            isDictationRunning = false
             return
         }
-        self.inputMode = inputMode
+        isDictationRunning = true
     }
     
     override public func dictationRecordingDidEnd() {
-        if isDictationRunning {
-            inputMode = nil
-        }
+        isDictationRunning = false
     }
     
     override public func dictationRecognitionFailed() {
-        if isDictationRunning {
-            inputMode = nil
-        }
+        isDictationRunning = false
     }
 
     /// Register a pill view that has been added through `NSTextAttachmentViewProvider`.


### PR DESCRIPTION
We found a way to intercept dictation, which would not work if the content is reconciliated while the dictation is still in progress, so we delay the `reconciliateIfNeeded()` function until the dictation state is false.