### PR TITLE
[Android] Add `releaseOnDetach` parameter to `EditorStyledText`

### DIFF
--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
@@ -66,16 +66,16 @@ fun EditorStyledText(
             view.applyStyleInCompose(style)
             view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
             view.typeface = typeface
+            view.onLinkClickedListener = onLinkClickedListener
+            view.onTextLayout = onTextLayout
             if (text is Spanned) {
                 view.setText(text, TextView.BufferType.SPANNABLE)
             } else {
                 view.setHtml(text.toString())
             }
-            view.onLinkClickedListener = onLinkClickedListener
-            view.onTextLayout = onTextLayout
         },
         onReset = { view: EditorStyledTextView ->
             view.setText("", TextView.BufferType.SPANNABLE)
-        }.takeIf { releaseOnDetach },
+        }.takeUnless { releaseOnDetach },
     )
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
@@ -28,7 +28,7 @@ import io.element.android.wysiwyg.display.TextDisplay
  * @param resolveRoomMentionDisplay A function to resolve the [TextDisplay] of an `@room` mention.
  * @param style The styles to use for any customisable elements.
  * @param releaseOnDetach Whether to release the view when the composable is detached from the composition or not.
- * Setting this to `false` is specially useful in Lazy composables that to reuse these views. Defaults to `true`.
+ * Setting this to `false` is specially useful in Lazy composables that need to reuse these views. Defaults to `true`.
  */
 @Composable
 fun EditorStyledText(

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/EditorStyledText.kt
@@ -27,6 +27,8 @@ import io.element.android.wysiwyg.display.TextDisplay
  * @param resolveMentionDisplay A function to resolve the [TextDisplay] of a mention.
  * @param resolveRoomMentionDisplay A function to resolve the [TextDisplay] of an `@room` mention.
  * @param style The styles to use for any customisable elements.
+ * @param releaseOnDetach Whether to release the view when the composable is detached from the composition or not.
+ * Setting this to `false` is specially useful in Lazy composables that to reuse these views. Defaults to `true`.
  */
 @Composable
 fun EditorStyledText(
@@ -37,6 +39,7 @@ fun EditorStyledText(
     onLinkClickedListener: ((String) -> Unit) = {},
     onTextLayout: (Layout) -> Unit = {},
     style: RichTextEditorStyle = RichTextEditorDefaults.style(),
+    releaseOnDetach: Boolean = true,
 ) {
     val typeface by style.text.rememberTypeface()
     val mentionDisplayHandler = remember(resolveMentionDisplay, resolveRoomMentionDisplay) {
@@ -70,6 +73,9 @@ fun EditorStyledText(
             }
             view.onLinkClickedListener = onLinkClickedListener
             view.onTextLayout = onTextLayout
-        }
+        },
+        onReset = { view: EditorStyledTextView ->
+            view.setText("", TextView.BufferType.SPANNABLE)
+        }.takeIf { releaseOnDetach },
     )
 }


### PR DESCRIPTION
Adds a `releaseOnDetach` parameter so the view can be reused in Lazy composables when it's set to `false`.