### PR TITLE
[Android] Fixes needed to get `EditorSyledTextView` to work with screenshot tests

### DIFF
--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
 import io.element.android.wysiwyg.EditorStyledTextView
 import io.element.android.wysiwyg.compose.internal.applyStyleInCompose
@@ -47,10 +48,14 @@ fun EditorStyledText(
             }
         }
     }
+
+    val isInEditMode = LocalInspectionMode.current
     AndroidView(
         modifier = modifier,
         factory = { context ->
-            EditorStyledTextView(context)
+            EditorStyledTextView(context).apply {
+                isNativeCodeEnabled = !isInEditMode
+            }
         },
         update = { view ->
             view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -36,7 +36,7 @@ open class EditorStyledTextView : AppCompatTextView {
     private val cleaner = Cleaner.getCleaner()
 
     private val mentionDetector: MentionDetector? by lazy {
-        if (!isInEditMode) {
+        if (!isInEditMode && isNativeCodeEnabled) {
             val detector = newMentionDetector()
             cleaner.register(this, RustCleanerTask(detector))
             detector
@@ -62,6 +62,8 @@ open class EditorStyledTextView : AppCompatTextView {
     private var htmlConverter: HtmlConverter? = null
 
     var onLinkClickedListener: ((String) -> Unit)? = null
+
+    var isNativeCodeEnabled: Boolean = !isInEditMode
 
     // This gesture detector will be used to detect clicks on spans
     private val gestureDetector = GestureDetectorCompat(context, object : GestureDetector.SimpleOnGestureListener() {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorStyledTextView.kt
@@ -63,6 +63,10 @@ open class EditorStyledTextView : AppCompatTextView {
 
     var onLinkClickedListener: ((String) -> Unit)? = null
 
+    /**
+     * In some contexts, such as screenshot tests, [isInEditMode] is may be forced to be false, when we
+     * need it to be true to disable native library loading. With this we can override this behaviour.
+     */
     var isNativeCodeEnabled: Boolean = !isInEditMode
 
     // This gesture detector will be used to detect clicks on spans

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlConverter.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlConverter.kt
@@ -17,8 +17,7 @@ interface HtmlConverter {
             mentionDisplayHandler: MentionDisplayHandler?,
             isMention: ((text: String, url: String) -> Boolean)? = null,
         ): HtmlConverter {
-            val resourcesProvider =
-                AndroidResourcesHelper(context.applicationContext as Application)
+            val resourcesProvider = AndroidResourcesHelper(context)
             return AndroidHtmlConverter(provideHtmlToSpansParser = { html ->
                 HtmlToSpansParser(
                     resourcesHelper = resourcesProvider,

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/ResourcesHelper.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/ResourcesHelper.kt
@@ -1,6 +1,6 @@
 package io.element.android.wysiwyg.utils
 
-import android.app.Application
+import android.content.Context
 import android.util.DisplayMetrics
 import androidx.annotation.ColorRes
 import androidx.annotation.Dimension
@@ -21,11 +21,11 @@ internal interface ResourcesHelper {
  * This class provides access to Android resources needed to convert HTML to spans.
  */
 internal class AndroidResourcesHelper(
-    private val application: Application,
+    private val context: Context,
 ) : ResourcesHelper {
 
     override fun getDisplayMetrics(): DisplayMetrics {
-        return application.resources.displayMetrics
+        return context.resources.displayMetrics
     }
 
     override fun dpToPx(dp: Int): Float {
@@ -33,6 +33,6 @@ internal class AndroidResourcesHelper(
     }
 
     override fun getColor(colorId: Int): Int {
-        return ResourcesCompat.getColor(application.resources, colorId, application.theme)
+        return ResourcesCompat.getColor(context.resources, colorId, context.theme)
     }
 }

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -162,7 +162,7 @@ class HtmlToSpansParserTest {
         val app = RuntimeEnvironment.getApplication()
         val styleConfig = createFakeStyleConfig()
         return HtmlToSpansParser(
-            resourcesHelper = AndroidResourcesHelper(application = app),
+            resourcesHelper = AndroidResourcesHelper(context = app),
             html = html,
             styleConfig = styleConfig,
             mentionDisplayHandler = mentionDisplayHandler,


### PR DESCRIPTION
## Changes

- Workaround for isInEditMode() being always false in Paparazzi tests. `isInEditMode` is used in Android code to decide whether to load the native libs or not.
- Use `Context` instead of `Application` in `AndroidResourcesHelper` (LayoutLib in Paparazzi can't cast `applicationContext` to `Application`).