### PR TITLE
Fix: Ending dictation crashes RTE

### DIFF
--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -72,12 +72,12 @@ public class WysiwygTextView: UITextView {
     }
     
     override public func dictationRecordingDidEnd() {
-        super.dictationRecordingDidEnd()
+        // Do not call super, this is an optional objc protocol
         isDictationRunning = false
     }
     
     override public func dictationRecognitionFailed() {
-        super.dictationRecognitionFailed()
+        // Do not call super this is an optional objc protocol
         isDictationRunning = false
     }
 


### PR DESCRIPTION
This is caused by a call to `super` in an override that is actually an optional objc protocol func in disguise, making the super call actually call an unused selector