### PR TITLE
[Android] Fixes to make `EditorStyleText` work properly in Compose

### DIFF
--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
@@ -53,9 +53,9 @@ fun EditorStyledText(
             EditorStyledTextView(context)
         },
         update = { view ->
+            view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
             view.applyStyleInCompose(style)
             view.typeface = typeface
-            view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
             if (text is Spanned) {
                 view.setText(text, TextView.BufferType.SPANNABLE)
             } else {

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
@@ -144,6 +144,7 @@ object RichTextEditorDefaults {
     fun textStyle(
         color: Color = MaterialTheme.colorScheme.onSurface,
         fontSize: TextUnit = MaterialTheme.typography.bodyLarge.fontSize,
+        lineHeight: TextUnit = MaterialTheme.typography.bodyLarge.lineHeight,
         fontFamily: FontFamily? = MaterialTheme.typography.bodyLarge.fontFamily,
         fontWeight: FontWeight? = MaterialTheme.typography.bodyLarge.fontWeight,
         fontStyle: FontStyle? = MaterialTheme.typography.bodyLarge.fontStyle,
@@ -151,6 +152,7 @@ object RichTextEditorDefaults {
     ) = TextStyle(
         color = color,
         fontSize = fontSize,
+        lineHeight = lineHeight,
         fontFamily = fontFamily,
         fontWeight = fontWeight,
         fontStyle = fontStyle,

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
@@ -51,6 +51,7 @@ data class PillStyle(
 data class TextStyle(
     val color: Color,
     val fontSize: TextUnit,
+    val lineHeight: TextUnit,
     val fontFamily: FontFamily?,
     val fontWeight: FontWeight?,
     val fontStyle: FontStyle?,

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
@@ -31,14 +31,14 @@ import io.element.android.wysiwyg.view.PillStyleConfig
 import io.element.android.wysiwyg.view.StyleConfig
 import kotlin.math.roundToInt
 
-internal fun RichTextEditorStyle.toStyleConfig(context: Context): StyleConfig = StyleConfig(
+fun RichTextEditorStyle.toStyleConfig(context: Context): StyleConfig = StyleConfig(
     bulletList = bulletList.toStyleConfig(context),
     inlineCode = inlineCode.toStyleConfig(context),
     codeBlock = codeBlock.toStyleConfig(context),
     pill = pill.toStyleConfig(),
 )
 
-internal fun BulletListStyle.toStyleConfig(context: Context): BulletListStyleConfig =
+fun BulletListStyle.toStyleConfig(context: Context): BulletListStyleConfig =
     with(Density(context)) {
         BulletListStyleConfig(
             bulletGapWidth = bulletGapWidth.toPx(),
@@ -46,7 +46,7 @@ internal fun BulletListStyle.toStyleConfig(context: Context): BulletListStyleCon
         )
     }
 
-internal fun InlineCodeStyle.toStyleConfig(context: Context): InlineCodeStyleConfig {
+fun InlineCodeStyle.toStyleConfig(context: Context): InlineCodeStyleConfig {
     val density = Density(context)
     return InlineCodeStyleConfig(
         horizontalPadding = with(density) { horizontalPadding.toPx().roundToInt() },
@@ -59,7 +59,7 @@ internal fun InlineCodeStyle.toStyleConfig(context: Context): InlineCodeStyleCon
     )
 }
 
-internal fun CodeBlockStyle.toStyleConfig(context: Context): CodeBlockStyleConfig {
+fun CodeBlockStyle.toStyleConfig(context: Context): CodeBlockStyleConfig {
     val density = Density(context)
     return CodeBlockStyleConfig(
         leadingMargin = with(density) { leadingMargin.toPx().roundToInt() },
@@ -69,7 +69,7 @@ internal fun CodeBlockStyle.toStyleConfig(context: Context): CodeBlockStyleConfi
     )
 }
 
-internal fun PillStyle.toStyleConfig(): PillStyleConfig = PillStyleConfig(
+fun PillStyle.toStyleConfig(): PillStyleConfig = PillStyleConfig(
     backgroundColor = backgroundColor.toArgb(),
 )
 
@@ -89,6 +89,14 @@ internal fun TextStyle.rememberTypeface(): State<Typeface> {
 
 internal fun TextView.applyStyleInCompose(style: RichTextEditorStyle) {
     setTextColor(style.text.color.toArgb())
+    val lineHeightInPx = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        style.text.lineHeight.value,
+        context.resources.displayMetrics
+    )
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        lineHeight = lineHeightInPx.roundToInt()
+    }
     setTextSize(TypedValue.COMPLEX_UNIT_SP, style.text.fontSize.value)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         val cursorDrawable = ContextCompat.getDrawable(context, R.drawable.cursor)

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
@@ -31,14 +31,14 @@ import io.element.android.wysiwyg.view.PillStyleConfig
 import io.element.android.wysiwyg.view.StyleConfig
 import kotlin.math.roundToInt
 
-fun RichTextEditorStyle.toStyleConfig(context: Context): StyleConfig = StyleConfig(
+internal fun RichTextEditorStyle.toStyleConfig(context: Context): StyleConfig = StyleConfig(
     bulletList = bulletList.toStyleConfig(context),
     inlineCode = inlineCode.toStyleConfig(context),
     codeBlock = codeBlock.toStyleConfig(context),
     pill = pill.toStyleConfig(),
 )
 
-fun BulletListStyle.toStyleConfig(context: Context): BulletListStyleConfig =
+internal fun BulletListStyle.toStyleConfig(context: Context): BulletListStyleConfig =
     with(Density(context)) {
         BulletListStyleConfig(
             bulletGapWidth = bulletGapWidth.toPx(),
@@ -46,7 +46,7 @@ fun BulletListStyle.toStyleConfig(context: Context): BulletListStyleConfig =
         )
     }
 
-fun InlineCodeStyle.toStyleConfig(context: Context): InlineCodeStyleConfig {
+internal fun InlineCodeStyle.toStyleConfig(context: Context): InlineCodeStyleConfig {
     val density = Density(context)
     return InlineCodeStyleConfig(
         horizontalPadding = with(density) { horizontalPadding.toPx().roundToInt() },
@@ -59,7 +59,7 @@ fun InlineCodeStyle.toStyleConfig(context: Context): InlineCodeStyleConfig {
     )
 }
 
-fun CodeBlockStyle.toStyleConfig(context: Context): CodeBlockStyleConfig {
+internal fun CodeBlockStyle.toStyleConfig(context: Context): CodeBlockStyleConfig {
     val density = Density(context)
     return CodeBlockStyleConfig(
         leadingMargin = with(density) { leadingMargin.toPx().roundToInt() },
@@ -69,7 +69,7 @@ fun CodeBlockStyle.toStyleConfig(context: Context): CodeBlockStyleConfig {
     )
 }
 
-fun PillStyle.toStyleConfig(): PillStyleConfig = PillStyleConfig(
+internal fun PillStyle.toStyleConfig(): PillStyleConfig = PillStyleConfig(
     backgroundColor = backgroundColor.toArgb(),
 )
 

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -86,7 +86,7 @@ kotlin {
 
 dependencies {
 
-    implementation "net.java.dev.jna:jna:5.7.0@aar"
+    implementation "net.java.dev.jna:jna:5.13.0@aar"
 
     implementation libs.kotlin.coroutines.android
     implementation libs.kotlin.coroutines

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -28,7 +28,7 @@ import uniffi.wysiwyg_composer.newMentionDetector
  */
 open class EditorStyledTextView : AppCompatTextView {
 
-    private var mentionDetector: MentionDetector? = null
+    private var mentionDetector: MentionDetector? = if (isInEditMode) null else newMentionDetector()
 
     private lateinit var inlineCodeBgHelper: SpanBackgroundHelper
     private lateinit var codeBlockBgHelper: SpanBackgroundHelper
@@ -43,7 +43,7 @@ open class EditorStyledTextView : AppCompatTextView {
 
     private val spannableFactory = ReuseSourceSpannableFactory()
 
-    private var mentionDisplayHandler: MentionDisplayHandler? = null
+    var mentionDisplayHandler: MentionDisplayHandler? = null
     private var htmlConverter: HtmlConverter? = null
 
     var onLinkClickedListener: ((String) -> Unit)? = null
@@ -148,14 +148,10 @@ open class EditorStyledTextView : AppCompatTextView {
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        mentionDetector = if (isInEditMode) null else newMentionDetector()
-
         updateStyle(styleConfig, mentionDisplayHandler)
     }
 
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-
+    fun finalize() {
         mentionDetector?.destroy()
         mentionDetector = null
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/ResourcesHelper.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/ResourcesHelper.kt
@@ -6,6 +6,9 @@ import androidx.annotation.ColorRes
 import androidx.annotation.Dimension
 import androidx.core.content.res.ResourcesCompat
 
+/**
+ * This class provides access to resources needed to convert HTML to spans.
+ */
 internal interface ResourcesHelper {
     fun getDisplayMetrics(): DisplayMetrics
 
@@ -14,6 +17,9 @@ internal interface ResourcesHelper {
     fun getColor(@ColorRes colorId: Int): Int
 }
 
+/**
+ * This class provides access to Android resources needed to convert HTML to spans.
+ */
 internal class AndroidResourcesHelper(
     private val application: Application,
 ) : ResourcesHelper {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/RustCleanerTask.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/RustCleanerTask.kt
@@ -1,0 +1,13 @@
+package io.element.android.wysiwyg.utils
+
+import timber.log.Timber
+import uniffi.wysiwyg_composer.Disposable
+
+class RustCleanerTask(
+    private val disposable: Disposable,
+) : Runnable {
+    override fun run() {
+        Timber.d("Cleaning up disposable: $disposable")
+        disposable.destroy()
+    }
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/RustCleanerTask.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/RustCleanerTask.kt
@@ -3,7 +3,7 @@ package io.element.android.wysiwyg.utils
 import timber.log.Timber
 import uniffi.wysiwyg_composer.Disposable
 
-class RustCleanerTask(
+internal class RustCleanerTask(
     private val disposable: Disposable,
 ) : Runnable {
     override fun run() {


### PR DESCRIPTION
Changes:

- Fixes link click detection by making sure the `TextView` won't consume the touch event if no link or mention span is clicked.
- Fixed a race condition with `MentionDetector` that prevented mentions from being detected and properly displayed half of the time.
- Added `TextStyle.lineHeight` property to be able to provide a custom line height and match the existing UI. 