### PR TITLE
[Android] Fix line height changes in `EditorStyledText`

### DIFF
--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
@@ -53,8 +53,8 @@ fun EditorStyledText(
             EditorStyledTextView(context)
         },
         update = { view ->
-            view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
             view.applyStyleInCompose(style)
+            view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
             view.typeface = typeface
             if (text is Spanned) {
                 view.setText(text, TextView.BufferType.SPANNABLE)

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorDefaults.kt
@@ -1,6 +1,8 @@
 package io.element.android.wysiwyg.compose
 
 import android.text.InputType
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -139,16 +141,24 @@ object RichTextEditorDefaults {
      * Creates the default text style for [RichTextEditor].
      *
      * @param color The text color to apply
+     * @param fontSize The font size to apply
+     * @param lineHeight The line height to apply
+     * @param fontFamily The font family to apply
+     * @param fontWeight The font weight to apply
+     * @param fontStyle The font style to apply
+     * @param fontSynthesis The font synthesis to apply
+     * @param includeFontPadding Whether to include font padding in line height or not. Defaults to `true`.
      */
     @Composable
     fun textStyle(
-        color: Color = MaterialTheme.colorScheme.onSurface,
-        fontSize: TextUnit = MaterialTheme.typography.bodyLarge.fontSize,
-        lineHeight: TextUnit = MaterialTheme.typography.bodyLarge.lineHeight,
-        fontFamily: FontFamily? = MaterialTheme.typography.bodyLarge.fontFamily,
-        fontWeight: FontWeight? = MaterialTheme.typography.bodyLarge.fontWeight,
-        fontStyle: FontStyle? = MaterialTheme.typography.bodyLarge.fontStyle,
+        color: Color = LocalContentColor.current,
+        fontSize: TextUnit = LocalTextStyle.current.fontSize,
+        lineHeight: TextUnit = LocalTextStyle.current.lineHeight,
+        fontFamily: FontFamily? = LocalTextStyle.current.fontFamily,
+        fontWeight: FontWeight? = LocalTextStyle.current.fontWeight,
+        fontStyle: FontStyle? = LocalTextStyle.current.fontStyle,
         fontSynthesis: FontSynthesis? = MaterialTheme.typography.bodyLarge.fontSynthesis,
+        includeFontPadding: Boolean = true,
     ) = TextStyle(
         color = color,
         fontSize = fontSize,
@@ -157,6 +167,7 @@ object RichTextEditorDefaults {
         fontWeight = fontWeight,
         fontStyle = fontStyle,
         fontSynthesis = fontSynthesis,
+        includeFontPadding = includeFontPadding,
     )
 
     /**

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorStyle.kt
@@ -56,6 +56,7 @@ data class TextStyle(
     val fontWeight: FontWeight?,
     val fontStyle: FontStyle?,
     val fontSynthesis: FontSynthesis?,
+    val includeFontPadding: Boolean,
 )
 
 data class CursorStyle(

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
@@ -90,6 +90,7 @@ internal fun TextStyle.rememberTypeface(): State<Typeface> {
 }
 
 internal fun TextView.applyStyleInCompose(style: RichTextEditorStyle) {
+    includeFontPadding = style.text.includeFontPadding
     setTextColor(style.text.color.toArgb())
     setTextSize(TypedValue.COMPLEX_UNIT_SP, style.text.fontSize.value)
     if (style.text.lineHeight.isSpecified && style.text.lineHeight.value > 0f) {

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
@@ -91,6 +91,7 @@ internal fun TextStyle.rememberTypeface(): State<Typeface> {
 
 internal fun TextView.applyStyleInCompose(style: RichTextEditorStyle) {
     setTextColor(style.text.color.toArgb())
+    setTextSize(TypedValue.COMPLEX_UNIT_SP, style.text.fontSize.value)
     if (style.text.lineHeight.isSpecified && style.text.lineHeight.value > 0f) {
         val lineHeightInPx = TypedValue.applyDimension(
             style.text.lineHeight.type.toTypeUnit(),
@@ -109,7 +110,6 @@ internal fun TextView.applyStyleInCompose(style: RichTextEditorStyle) {
             setLineSpacing(extra, 1f)
         }
     }
-    setTextSize(TypedValue.COMPLEX_UNIT_SP, style.text.fontSize.value)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         val cursorDrawable = ContextCompat.getDrawable(context, R.drawable.cursor)
         cursorDrawable?.setTint(style.cursor.color.toArgb())


### PR DESCRIPTION
When using `EditorStyledText` for the timeline items in EXA I sometimes saw the line height changing in real time. 

This was probably caused by setting this line height before the typeface, since this latter change recalculates the line height too.

While at it, I thought it would be nice to be able to customise `includeFontPadding` so the text in these components behave the same as the one in Compose.

Also, I think it's probably better to default to the local text style and font color than just setting a default one ourselves? If this is not right, I can revert these changes.