### PR TITLE
Android: try to get AVD action working again

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -84,6 +84,7 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           enable-hw-keyboard: true
+          disk-size: 3g
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run all tests with coverage

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -53,8 +53,6 @@ jobs:
           ANDROID_NDK_TOOLCHAIN_DIR: ${{ env.ANDROID_NDK_HOME }}/toolchains
         with:
           build-root-directory: platforms/android
-          arguments: |
-            :library:assembleDebugUnitTest :library:assembleDebugAndroidTest ${{ env.CI_GRADLE_ARG_PROPERTIES }}
           cache-read-only: false
 
       - name: Enable KVM group perms

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorStyledTextViewTest.kt
@@ -8,7 +8,6 @@ import android.widget.TextView
 import androidx.core.text.buildSpannedString
 import androidx.core.text.inSpans
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -17,11 +16,13 @@ import io.element.android.wysiwyg.test.R
 import io.element.android.wysiwyg.test.utils.FakeLinkClickedListener
 import io.element.android.wysiwyg.test.utils.TestActivity
 import io.element.android.wysiwyg.test.utils.TextViewActions
+import io.element.android.wysiwyg.test.utils.clickXY
 import io.element.android.wysiwyg.view.spans.CustomMentionSpan
 import io.element.android.wysiwyg.view.spans.LinkSpan
 import io.element.android.wysiwyg.view.spans.PillSpan
 import org.junit.Rule
 import org.junit.Test
+
 
 internal class EditorStyledTextViewTest {
 
@@ -71,7 +72,7 @@ internal class EditorStyledTextViewTest {
             .perform(TextViewActions.setText(urlSpanText, TextView.BufferType.SPANNABLE))
             .perform(TextViewActions.setOnLinkClickedListener(fakeLinkClickedListener))
             .check(matches(withText(HELLO_WORLD)))
-            .perform(ViewActions.click())
+            .perform(clickXY(0f, 0f))
 
         fakeLinkClickedListener.assertLinkClicked(url = URL)
     }
@@ -87,7 +88,7 @@ internal class EditorStyledTextViewTest {
             .perform(TextViewActions.setText(linkSpanText, TextView.BufferType.SPANNABLE))
             .perform(TextViewActions.setOnLinkClickedListener(fakeLinkClickedListener))
             .check(matches(withText(HELLO_WORLD)))
-            .perform(ViewActions.click())
+            .perform(clickXY(0f, 0f))
 
         fakeLinkClickedListener.assertLinkClicked(url = URL)
     }
@@ -103,7 +104,7 @@ internal class EditorStyledTextViewTest {
             .perform(TextViewActions.setText(pillSpanText, TextView.BufferType.SPANNABLE))
             .perform(TextViewActions.setOnLinkClickedListener(fakeLinkClickedListener))
             .check(matches(withText(HELLO_WORLD)))
-            .perform(ViewActions.click())
+            .perform(clickXY(0f, 0f))
 
         fakeLinkClickedListener.assertLinkClicked(url = URL)
     }
@@ -119,7 +120,7 @@ internal class EditorStyledTextViewTest {
             .perform(TextViewActions.setText(mentionSpanText, TextView.BufferType.SPANNABLE))
             .perform(TextViewActions.setOnLinkClickedListener(fakeLinkClickedListener))
             .check(matches(withText(HELLO_WORLD)))
-            .perform(ViewActions.click())
+            .perform(clickXY(0f, 0f))
 
         fakeLinkClickedListener.assertLinkClicked(url = URL)
     }
@@ -130,15 +131,16 @@ internal class EditorStyledTextViewTest {
             .perform(TextViewActions.setHtml(MENTION_HTML))
             .perform(TextViewActions.setOnLinkClickedListener(fakeLinkClickedListener))
             .check(matches(withText(MENTION_TEXT)))
-            .perform(ViewActions.click())
+            .perform(clickXY(0f, 0f))
 
         fakeLinkClickedListener.assertLinkClicked(MENTION_URI)
     }
 }
 
 object DummyReplacementSpan : ReplacementSpan() {
-    override fun getSize(paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int = 1
+    override fun getSize(paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int = 100
 
     override fun draw(canvas: Canvas, text: CharSequence?, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint)  = Unit
 
 }
+

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/ClickActions.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/test/utils/ClickActions.kt
@@ -1,0 +1,23 @@
+package io.element.android.wysiwyg.test.utils
+
+import android.view.InputDevice
+import android.view.MotionEvent
+import androidx.test.espresso.action.GeneralClickAction
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.action.Tap
+
+fun clickXY(x: Float, y: Float): GeneralClickAction {
+    return GeneralClickAction(
+        Tap.SINGLE,
+        { view ->
+            val screenPos = IntArray(2)
+            view.getLocationOnScreen(screenPos)
+            val screenX = screenPos[0] + x
+            val screenY = screenPos[1] + y
+            floatArrayOf(screenX, screenY)
+        },
+        Press.FINGER,
+        InputDevice.SOURCE_MOUSE,
+        MotionEvent.BUTTON_PRIMARY,
+    )
+}


### PR DESCRIPTION
After some changes in the available space in the GH runners, the Android emulator job was failing because there was not enough space.

This PR contains the next changes:
- We were downloading the Android SDK twice: once when setting up Gradle and another when launching the emulator action. This takes *lots* of disk space and was the main source of issues. Since we can't stop the AVD action from re-downloading the SDK, we'll avoid pre-building the tests so the first SDK download is skipped instead.
- Downsized the Android emulator's data partition to 3GB (in theory, I'm not confident this is actually changing anything).
- Fix the broken UI tests introduced in #937 (my bad!) since the tests were skipped there because of this issue.