### PR TITLE
Remove trailingTrimmed from withNBSP

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Tools/StringDiffer.swift
@@ -117,17 +117,7 @@ private struct StringDiff {
 private extension String {
     /// Converts all whitespaces to NBSP to avoid diffs caused by HTML translations.
     var withNBSP: String {
-        String(map { $0.isWhitespace ? Character.nbsp : $0 }).trailingTrimmed
-    }
-
-    var trailingTrimmed: String {
-        var view = self[...]
-
-        while view.last?.isWhitespace == true || view.last?.isNewline == true {
-            view = view.dropLast()
-        }
-
-        return String(view)
+        String(map { $0.isWhitespace ? Character.nbsp : $0 })
     }
 
     /// Computes the diff from provided string to self. Outputs UTF16 locations and lengths.

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Tools/StringDifferTests.swift
@@ -81,6 +81,11 @@ final class StringDifferTests: XCTestCase {
         XCTAssertEqual(try StringDiffer.replacement(from: " \u{00A0} text", to: " \u{00A0} test"),
                        .init(location: 5, length: 1, text: "s"))
     }
+    
+    func testDoubleSpaceDotConversion() throws {
+        XCTAssertEqual(try StringDiffer.replacement(from: "a  ", to: "a."),
+                       .init(location: 1, length: 2, text: "."))
+    }
 }
 
 private extension CharacterSet {


### PR DESCRIPTION
Fixes an issue with double space -> `.` conversion breaking formatting:

https://github.com/matrix-org/matrix-rich-text-editor/assets/6135282/90a688a4-da9b-4caf-ab29-ec892cb2e22f

The trimming in withNBSP was added back when we were using zero-width spaces(ZWSP) as a part of the initial [paragraphs work](https://github.com/matrix-org/matrix-rich-text-editor/pull/520).
We no longer use ZWSP.

In https://github.com/matrix-org/matrix-rich-text-editor/pull/831 @aringenbach changed it to just remove trailing(not leading) space to fix that issue. Maybe it's not needed at all anymore. 

Nit: Either way it probably shouldn't be a function called `withNBSP` as it's not clear form the call site that it is also trimming.

So unless somebody knows of a problem it is currently solving, lets remove it to fix this issue. If it causes a regression we can then solve for both cases.

@Velin92 Do you happen to remember why the trimming was needed [here](https://github.com/matrix-org/matrix-rich-text-editor/commit/3c4d4571b604eb815f070d7b40e37b84af043fbd#diff-e9ce992d1f93a4e51179f9efd0a37232a76a5883f4ba95b599d2fba265c12d89R120)? And if maybe it's not needed anymore now that we use just paragraphs and no ZWSP?

