### PR TITLE
Version 2.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# [2.30.0] - 2024-01-04
+- [Rust] Bumped Rust version to `1.76`.
+- [Rust] Bumped UniFFi to `v0.26.1`.
+- [Rust] Bumped speculoos to `0.11.0`.
+- [Android] Fix touch handling for links: the listener should only fire once per click and tapping on an empty space next to a link wrapping several lines should not fire it.
+
 # [2.29.0] - 2024-02-08
 ### Changed
 - [iOS] Improved the textView injection process in the view model.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "2.29.0"
+version = "2.30.0"
 dependencies = [
  "matrix_mentions",
  "uniffi",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg"
-version = "2.29.0"
+version = "2.30.0"
 dependencies = [
  "cfg-if",
  "email_address",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "2.29.0"
+version = "2.30.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -7,7 +7,7 @@ description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
 name = "uniffi-wysiwyg-composer"
-version = "2.29.0"
+version = "2.30.0"
 rust-version = { workspace = true }
 
 [features]

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASM bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
 name = "wysiwyg-wasm"
-version = "2.29.0"
+version = "2.30.0"
 rust-version = { workspace = true }
 
 [package.metadata.wasm-pack.profile.profiling]

--- a/bindings/wysiwyg-wasm/package-lock.json
+++ b/bindings/wysiwyg-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wysiwyg-wasm",
-      "version": "2.29.0",
+      "version": "2.30.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^28.1.0",

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "homepage": "https://gitlab.com/andybalaam/wysiwyg-rust",
   "description": "WASM bindings for wysiwyg-rust",
   "license": "Apache-2.0",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -7,7 +7,7 @@ description = "Model code to power a rich text editor for Matrix"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
 name = "wysiwyg"
-version = "2.29.0"
+version = "2.30.0"
 rust-version = { workspace = true }
 
 [features]

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -27,7 +27,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=io.element.android
 # POM_ARTIFACT_ID is configured in each module's gradle.properties
-VERSION_NAME=2.29.0
+VERSION_NAME=2.30.0
 
 POM_NAME=Matrix WYSIWYG
 POM_DESCRIPTION=Cross-platform rich text editor that generates HTML output.

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-wysiwyg",
-    "version": "2.29.0",
+    "version": "2.30.0",
     "type": "module",
     "description": "Wysiwyg composer for matrix.org using React",
     "author": "matrix.org",


### PR DESCRIPTION
Changes:

- [Rust] Bumped Rust version to `1.76`.
- [Rust] Bumped UniFFi to `v0.26.1`.
- [Rust] Bumped speculoos to `0.11.0`.
- [Android] Fix touch handling for links: the listener should only fire once per click and tapping on an empty space next to a link wrapping several lines should not fire it.