### PR TITLE
[Android] Improve text view test

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/FakeLinkClickedListener.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/FakeLinkClickedListener.kt
@@ -1,0 +1,16 @@
+package io.element.android.wysiwyg.test.utils
+
+import org.junit.Assert
+
+class FakeLinkClickedListener: (String) -> Unit {
+    private val clickedLinks: MutableList<String> = mutableListOf()
+
+    override fun invoke(link: String) {
+        clickedLinks.add(link)
+    }
+
+    fun assertLinkClicked(url: String) {
+        Assert.assertTrue(clickedLinks.size == 1)
+        Assert.assertTrue(clickedLinks.contains(url))
+    }
+}

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/TextViewActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/TextViewActions.kt
@@ -2,14 +2,17 @@ package io.element.android.wysiwyg.test.utils
 
 import android.view.View
 import android.widget.TextView
+import android.widget.TextView.BufferType
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import io.element.android.wysiwyg.EditorStyledTextView
 import org.hamcrest.Matcher
 
 object TextViewAction {
     class SetText(
-        private val text: String,
+        private val text: CharSequence,
+        private val type: BufferType = BufferType.NORMAL,
     ) : ViewAction {
         override fun getConstraints(): Matcher<View> = isDisplayed()
 
@@ -17,12 +20,39 @@ object TextViewAction {
 
         override fun perform(uiController: UiController?, view: View?) {
             val textView = view as? TextView ?: return
-            textView.setText(text)
+            textView.setText(text, type)
         }
     }
 
+    class SetHtml(
+        private val html: String,
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Set html to $html"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val textView = view as? EditorStyledTextView ?: return
+            textView.setHtml(html)
+        }
+    }
+
+    class SetOnLinkClickedListener(
+        private val listener: (String) -> Unit,
+    ) : ViewAction {
+        override fun getConstraints(): Matcher<View> = isDisplayed()
+
+        override fun getDescription(): String = "Set link clicked listener"
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val textView = view as? EditorStyledTextView ?: return
+            textView.onLinkClickedListener = listener
+        }
+    }
 }
 
 object TextViewActions {
-    fun setText(text: String) = TextViewAction.SetText(text)
+    fun setText(text: CharSequence, type: BufferType = BufferType.NORMAL) = TextViewAction.SetText(text, type)
+    fun setHtml(html: String) = TextViewAction.SetHtml(html)
+    fun setOnLinkClickedListener(listener: (String) -> Unit) = TextViewAction.SetOnLinkClickedListener(listener)
 }


### PR DESCRIPTION
- Use Espresso `ViewAction`s instead of `onActivity` + `findViewById`.
- Add `FakeClickListener` test util.
- Add assertions for the correct URL being clicked.
- Add test for parsing a mention and clicking it.