### PR TITLE
Avoid dispatching to text watcher an empty text when calling replaceAll

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.test.core.app.ApplicationProvider
+import io.element.android.wysiwyg.EditorEditText
 import io.element.android.wysiwyg.fakes.createFakeStyleConfig
 import io.element.android.wysiwyg.internal.viewmodel.EditorInputAction
 import io.element.android.wysiwyg.internal.viewmodel.EditorViewModel
@@ -33,6 +34,7 @@ class InterceptInputConnectionIntegrationTest {
         viewModel = viewModel,
         editorEditText = textView,
         baseInputConnection = textView.onCreateInputConnection(EditorInfo()),
+        suspendableTextWatcher = EditorEditText.TextWatcherWrapper(),
     )
 
     private val baseEditedSpans = listOf(

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/SuspendableTextWatcher.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/SuspendableTextWatcher.kt
@@ -1,0 +1,11 @@
+package io.element.android.wysiwyg.utils
+
+import android.text.TextWatcher
+
+/**
+ * A TextWatcher that can be suspended.
+ * When suspended, the TextWatcher will not dispatch any events.
+ */
+internal interface SuspendableTextWatcher : TextWatcher {
+    fun pause(block: () -> Unit)
+}


### PR DESCRIPTION
We have a custom `InterceptInputConnection` and to avoid messing up with selection/composition spans, we are calling sequentially : 
```
editable.clear
editable.append
```
Which causes registered text watchers to get an empty string which shouldn't be dispatched.

This PR introduce a `TextWatcher` which can be temporary disabled.

I don't want the burden of filtering this events on the client side.