### PR TITLE
Android: handle all `ClickableSpans` in the gesture detector

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
@@ -3,6 +3,7 @@ package io.element.android.wysiwyg
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.text.style.ReplacementSpan
+import android.text.style.URLSpan
 import android.widget.TextView
 import androidx.core.text.buildSpannedString
 import androidx.core.text.inSpans
@@ -32,6 +33,29 @@ internal class EditorStyledTextViewTest {
         onView(ViewMatchers.withId(R.id.styledTextView))
             .perform(TextViewActions.setText("Hello, world"))
             .check(matches(withText("Hello, world")))
+    }
+
+    @Test
+    fun testUrlClicks() {
+        var pass = false
+        scenarioRule.scenario.onActivity {
+            it.findViewById<EditorStyledTextView>(R.id.styledTextView).apply {
+                val spanned = buildSpannedString {
+                    inSpans(URLSpan("")) {
+                        append("Hello, world")
+                    }
+                }
+                setText(spanned, TextView.BufferType.SPANNABLE)
+                onLinkClickedListener = {
+                    pass = true
+                }
+            }
+        }
+        onView(ViewMatchers.withId(R.id.styledTextView))
+            .check(matches(withText("Hello, world")))
+            .perform(ViewActions.click())
+
+        Assert.assertTrue(pass)
     }
 
     @Test

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
@@ -36,6 +36,28 @@ internal class EditorStyledTextViewTest {
     }
 
     @Test
+    fun testSetHtml() {
+        scenarioRule.scenario.onActivity {
+            it.findViewById<EditorStyledTextView>(R.id.styledTextView).apply {
+                setHtml("<p>Hello, world</p>")
+            }
+        }
+        onView(ViewMatchers.withId(R.id.styledTextView))
+            .check(matches(withText("Hello, world")))
+    }
+
+    @Test
+    fun testSetHtmlWithMention() {
+        scenarioRule.scenario.onActivity {
+            it.findViewById<EditorStyledTextView>(R.id.styledTextView).apply {
+                setHtml("<p>Hello, <a href='https://matrix.to/#/@alice:matrix.org'>@Alice</a></p>")
+            }
+        }
+        onView(ViewMatchers.withId(R.id.styledTextView))
+            .check(matches(withText("Hello, @Alice")))
+    }
+
+    @Test
     fun testUrlClicks() {
         var pass = false
         scenarioRule.scenario.onActivity {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -67,12 +67,15 @@ open class EditorStyledTextView : AppCompatTextView {
     private val gestureDetector = GestureDetectorCompat(context, object : GestureDetector.SimpleOnGestureListener() {
 
         override fun onDown(e: MotionEvent): Boolean {
-            // Find any spans in the coordinates
+            // Find any spans with URLs in the coordinates
             val spans = findSpansForTouchEvent(e)
-            return spans.any { it is LinkSpan || it is PillSpan || it is CustomMentionSpan || it is ClickableSpan }
+            return spans.any { it is URLSpan || it is PillSpan || it is CustomMentionSpan }
         }
 
         override fun onSingleTapUp(e: MotionEvent): Boolean {
+            // No need to detect user interaction if there is no listener
+            val onLinkClickedListener = this@EditorStyledTextView.onLinkClickedListener ?: return false
+
             // Find any spans in the coordinates
             val spans = findSpansForTouchEvent(e)
 
@@ -80,15 +83,15 @@ open class EditorStyledTextView : AppCompatTextView {
             for (span in spans) {
                 when (span) {
                     is URLSpan -> { // This includes LinkSpan
-                        onLinkClickedListener?.invoke(span.url)
+                        onLinkClickedListener(span.url)
                         return true
                     }
                     is PillSpan -> {
-                        span.url?.let { onLinkClickedListener?.invoke(it) }
+                        span.url?.let(onLinkClickedListener)
                         return true
                     }
                     is CustomMentionSpan -> {
-                        span.url?.let { onLinkClickedListener?.invoke(it) }
+                        span.url?.let(onLinkClickedListener)
                         return true
                     }
                     else -> Unit

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -3,6 +3,8 @@ package io.element.android.wysiwyg
 import android.content.Context
 import android.graphics.Canvas
 import android.text.Spanned
+import android.text.style.ClickableSpan
+import android.text.style.URLSpan
 import android.util.AttributeSet
 import android.view.GestureDetector
 import android.view.MotionEvent
@@ -67,7 +69,7 @@ open class EditorStyledTextView : AppCompatTextView {
         override fun onDown(e: MotionEvent): Boolean {
             // Find any spans in the coordinates
             val spans = findSpansForTouchEvent(e)
-            return spans.any { it is LinkSpan || it is PillSpan || it is CustomMentionSpan }
+            return spans.any { it is LinkSpan || it is PillSpan || it is CustomMentionSpan || it is ClickableSpan }
         }
 
         override fun onSingleTapUp(e: MotionEvent): Boolean {
@@ -77,7 +79,7 @@ open class EditorStyledTextView : AppCompatTextView {
             // Notify the link has been clicked
             for (span in spans) {
                 when (span) {
-                    is LinkSpan -> {
+                    is URLSpan -> { // This includes LinkSpan
                         onLinkClickedListener?.invoke(span.url)
                         return true
                     }


### PR DESCRIPTION
While testing the latest version on EX Android I realised auto-linkified links (using `URLSpan`) weren't clickable since the gesture detector ignored them. This fixes the issue.