### PR TITLE
Android: add IME rich content compatibility

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -60,6 +60,15 @@ internal class InterceptInputConnection(
         return baseInputConnection.commitCorrection(correctionInfo)
     }
 
+    @RequiresApi(Build.VERSION_CODES.N_MR1)
+    override fun commitContent(
+        inputContentInfo: InputContentInfo,
+        flags: Int,
+        opts: Bundle?
+    ): Boolean {
+        return baseInputConnection.commitContent(inputContentInfo, flags, opts)
+    }
+
     override fun performEditorAction(actionCode: Int): Boolean {
         return baseInputConnection.performEditorAction(actionCode)
     }


### PR DESCRIPTION
This is enabled on API >= 25 (Android 7.1).

I had one device on Android 11 that was refusing to consume any rich content (images, stickers, etc.) from Gboard, while it worked on every other device and emulator I tried. With this change, it works.