### PR TITLE
Bump Rust version to 1.76 (stable) to fix WASM issues

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -61,30 +61,6 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: AVD cache
-        uses: actions/cache@v3
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
-
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          working-directory: platforms/android
-          api-level: ${{ matrix.api-level }}
-          profile: ${{ env.DEVICE }}
-          arch: ${{ env.ARCH }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          enable-hw-keyboard: true
-          disk-size: 3G
-          script: echo "Generated AVD snapshot for caching."
-
       - name: Run all tests with coverage
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -82,7 +82,7 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           enable-hw-keyboard: true
-          disk-size: 3g
+          disk-size: 3G
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run all tests with coverage
@@ -96,6 +96,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           enable-hw-keyboard: true
+          disk-size: 3G
           script: |
             chmod +x scripts/ci_test.sh
             scripts/ci_test.sh

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.71
+        toolchain: 1.76
         profile: minimal
         override: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.71
+          toolchain: 1.76
           profile: minimal
           override: true
           

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set Version
-      run: rustup default 1.74
+      run: rustup default 1.76
     - name: Set Component 
       run: rustup component add rustfmt clippy
     - name: Format

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set Version
-      run: rustup default 1.71
+      run: rustup default 1.74
     - name: Set Component 
       run: rustup component add rustfmt clippy
     - name: Format

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set Version
-      run: rustup default 1.71
+      run: rustup default 1.76
     - name: Install `wasm-pack`
       run: cargo install wasm-pack
     - name: Test the `wysiwyg` crate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,12 +240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.42"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -620,24 +614,22 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.1.44"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
+ "autocfg",
  "num-integer",
  "num-traits",
- "rand 0.4.6",
- "rustc-serialize",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.1.43"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -663,21 +655,21 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.1.42"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
+ "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
- "rustc-serialize",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -866,19 +858,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -924,21 +903,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -971,15 +935,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1086,12 +1041,6 @@ dependencies = [
  "syn 1.0.103",
  "toml 0.7.4",
 ]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustix"
@@ -1236,9 +1185,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "speculoos"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bcff6a72e2ddfb09ce0064568857e70d3cf6f4342244ebb1f84fa6f89b16c26"
+checksum = "65881c9270d6157f30a09233305da51bed97eef9192d0ea21e57b1c8f05c3620"
 dependencies = [
  "num",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,19 +250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "windows",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,9 +279,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
 dependencies = [
  "log",
  "plain",
@@ -457,12 +444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "984e109462d46ad18314f10e392c286c3d47bce203088a09012de1015b45b737"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,20 +475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
-dependencies = [
- "cfg-if",
- "generator",
- "pin-utils",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,15 +492,6 @@ dependencies = [
  "string_cache",
  "string_cache_codegen",
  "tendril",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -586,16 +544,6 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
 ]
 
 [[package]]
@@ -681,19 +629,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
-name = "oneshot"
+name = "oneshot-uniffi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6640c6bda7731b1fdbab747981a0f896dd1fedaf9f4a53fa237a04a84431f4"
-dependencies = [
- "loom",
-]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+checksum = "6c548d5c78976f6955d72d0ced18c48ca07030f7a1d4024529fedd7c1c01b29c"
 
 [[package]]
 name = "parking_lot"
@@ -792,12 +731,6 @@ name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plain"
@@ -954,17 +887,8 @@ checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -975,14 +899,8 @@ checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1082,22 +1000,22 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1163,15 +1081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1091,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "speculoos"
@@ -1292,6 +1207,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,16 +1235,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.27",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1409,36 +1325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1463,6 +1349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,10 +1370,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
-name = "uniffi"
-version = "0.25.2"
+name = "unicode-width"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e192430644d99babe02bede25316eee84fa154b1e5f8cfe99406c028b8c577"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "uniffi"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
 dependencies = [
  "anyhow",
  "camino",
@@ -1512,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c235355da41bc8347b2d5851e1060d4652dfbdc6d7d6ccddaabebe25e3c32a4"
+checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
 dependencies = [
  "anyhow",
  "askama",
@@ -1528,6 +1426,7 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
+ "textwrap",
  "toml 0.5.9",
  "uniffi_meta",
  "uniffi_testing",
@@ -1536,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81049ed7015a8a66b085aca3fb0c0011fdae4dd9ab8c38f5751f7861d60eb0f4"
+checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
 dependencies = [
  "anyhow",
  "camino",
@@ -1547,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce082833f0fcaf6fc221fbab26720440daf99381f5a71e89b6e23375eb6ea770"
+checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote",
  "syn 2.0.27",
@@ -1557,25 +1456,25 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389bbe4d8334b3370c7cc998788d7a9619e0b61b58f1cbcd4a6a8606ab0a6f7d"
+checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
 dependencies = [
  "anyhow",
  "bytes",
  "camino",
  "log",
  "once_cell",
- "oneshot",
+ "oneshot-uniffi",
  "paste",
  "static_assertions",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa170f970d42d8fbe205f5794b83f72d6617835a73b91ed1869e1eba5dd06c"
+checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
 dependencies = [
  "bincode",
  "camino",
@@ -1592,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ef337c28a379ed6962eae0cb0824ab31202b21b8ae3bf6c2a706f5e7285f5f"
+checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1604,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2e218997229b4ed6e08c1abc9e277dde817f68a633babd3ebbfc77e32db302"
+checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
 dependencies = [
  "anyhow",
  "camino",
@@ -1617,11 +1516,12 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb29909e50256f32986ea3b3c32d2c49dece14ae4b3428c047913696ed200b2a"
+checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
 dependencies = [
  "anyhow",
+ "textwrap",
  "uniffi_meta",
  "uniffi_testing",
  "weedle2",
@@ -1649,12 +1549,6 @@ name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -1776,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "weedle2"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]
@@ -1825,15 +1719,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.71"
+rust-version = "1.76"
 
 [workspace.dependencies]
 uniffi = "0.25.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ resolver = "2"
 rust-version = "1.76"
 
 [workspace.dependencies]
-uniffi = "0.25.2"
-uniffi_macros = "0.25.2"
-uniffi_build = "0.25.2"
+uniffi = "0.26.1"
+uniffi_macros = "0.26.1"
+uniffi_build = "0.26.1"
 
 [profile.release]
 opt-level = 'z'     # Optimize for size.

--- a/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
+++ b/bindings/wysiwyg-ffi/src/ffi_composer_update.rs
@@ -231,9 +231,11 @@ mod test {
     // https://github.com/matrix-org/matrix-rich-text-editor/issues/709
     fn insert_mention_at_cursor(model: &mut Arc<ComposerModel>) {
         let update = model.replace_text("@alic".into());
-        let MenuAction::Suggestion{suggestion_pattern} = update.menu_action() else {
-        panic!("No suggestion pattern found")
-    };
+        let MenuAction::Suggestion { suggestion_pattern } =
+            update.menu_action()
+        else {
+            panic!("No suggestion pattern found")
+        };
         model.insert_mention_at_suggestion(
             "https://matrix.to/#/@alice:matrix.org".into(),
             "Alice".into(),

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -35,7 +35,7 @@ regex="1.9.5"
 matrix_mentions = { path = "../matrix_mentions" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-speculoos = "0.9"
+speculoos = "0.11.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.33"

--- a/crates/wysiwyg/src/composer_model/code_block.rs
+++ b/crates/wysiwyg/src/composer_model/code_block.rs
@@ -31,28 +31,41 @@ where
 
     fn add_code_block(&mut self) -> ComposerUpdate<S> {
         let (s, e) = self.safe_selection();
-        let Some(wrap_result) = self.state.dom.find_nodes_to_wrap_in_block(s, e) else {
+        let Some(wrap_result) =
+            self.state.dom.find_nodes_to_wrap_in_block(s, e)
+        else {
             // No suitable nodes found to be wrapped inside the code block. Add an empty block.
             let range = self.state.dom.find_range(s, e);
             let leaves: Vec<&DomLocation> = range.leaves().collect();
-            let node = DomNode::new_code_block(vec![DomNode::new_paragraph(Vec::new())]);
+            let node = DomNode::new_code_block(vec![DomNode::new_paragraph(
+                Vec::new(),
+            )]);
             if leaves.is_empty() {
-                if let Some(deepest_block_location) = range.deepest_block_node(None) {
-                    let mut block_node = self.state.dom.remove(&deepest_block_location.node_handle);
+                if let Some(deepest_block_location) =
+                    range.deepest_block_node(None)
+                {
+                    let mut block_node = self
+                        .state
+                        .dom
+                        .remove(&deepest_block_location.node_handle);
                     let node = if block_node.is_list_item() {
                         let list_item = block_node.as_container_mut().unwrap();
                         let children = list_item.remove_children();
-                        let children = if children.iter().all(|c| !c.is_block_node()) {
-                            vec![DomNode::new_paragraph(children)]
-                        } else {
-                            children
-                        };
-                        list_item.append_child(DomNode::new_code_block(children));
+                        let children =
+                            if children.iter().all(|c| !c.is_block_node()) {
+                                vec![DomNode::new_paragraph(children)]
+                            } else {
+                                children
+                            };
+                        list_item
+                            .append_child(DomNode::new_code_block(children));
                         block_node
                     } else {
                         DomNode::new_code_block(vec![block_node])
                     };
-                    self.state.dom.insert_at(&deepest_block_location.node_handle, node);
+                    self.state
+                        .dom
+                        .insert_at(&deepest_block_location.node_handle, node);
                 } else {
                     self.state.dom.append_at_end_of_document(node);
                 }
@@ -61,7 +74,7 @@ where
                 let insert_at = if first_leaf_loc.is_start() {
                     first_leaf_loc.node_handle.next_sibling()
                 } else {
-                   first_leaf_loc.node_handle.clone()
+                    first_leaf_loc.node_handle.clone()
                 };
                 self.state.dom.insert_at(&insert_at, node);
             }
@@ -161,7 +174,9 @@ where
     fn remove_code_block(&mut self) -> ComposerUpdate<S> {
         let (s, e) = self.safe_selection();
         let range = self.state.dom.find_range(s, e);
-        let Some(block_location) = range.locations.iter().find(|l| l.kind == CodeBlock) else {
+        let Some(block_location) =
+            range.locations.iter().find(|l| l.kind == CodeBlock)
+        else {
             return ComposerUpdate::keep();
         };
 

--- a/crates/wysiwyg/src/composer_model/lists.rs
+++ b/crates/wysiwyg/src/composer_model/lists.rs
@@ -307,7 +307,7 @@ where
         self.indent_list_item_handles(&handles);
     }
 
-    fn indent_list_item_handles(&mut self, handles: &Vec<DomHandle>) {
+    fn indent_list_item_handles(&mut self, handles: &[DomHandle]) {
         // Pre-checks
         if handles.is_empty() {
             return;
@@ -326,10 +326,10 @@ where
         }
 
         // Sort handles to avoid issues where we delete a former handle so the rest become invalid
-        let mut sorted_handles = handles.clone();
+        let mut sorted_handles = handles.to_owned();
         sorted_handles.sort();
 
-        let first_handle = sorted_handles.get(0).unwrap();
+        let first_handle = sorted_handles.first().unwrap();
         let insert_into_handle = first_handle.prev_sibling();
 
         let parent_list_type = self
@@ -377,7 +377,7 @@ where
         self.unindent_handles(&handles);
     }
 
-    fn unindent_handles(&mut self, handles: &Vec<DomHandle>) {
+    fn unindent_handles(&mut self, handles: &[DomHandle]) {
         // Pre-checks
         if handles.is_empty() {
             return;
@@ -396,7 +396,7 @@ where
         }
 
         // Sort handles to avoid issues where we delete a former handle so the rest become invalid
-        let mut sorted_handles = handles.clone();
+        let mut sorted_handles = handles.to_owned();
         sorted_handles.sort();
 
         // We should always insert the new List inside the next ListItem sibling

--- a/crates/wysiwyg/src/composer_model/new_lines.rs
+++ b/crates/wysiwyg/src/composer_model/new_lines.rs
@@ -240,7 +240,8 @@ where
             // Now do the same for any children remaining in the tree
             if !block_node_is_paragraph {
                 let DomNode::Container(block_container) =
-                    self.state.dom.lookup_node_mut(&block_node_handle) else {
+                    self.state.dom.lookup_node_mut(&block_node_handle)
+                else {
                     panic!("Block container must be a container node");
                 };
                 let mut children = Vec::new();

--- a/crates/wysiwyg/src/composer_model/quotes.rs
+++ b/crates/wysiwyg/src/composer_model/quotes.rs
@@ -32,24 +32,34 @@ where
 
     fn add_quote(&mut self) -> ComposerUpdate<S> {
         let (s, e) = self.safe_selection();
-        let Some(wrap_result) = self.state.dom.find_nodes_to_wrap_in_block(s, e) else {
+        let Some(wrap_result) =
+            self.state.dom.find_nodes_to_wrap_in_block(s, e)
+        else {
             // No nodes to be wrapped found.
             // Adding an empty Quote block with a paragraph
             let range = self.state.dom.find_range(s, e);
             let leaves: Vec<&DomLocation> = range.leaves().collect();
-            let node = DomNode::new_quote(vec![DomNode::new_paragraph(Vec::new())]);
+            let node =
+                DomNode::new_quote(vec![DomNode::new_paragraph(Vec::new())]);
             if leaves.is_empty() {
-                if let Some(deepest_block_location) = range.deepest_block_node(None) {
-                    let mut block_node = self.state.dom.remove(&deepest_block_location.node_handle);
+                if let Some(deepest_block_location) =
+                    range.deepest_block_node(None)
+                {
+                    let mut block_node = self
+                        .state
+                        .dom
+                        .remove(&deepest_block_location.node_handle);
                     let node = if block_node.is_list_item() {
                         let list_item = block_node.as_container_mut().unwrap();
                         let children = list_item.remove_children();
                         list_item.append_child(DomNode::new_quote(children));
                         block_node
                     } else {
-                         DomNode::new_quote(vec![block_node])
+                        DomNode::new_quote(vec![block_node])
                     };
-                    self.state.dom.insert_at(&deepest_block_location.node_handle, node);
+                    self.state
+                        .dom
+                        .insert_at(&deepest_block_location.node_handle, node);
                 } else {
                     self.state.dom.append_at_end_of_document(node);
                 }
@@ -122,7 +132,9 @@ where
     fn remove_quote(&mut self) -> ComposerUpdate<S> {
         let (s, e) = self.safe_selection();
         let range = self.state.dom.find_range(s, e);
-        let Some(quote_location) = range.locations.iter().find(|l| l.kind == Quote) else {
+        let Some(quote_location) =
+            range.locations.iter().find(|l| l.kind == Quote)
+        else {
             return ComposerUpdate::keep();
         };
 

--- a/crates/wysiwyg/src/dom/dom_list_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_list_methods.rs
@@ -198,7 +198,9 @@ where
         let list_item = self.lookup_node_mut(handle);
         let slice = list_item.slice_after(offset);
         let list = self.lookup_node_mut(&handle.parent_handle());
-        let DomNode::Container(list) = list else { panic!("List node is not a container") };
+        let DomNode::Container(list) = list else {
+            panic!("List node is not a container")
+        };
         list.insert_child(handle.index_in_parent() + 1, slice);
         self.join_nodes_in_container(&handle.parent_handle());
     }

--- a/crates/wysiwyg/src/dom/dom_methods.rs
+++ b/crates/wysiwyg/src/dom/dom_methods.rs
@@ -751,7 +751,9 @@ where
         &mut self,
         container_handle: &DomHandle,
     ) {
-        let DomNode::Container(container) = self.lookup_node_mut(container_handle) else {
+        let DomNode::Container(container) =
+            self.lookup_node_mut(container_handle)
+        else {
             return;
         };
 
@@ -1129,10 +1131,12 @@ where
 
 fn first_shrinkable_link_node_handle(range: &Range) -> Option<&DomLocation> {
     let Some(link_loc) = range.locations.iter().find(|loc| {
-            loc.kind == DomNodeKind::Link && !loc.is_covered() && (loc.is_start() || loc.leading_is_end())
-        }) else {
-            return None
-        };
+        loc.kind == DomNodeKind::Link
+            && !loc.is_covered()
+            && (loc.is_start() || loc.leading_is_end())
+    }) else {
+        return None;
+    };
     Some(link_loc)
 }
 

--- a/crates/wysiwyg/src/dom/dom_struct.rs
+++ b/crates/wysiwyg/src/dom/dom_struct.rs
@@ -276,7 +276,7 @@ where
     ) -> Vec<DomHandle> {
         let node = self.lookup_node(node_handle);
         let Some(parent) = node.as_container() else {
-            return vec![]
+            return vec![];
         };
         let ret = self.replace(node_handle, parent.children().clone());
         self.join_nodes_in_container(&node_handle.parent_handle());

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -105,16 +105,15 @@ where
     pub fn new_formatting_from_tag(
         format: S,
         children: Vec<DomNode<S>>,
-    ) -> Option<Self> {
-        InlineFormatType::try_from(format.clone())
-            .map(|f| Self {
-                name: format,
-                kind: ContainerNodeKind::Formatting(f),
-                attrs: None,
-                children,
-                handle: DomHandle::new_unset(),
-            })
-            .ok()
+    ) -> Self {
+        let format_type = InlineFormatType::from(format.clone());
+        Self {
+            name: format,
+            kind: ContainerNodeKind::Formatting(format_type),
+            attrs: None,
+            children,
+            handle: DomHandle::new_unset(),
+        }
     }
 
     pub fn new_formatting(
@@ -462,7 +461,7 @@ where
     /// Returns whether this container first text-like
     /// child is a line break.
     pub fn has_leading_line_break(&self) -> bool {
-        let Some(first_child) = self.children.get(0) else {
+        let Some(first_child) = self.children.first() else {
             return false;
         };
         first_child.has_leading_line_break()

--- a/crates/wysiwyg/src/dom/nodes/container_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/container_node.rs
@@ -419,7 +419,7 @@ where
 
     pub(crate) fn get_link_url(&self) -> Option<S> {
         let ContainerNodeKind::Link(url) = self.kind.clone() else {
-            return None
+            return None;
         };
         Some(url)
     }

--- a/crates/wysiwyg/src/dom/nodes/dom_node.rs
+++ b/crates/wysiwyg/src/dom/nodes/dom_node.rs
@@ -73,10 +73,10 @@ where
         format: S,
         children: Vec<DomNode<S>>,
     ) -> DomNode<S> {
-        DomNode::Container(
-            ContainerNode::new_formatting_from_tag(format.clone(), children)
-                .unwrap_or_else(|| panic!("Unknown format tag {format}")),
-        )
+        DomNode::Container(ContainerNode::new_formatting_from_tag(
+            format.clone(),
+            children,
+        ))
     }
 
     pub fn new_list(

--- a/crates/wysiwyg/src/dom/parser/markdown.rs
+++ b/crates/wysiwyg/src/dom/parser/markdown.rs
@@ -1,3 +1,4 @@
 pub mod markdown_html_parser;
 
+#[allow(unused_imports)]
 pub use markdown_html_parser::MarkdownHTMLParser;

--- a/crates/wysiwyg/src/dom/parser/markdown/markdown_html_parser.rs
+++ b/crates/wysiwyg/src/dom/parser/markdown/markdown_html_parser.rs
@@ -77,6 +77,6 @@ impl MarkdownHTMLParser {
             // of a formatted codeblock
             .replace("\n</code>", "</code>");
 
-        Ok(S::try_from(html).unwrap())
+        Ok(S::from(html))
     }
 }

--- a/crates/wysiwyg/src/dom/parser/parse.rs
+++ b/crates/wysiwyg/src/dom/parser/parse.rs
@@ -200,7 +200,7 @@ mod sys {
                         _ => None,
                     };
 
-                    if is_mention && matches!(text, Some(_)) {
+                    if is_mention && text.is_some() {
                         self.current_path.push(DomNodeKind::Mention);
                         let mention = Self::new_mention(child, text.unwrap());
                         node.append_child(mention);
@@ -280,10 +280,10 @@ mod sys {
         where
             S: UnicodeString,
         {
-            DomNode::Container(
-                ContainerNode::new_formatting_from_tag(tag.into(), Vec::new())
-                    .unwrap_or_else(|| panic!("Unknown format tag {}", tag)),
-            )
+            DomNode::Container(ContainerNode::new_formatting_from_tag(
+                tag.into(),
+                Vec::new(),
+            ))
         }
 
         /// Create a br node
@@ -341,7 +341,7 @@ mod sys {
             S: UnicodeString,
         {
             DomNode::Container(ContainerNode::new_list(
-                ListType::try_from(S::from(tag)).unwrap(),
+                ListType::from(S::from(tag)),
                 Vec::new(),
             ))
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.71"
+channel = "1.76"
 components = ["rustfmt"]


### PR DESCRIPTION
Changes:
- Bump Rust to `v1.76` and fix the clippy issues found.
- Bump UniFFi to `v0.26.1`. To be compatible.
- Bump `speculoos` dependency since it became incompatible.
- Remove AVD cache from the Android CI, reduce the AVD `data` partition size to 3GB.