### PR TITLE
[iOS] Fix the position of the caret

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -150,16 +150,12 @@ public class WysiwygTextView: UITextView {
     override public func caretRect(for position: UITextPosition) -> CGRect {
         // Compute system expected caret rect.
         let rect = super.caretRect(for: position)
-        // Determine rect for glyph at expected position.
-        let index = offset(from: beginningOfDocument, to: position)
-        let glyphRange = layoutManager.glyphRange(forCharacterRange: .init(location: index, length: 1), actualCharacterRange: nil)
-        let glyphRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
         // Use the system caret rect for `x` position and width and correct
-        // the `y` position and the height using the text glyphs.
+        // the `y` position and the height.
         return CGRect(x: rect.minX,
-                      y: glyphRect.minY - Constants.caretVerticalOffset,
+                      y: rect.minY - Constants.caretVerticalOffset,
                       width: rect.width,
-                      height: glyphRect.height + 2 * Constants.caretVerticalOffset)
+                      height: rect.height + 2 * Constants.caretVerticalOffset)
     }
 
     // Enter Key commands support


### PR DESCRIPTION
This PR fixes https://github.com/vector-im/element-x-ios/issues/1674

The caret position was calculated using the glyph bounding rectangle, but this rectangle sometimes (almost always when the caret is set at the end of a wrapped line) coincided with the start of the next line. So the final caret position was at the correct x position, but at the wrong y position.

The fix is to let the UITextView calculate the correct caret rect and just update it's y and height.