### PR TITLE
Remove NBSP chars in `replace_text` for empty paragraphs

### DIFF
--- a/crates/wysiwyg/src/composer_model/replace_text.rs
+++ b/crates/wysiwyg/src/composer_model/replace_text.rs
@@ -207,7 +207,7 @@ where
             let mut slices = text_string.split('\n').peekable();
             while let Some(slice) = slices.next() {
                 let (s, e) = self.safe_selection();
-                if !slice.is_empty() {
+                if !slice.is_empty() && slice != "\u{A0}" {
                     self.do_replace_text_in(S::from(slice), s, e);
                 }
                 if slices.peek().is_some() {

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -262,7 +262,8 @@ fn replacing_text_with_empty_paragraphs_removes_nbsps_from_them() {
 ├>p
 └>p
   └>"2"
-"#);
+"#
+    );
 }
 
 #[test]

--- a/crates/wysiwyg/src/tests/test_characters.rs
+++ b/crates/wysiwyg/src/tests/test_characters.rs
@@ -251,6 +251,21 @@ fn multiple_spaces_between_text() {
 }
 
 #[test]
+fn replacing_text_with_empty_paragraphs_removes_nbsps_from_them() {
+    let mut model = cm("|");
+    replace_text(&mut model, "1\n\u{A0}\n2");
+    assert_eq!(
+        model.to_tree().to_string(),
+        r#"
+├>p
+│ └>"1"
+├>p
+└>p
+  └>"2"
+"#);
+}
+
+#[test]
 fn typing_html_does_not_break_anything() {
     let mut model = cm("|");
     replace_text(&mut model, "<");


### PR DESCRIPTION
This should fix the issue about the extra NBSPs being added when pasting text.