### PR TITLE
Fix disappearing numbers with some keyboards

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
@@ -32,6 +32,7 @@ import io.element.android.wysiwyg.display.TextDisplay
 import io.element.android.wysiwyg.test.R
 import io.element.android.wysiwyg.test.rules.createFlakyEmulatorRule
 import io.element.android.wysiwyg.test.utils.*
+import io.element.android.wysiwyg.utils.NBSP
 import io.element.android.wysiwyg.utils.RustErrorCollector
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.spans.LinkSpan
@@ -510,6 +511,16 @@ class EditorEditTextInputTests {
             textWatcher.invoke(match { it.toString() == "" })
         }
         confirmVerified(textWatcher)
+    }
+
+    @Test
+    fun testWritingOnlyDigits() {
+        onView(withId(R.id.rich_text_edit_text))
+            .perform(ImeActions.setComposingText("1"))
+            .perform(ImeActions.setComposingText("2"))
+            .perform(ImeActions.setComposingText("3"))
+            .perform(ImeActions.commitText(" "))
+            .check(matches(withText("123$NBSP")))
     }
 
     @Test

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -9,6 +9,7 @@ import android.view.inputmethod.*
 import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
+import androidx.core.text.isDigitsOnly
 import io.element.android.wysiwyg.internal.utils.TextRangeHelper
 import io.element.android.wysiwyg.internal.viewmodel.EditorInputAction
 import io.element.android.wysiwyg.internal.viewmodel.ReplaceTextResult
@@ -322,7 +323,11 @@ internal class InterceptInputConnection(
         beginBatchEdit()
         editable.removeFormattingSpans()
         editable.replace(0, editable.length, charSequence)
-        setComposingRegion(compositionStart, compositionEnd)
+        val start = compositionStart.coerceIn(0, editable.length)
+        val end = compositionEnd.coerceIn(0, editable.length)
+        if (!editable.substring(start, end).isDigitsOnly()) {
+            setComposingRegion(start, end)
+        }
         endBatchEdit()
     }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -325,7 +325,8 @@ internal class InterceptInputConnection(
         editable.replace(0, editable.length, charSequence)
         val start = compositionStart.coerceIn(0, editable.length)
         val end = compositionEnd.coerceIn(0, editable.length)
-        if (!editable.substring(start, end).isDigitsOnly()) {
+        val newComposition = editable.substring(start, end)
+        if (newComposition.isEmpty() || !newComposition.isDigitsOnly()) {
             setComposingRegion(start, end)
         }
         endBatchEdit()

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -260,7 +260,7 @@ internal class InterceptInputConnection(
                 processInput(action)
             }
             if (result != null) {
-                replaceAll(result.text, 0, editable.length)
+                replaceAll(result.text, result.selection.first, result.selection.last)
                 setSelectionOnEditable(editable, result.selection.first, result.selection.last)
                 setComposingRegion(result.selection.first, result.selection.last)
             }
@@ -281,7 +281,7 @@ internal class InterceptInputConnection(
                 processInput(EditorInputAction.BackPress)
             }
             if (result != null) {
-                replaceAll(result.text, 0, editable.length)
+                replaceAll(result.text, result.selection.first, result.selection.last)
                 setSelectionOnEditable(editable, result.selection.first, result.selection.last)
                 setComposingRegion(result.selection.first, result.selection.last)
             }
@@ -323,11 +323,9 @@ internal class InterceptInputConnection(
         beginBatchEdit()
         editable.removeFormattingSpans()
         editable.replace(0, editable.length, charSequence)
-        val start = compositionStart.coerceIn(0, editable.length)
-        val end = compositionEnd.coerceIn(0, editable.length)
-        val newComposition = editable.substring(start, end)
+        val newComposition = editable.substring(compositionStart, compositionEnd)
         if (newComposition.isEmpty() || !newComposition.isDigitsOnly()) {
-            setComposingRegion(start, end)
+            setComposingRegion(compositionStart, compositionEnd)
         }
         endBatchEdit()
     }


### PR DESCRIPTION
Don't set composition if the replaced text is all digits. This seems to be the default behaviour in all keyboards I've tested (Gboard, AnySoftKeyboard, Simple Keyboard...), and prevents the composition (the last digit) from being replaced with a whitespace.

Fixes https://github.com/vector-im/element-x-android/issues/1415.