### PR TITLE
[iOS] Key Commands Refactor

### DIFF
--- a/platforms/ios/example/Wysiwyg/Views/Composer.swift
+++ b/platforms/ios/example/Wysiwyg/Views/Composer.swift
@@ -22,7 +22,7 @@ import WysiwygComposer
 struct Composer: View {
     @ObservedObject var viewModel: WysiwygComposerViewModel
     let itemProviderHelper: WysiwygItemProviderHelper?
-    let keyCommandHandler: KeyCommandHandler?
+    let keyCommands: [WysiwygKeyCommand]?
     let pasteHandler: PasteHandler?
     let minTextViewHeight: CGFloat = 20
     let borderHeight: CGFloat = 40
@@ -39,7 +39,7 @@ struct Composer: View {
                     placeholder: "Placeholder",
                     viewModel: viewModel,
                     itemProviderHelper: itemProviderHelper,
-                    keyCommandHandler: keyCommandHandler,
+                    keyCommands: keyCommands,
                     pasteHandler: pasteHandler
                 )
                 .frame(height: viewModel.idealHeight)
@@ -76,7 +76,7 @@ struct Composer_Previews: PreviewProvider {
     static var previews: some View {
         Composer(viewModel: viewModel,
                  itemProviderHelper: nil,
-                 keyCommandHandler: nil,
+                 keyCommands: nil,
                  pasteHandler: nil)
     }
 }

--- a/platforms/ios/example/Wysiwyg/Views/ContentView.swift
+++ b/platforms/ios/example/Wysiwyg/Views/ContentView.swift
@@ -89,16 +89,12 @@ struct ContentView: View {
         .frame(width: nil, height: 50, alignment: .center)
         Composer(viewModel: viewModel,
                  itemProviderHelper: nil,
-                 keyCommandHandler: { keyCommand in
-                     switch keyCommand {
-                     case .enter:
+                 keyCommands: [
+                     .enter {
                          sentMessage = viewModel.content
                          viewModel.clearContent()
-                         return true
-                     case .shiftEnter:
-                         return false
-                     }
-                 },
+                     },
+                 ],
                  pasteHandler: { _ in })
             .focused($composerFocused, equals: true)
         ScrollView {

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -24,20 +24,16 @@ protocol WysiwygTextViewDelegate: AnyObject {
     /// - Parameter itemProvider: The item provider.
     /// - Returns: True if it can be pasted, false otherwise.
     func isPasteSupported(for itemProvider: NSItemProvider) -> Bool
-
-    /// Notify the delegate that a key command has been received by the text view.
-    ///
-    /// - Parameters:
-    ///   - textView: Composer text view.
-    ///   - keyCommand: Key command received.
-    func textViewDidReceiveKeyCommand(_ textView: UITextView, keyCommand: WysiwygKeyCommand)
-
+    
     /// Notify the delegate that a paste event has beeb received by the text view.
     ///
     /// - Parameters:
     ///   - textView: Composer text view.
     ///   - provider: Item provider for the paste event.
     func textView(_ textView: UITextView, didReceivePasteWith provider: NSItemProvider)
+    
+    /// The supported key commands for the text view.
+    var keyCommands: [WysiwygKeyCommand]? { get }
 }
 
 /// A markdown protocol used to provide additional context to the text view when displaying mentions through the text attachment provider
@@ -161,15 +157,13 @@ public class WysiwygTextView: UITextView {
     // Enter Key commands support
 
     override public var keyCommands: [UIKeyCommand]? {
-        WysiwygKeyCommand.allCases.map { UIKeyCommand(input: $0.input,
-                                                      modifierFlags: $0.modifierFlags,
-                                                      action: #selector(keyCommandAction)) }
+        wysiwygDelegate?.keyCommands?.map { UIKeyCommand(input: $0.input,
+                                                         modifierFlags: $0.modifierFlags,
+                                                         action: #selector(keyCommandAction)) }
     }
-
+    
     @objc func keyCommandAction(sender: UIKeyCommand) {
-        guard let command = WysiwygKeyCommand.from(sender) else { return }
-
-        wysiwygDelegate?.textViewDidReceiveKeyCommand(self, keyCommand: command)
+        wysiwygDelegate?.keyCommands?.first(where: { $0.input == sender.input && $0.modifierFlags == sender.modifierFlags })?.action()
     }
 
     // Paste support

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -162,7 +162,8 @@ public class WysiwygTextView: UITextView {
                                                          action: #selector(keyCommandAction)) }
     }
     
-    @objc func keyCommandAction(sender: UIKeyCommand) {
+    // This needs to be handled here, if the selector was directly added to the WysiwygKeyCommand it would not work properly.
+    @objc private func keyCommandAction(sender: UIKeyCommand) {
         wysiwygDelegate?.keyCommands?.first(where: { $0.input == sender.input && $0.modifierFlags == sender.modifierFlags })?.action()
     }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygKeyCommand.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygKeyCommand.swift
@@ -16,33 +16,14 @@
 
 import UIKit
 
-/// An enum describing key commands that can be handled by the hosting application.
-/// This can be done by providing a `KeyCommandHandler` to the `WysiwygComposerView`.
-/// If handler is nil, or if the handler returns false, a default behaviour will be applied (see cases description).
-public enum WysiwygKeyCommand: CaseIterable {
-    /// User pressed `enter`. Default behaviour: a line feed is created.
-    /// Note: in the context of a messaging app, this is usually used to send a message.
-    case enter
-    /// User pressed `shift` + `enter`. Default behaviour: a line feed is created.
-    case shiftEnter
-
-    var input: String {
-        switch self {
-        case .enter, .shiftEnter:
-            return "\r"
-        }
+/// An class that describes key commands that can be handled by the hosting application wth their associated action
+public struct WysiwygKeyCommand {
+    /// A default initialiser for the enter command which is most commonly used
+    public static func enter(action: @escaping () -> Void) -> WysiwygKeyCommand {
+        WysiwygKeyCommand(input: "\r", modifierFlags: [], action: action)
     }
-
-    var modifierFlags: UIKeyModifierFlags {
-        switch self {
-        case .enter:
-            return []
-        case .shiftEnter:
-            return .shift
-        }
-    }
-
-    static func from(_ keyCommand: UIKeyCommand) -> WysiwygKeyCommand? {
-        WysiwygKeyCommand.allCases.first(where: { $0.input == keyCommand.input && $0.modifierFlags == keyCommand.modifierFlags })
-    }
+    
+    let input: String
+    let modifierFlags: UIKeyModifierFlags
+    let action: () -> Void
 }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerSnapshotTests/SnapshotTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerSnapshotTests/SnapshotTests.swift
@@ -30,7 +30,7 @@ class SnapshotTests: XCTestCase {
         let composerView = WysiwygComposerView(placeholder: "Placeholder",
                                                viewModel: viewModel,
                                                itemProviderHelper: nil,
-                                               keyCommandHandler: nil,
+                                               keyCommands: nil,
                                                pasteHandler: nil)
         hostingController = UIHostingController(rootView: VStack {
             // Set the composer's text view at the top of the controller.


### PR DESCRIPTION
The issue with the current KeyCommandsHandler, is that even if the key command is set to be false, the command is not really ignored and was stll being handled by the default function, which at the same time was not working properly with plain text mode since it forced an update in the model.

Also the usage of the enter() function was redundant also for the RTE mode, since we already handle the enter directly in the replaceText properly, and we are constraining the usage of the key commands only to the ones we have defined in the library not giving to the users of the library a proper control on which and when they should be and should enabled.

The alternative approach was to disabled the default handling in plain text mode for such commands, but this created two issues:
- The command was still handled by the TextView, which was then preventing the key to use the replace text function in the delegate properly, which means that shift+enter and enter were not doing anything.
- The ignored command was not really ignored at all, but just silently handled in the background, which kinda created a side effect that was not clear to the user of the library


The current solution allows full control and customisation for the key commands while also providing the possibility of creating some default rapid key commands (like .enter) for the general use cases, while also fixing the shift+enter bug in plain text mode.