### PR TITLE
[iOS] Disabling auto correction

### DIFF
--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Autocorrection.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Autocorrection.swift
@@ -17,7 +17,7 @@
 import XCTest
 
 extension WysiwygUITests {
-    func testRichTextModeAutocorrection() throws {
+    func disable_testRichTextModeAutocorrection() throws {
         textView.typeTextCharByChar("/")
         XCTAssertFalse(image(.autocorrectionIndicator).exists)
         textView.typeText(XCUIKeyboardKey.delete.rawValue)
@@ -29,7 +29,7 @@ extension WysiwygUITests {
         XCTAssertTrue(image(.autocorrectionIndicator).exists)
     }
 
-    func testPlainTextModeAutocorrection() throws {
+    func disable_testPlainTextModeAutocorrection() throws {
         waitForButtonToExistAndTap(.plainRichButton)
         textView.typeTextCharByChar("/")
         XCTAssertFalse(image(.autocorrectionIndicator).exists)

--- a/platforms/ios/example/WysiwygUITests/WysiwygUITests+Autocorrection.swift
+++ b/platforms/ios/example/WysiwygUITests/WysiwygUITests+Autocorrection.swift
@@ -42,12 +42,12 @@ extension WysiwygUITests {
         XCTAssertTrue(image(.autocorrectionIndicator).exists)
     }
 
-    func testRichTextModeNonLeadingCommand() throws {
+    func disable_testRichTextModeNonLeadingCommand() throws {
         textView.typeTextCharByChar("text /not_a_command")
         XCTAssertTrue(image(.autocorrectionIndicator).exists)
     }
 
-    func testPlainTextModeNonLeadingCommand() throws {
+    func disable_testPlainTextModeNonLeadingCommand() throws {
         waitForButtonToExistAndTap(.plainRichButton)
         textView.typeTextCharByChar("text /not_a_command")
         XCTAssertTrue(image(.autocorrectionIndicator).exists)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerView.swift
@@ -203,7 +203,8 @@ struct UITextViewWrapper: UIViewRepresentable {
                 functionName: #function
             )
             didUpdateText()
-            textView.toggleAutocorrectionIfNeeded()
+            // Disabled always until we fix the predictive text issue
+//            textView.toggleAutocorrectionIfNeeded()
             textView.invalidateIntrinsicContentSize()
         }
 

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -29,12 +29,16 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
     /// The textView that the model currently manages, a default text view is provided, but you should always inject it from the UIWrapper
     public lazy var textView = {
         let textView = WysiwygTextView()
+        // Disabled until we fix the issue with the predictive text
+        textView.autocorrectionType = .no
         textView.linkTextAttributes[.foregroundColor] = parserStyle.linkColor
         textView.mentionDisplayHelper = mentionDisplayHelper
         textView.apply(attributedContent)
         return textView
     }() {
         didSet {
+            // Disabled until we fix the issue with the predictive text
+            textView.autocorrectionType = .no
             textView.linkTextAttributes[.foregroundColor] = parserStyle.linkColor
             textView.mentionDisplayHelper = mentionDisplayHelper
             textView.apply(attributedContent)

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -137,7 +137,7 @@ public class WysiwygTextView: UITextView {
         }
         didSet {
             // Disabled until we fix the predictive text issue
-            //toggleAutocorrectionIfNeeded()
+            // toggleAutocorrectionIfNeeded()
             delegate?.textViewDidChange?(self)
         }
     }

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygTextView.swift
@@ -136,7 +136,8 @@ public class WysiwygTextView: UITextView {
             flusher.flush()
         }
         didSet {
-            toggleAutocorrectionIfNeeded()
+            // Disabled until we fix the predictive text issue
+            //toggleAutocorrectionIfNeeded()
             delegate?.textViewDidChange?(self)
         }
     }

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Autocorrection.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests+Autocorrection.swift
@@ -17,8 +17,9 @@
 @testable import WysiwygComposer
 import XCTest
 
+// THESE TESTS ARE DISABLED UNTIL WE FIX THE PREDICTIVE TEXT ISSUE
 extension WysiwygComposerViewModelTests {
-    func testAutocorrectionIsDisabled() throws {
+    func disabled_testAutocorrectionIsDisabled() throws {
         mockTrailingTyping("/")
         assertAutocorrectDisabled()
 
@@ -29,7 +30,7 @@ extension WysiwygComposerViewModelTests {
         assertAutocorrectDisabled()
     }
 
-    func testAutocorrectionIsEnabled() throws {
+    func disabled_testAutocorrectionIsEnabled() throws {
         mockTrailingTyping("Just some text")
         assertAutoCorrectEnabled()
 
@@ -37,12 +38,12 @@ extension WysiwygComposerViewModelTests {
         assertAutoCorrectEnabled()
     }
 
-    func testDoubleSlashKeepAutocorrectionEnabled() throws {
+    func disabled_testDoubleSlashKeepAutocorrectionEnabled() throws {
         mockTrailingTyping("//")
         assertAutoCorrectEnabled()
     }
 
-    func testAutocorrectionIsReEnabled() throws {
+    func disabled_testAutocorrectionIsReEnabled() throws {
         mockTrailingTyping("/")
         assertAutocorrectDisabled()
 
@@ -58,7 +59,7 @@ extension WysiwygComposerViewModelTests {
         assertAutoCorrectEnabled()
     }
 
-    func testAutocorrectionAfterSetHtmlContent() {
+    func disabled_testAutocorrectionAfterSetHtmlContent() {
         viewModel.setHtmlContent("/join #some_room:matrix.org")
         assertAutocorrectDisabled()
 
@@ -79,7 +80,7 @@ extension WysiwygComposerViewModelTests {
 //        assertAutoCorrectEnabled()
 //    }
 
-    func testAutocorrectionAfterSetMarkdownContent() {
+    func disabled_testAutocorrectionAfterSetMarkdownContent() {
         viewModel.setMarkdownContent("/join #some_room:matrix.org")
         assertAutocorrectDisabled()
 


### PR DESCRIPTION
Until we fix the predictive text issue is better to just disable it