### PR TITLE
Android: reconcile UI text with editor text

### DIFF
--- a/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
+++ b/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
@@ -10,12 +10,14 @@ import android.widget.ArrayAdapter
 import android.widget.LinearLayout
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.core.widget.addTextChangedListener
 import io.element.android.wysiwyg.EditorEditText
 import io.element.android.wysiwyg.poc.databinding.ViewRichTextEditorBinding
 import io.element.android.wysiwyg.poc.matrix.MatrixMentionMentionDisplayHandler
 import io.element.android.wysiwyg.poc.matrix.Mention
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.models.LinkAction
+import timber.log.Timber
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
 import uniffi.wysiwyg_composer.MenuAction
@@ -41,6 +43,17 @@ class RichTextEditor : LinearLayout {
         super.onAttachedToWindow()
 
         with(binding) {
+            richTextEditText.addTextChangedListener(
+                beforeTextChanged = { text, start, count, after ->
+                    Timber.d("Before text changed: '$text', start: $start, count: $count, after: $after")
+                },
+                onTextChanged = { text, start, before, count ->
+                    Timber.d("Text changed: '$text', start: $start, before: $before, count: $count")
+                },
+                afterTextChanged = { text ->
+                    Timber.d("After text changed: '$text'")
+                }
+            )
             formattingSwitch.apply {
                 isChecked = true
                 setOnCheckedChangeListener { _, isChecked ->

--- a/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
+++ b/platforms/android/example-view/src/main/java/io/element/android/wysiwyg/poc/RichTextEditor.kt
@@ -16,7 +16,6 @@ import io.element.android.wysiwyg.poc.matrix.MatrixMentionMentionDisplayHandler
 import io.element.android.wysiwyg.poc.matrix.Mention
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.models.LinkAction
-import timber.log.Timber
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
 import uniffi.wysiwyg_composer.MenuAction
@@ -194,7 +193,6 @@ class RichTextEditor : LinearLayout {
     override fun requestFocus(direction: Int, previouslyFocusedRect: Rect?): Boolean {
         return binding.richTextEditText.requestFocus(direction, previouslyFocusedRect)
     }
-
 }
 
 interface OnSetLinkListener {

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/EditorEditTextInputTests.kt
@@ -31,7 +31,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.wysiwyg.display.TextDisplay
 import io.element.android.wysiwyg.test.R
 import io.element.android.wysiwyg.test.rules.createFlakyEmulatorRule
-import io.element.android.wysiwyg.test.utils.*
+import io.element.android.wysiwyg.test.utils.AnyViewAction
+import io.element.android.wysiwyg.test.utils.EditorActions
+import io.element.android.wysiwyg.test.utils.ImeActions
+import io.element.android.wysiwyg.test.utils.ScreenshotFailureHandler
+import io.element.android.wysiwyg.test.utils.TestActivity
+import io.element.android.wysiwyg.test.utils.TestMentionDisplayHandler
+import io.element.android.wysiwyg.test.utils.selectionIsAt
 import io.element.android.wysiwyg.utils.NBSP
 import io.element.android.wysiwyg.utils.RustErrorCollector
 import io.element.android.wysiwyg.view.models.InlineFormat
@@ -45,9 +51,12 @@ import io.mockk.verify
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Description
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
-import org.junit.*
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
@@ -145,7 +154,6 @@ class EditorEditTextInputTests {
         val emoji = "\uD83E\uDD17"
         onView(withId(R.id.rich_text_edit_text))
             // pressKey doesn't seem to work if no `typeText` is used before
-            .perform(pressKey(KeyEvent.KEYCODE_A))
             .perform(replaceText(emoji))
             .perform(pressKey(KeyEvent.KEYCODE_ENTER))
             .check(matches(withText(containsString(emoji + "\n"))))
@@ -569,15 +577,15 @@ class EditorEditTextInputTests {
 
         verify(exactly = 2) {
             // In future when we support parsing/loading of pasted html into the model
-            // we can make more assertions on that the corrrect formating is applied
-            textWatcher.invoke(match { it.toString() == ipsum + ipsum })
+            // we can make more assertions on that the correct formatting is applied
+            textWatcher(match { it.toString() == ipsum + ipsum })
         }
 
         confirmVerified(contentWatcher)
     }
 
 
-    private fun pasteFromClipboard(clipData: ClipData, pasteAsPlainText: Boolean){
+    private fun pasteFromClipboard(clipData: ClipData, pasteAsPlainText: Boolean) {
         scenarioRule.scenario.onActivity { activity ->
             val editor = activity.findViewById<EditorEditText>(R.id.rich_text_edit_text)
             val clipboardManager =

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -4,9 +4,11 @@ import android.app.Application
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.test.core.app.ApplicationProvider
+import io.element.android.wysiwyg.EditorTextWatcher
 import io.element.android.wysiwyg.fakes.createFakeStyleConfig
 import io.element.android.wysiwyg.internal.viewmodel.EditorInputAction
 import io.element.android.wysiwyg.internal.viewmodel.EditorViewModel
+import io.element.android.wysiwyg.test.utils.Editor
 import io.element.android.wysiwyg.test.utils.dumpSpans
 import io.element.android.wysiwyg.utils.HtmlConverter
 import io.element.android.wysiwyg.utils.NBSP
@@ -33,6 +35,7 @@ class InterceptInputConnectionIntegrationTest {
         viewModel = viewModel,
         editorEditText = textView,
         baseInputConnection = textView.onCreateInputConnection(EditorInfo()),
+        textWatcher = EditorTextWatcher(),
     )
 
     private val baseEditedSpans = listOf(

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
@@ -12,6 +12,8 @@ class EditorTextWatcher: TextWatcher {
     private val nestedWatchers: MutableList<TextWatcher> = mutableListOf()
     private val updateIsFromEditor: AtomicBoolean = AtomicBoolean(false)
 
+    var enableDebugLogs = false
+
     private var beforeText: CharSequence? = null
 
     /**
@@ -49,14 +51,18 @@ class EditorTextWatcher: TextWatcher {
     }
 
     override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-        Timber.v("beforeTextChanged | text: \"$s\", start: $start, count: $count, after: $after")
+        if (enableDebugLogs) {
+            Timber.v("beforeTextChanged | text: \"$s\", start: $start, count: $count, after: $after")
+        }
         if (!updateIsFromEditor.get()) {
             beforeText = s?.subSequence(start, start + count)
         }
     }
 
     override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-        Timber.v("onTextChanged | text: \"$s\", start: $start, before: $before, count: $count")
+        if (enableDebugLogs) {
+            Timber.v("onTextChanged | text: \"$s\", start: $start, before: $before, count: $count")
+        }
         if (!updateIsFromEditor.get()) {
             val newText = s?.subSequence(start, start + count) ?: ""
             updateCallback(newText, start, start + before, beforeText)
@@ -64,7 +70,9 @@ class EditorTextWatcher: TextWatcher {
     }
 
     override fun afterTextChanged(s: Editable?) {
-        Timber.v("afterTextChanged")
+        if (enableDebugLogs) {
+            Timber.v("afterTextChanged")
+        }
         if (!updateIsFromEditor.get()) {
             beforeText = null
         }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
@@ -1,0 +1,102 @@
+package io.element.android.wysiwyg
+
+import android.text.Editable
+import android.text.TextWatcher
+import timber.log.Timber
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A [TextWatcher] that intercepts changes in the underlying text and can have child watchers.
+ */
+class EditorTextWatcher: TextWatcher {
+    private val nestedWatchers: MutableList<TextWatcher> = mutableListOf()
+    private val updateIsFromEditor: AtomicBoolean = AtomicBoolean(false)
+
+    private var beforeText: CharSequence? = null
+
+    /**
+     * The callback to be called when the text changes unexpectedly.
+     * These changes don't come from the editor, they might come from the OS or other sources.
+     */
+    var updateCallback: (CharSequence, Int, Int, CharSequence?) -> Unit = { _, _, _, _ -> }
+
+    /**
+     * Add a child watcher to be notified of text changes.
+     */
+    fun addChild(watcher: TextWatcher) {
+        nestedWatchers.add(watcher)
+    }
+
+    /**
+     * Remove a child watcher from being notified of text changes.
+     */
+    fun removeChild(watcher: TextWatcher) {
+        nestedWatchers.remove(watcher)
+    }
+
+    /**
+     * Run a block of code that comes from the editor.
+     *
+     * This is used to prevent the editor from updating itself when it's already updating itself and
+     * entering an endless loop.
+     *
+     * @param block The block of code to run.
+     */
+    fun runInEditor(block: EditorTextWatcher.() -> Unit) {
+        updateIsFromEditor.set(true)
+        this.block()
+        updateIsFromEditor.set(false)
+    }
+
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+        Timber.v("beforeTextChanged | text: \"$s\", start: $start, count: $count, after: $after")
+        if (!updateIsFromEditor.get()) {
+            beforeText = s?.subSequence(start, start + count)
+        }
+    }
+
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+        Timber.v("onTextChanged | text: \"$s\", start: $start, before: $before, count: $count")
+        if (!updateIsFromEditor.get()) {
+            val newText = s?.subSequence(start, start + count) ?: ""
+            updateCallback(newText, start, start + before, beforeText)
+        }
+    }
+
+    override fun afterTextChanged(s: Editable?) {
+        Timber.v("afterTextChanged")
+        if (!updateIsFromEditor.get()) {
+            beforeText = null
+        }
+    }
+
+    /**
+     * Notify the nested watchers that the text is about to change.
+     * @param text The text that will be changed.
+     * @param start The start index of the change.
+     * @param count The number of characters that will be removed.
+     * @param after The number of characters that will be added.
+     */
+    fun notifyBeforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
+        nestedWatchers.forEach { it.beforeTextChanged(text, start, count, after) }
+    }
+
+    /**
+     * Notify the nested watchers that the text is changing.
+     * @param text The new text.
+     * @param start The start index of the change.
+     * @param before The number of characters that were removed.
+     * @param count The number of characters that were added.
+     */
+    fun notifyOnTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {
+        nestedWatchers.forEach { it.onTextChanged(text, start, before, count) }
+    }
+
+    /**
+     * Notify the nested watchers that the text changed.
+     * @param editable The updated text.
+     */
+    fun notifyAfterTextChanged(editable: Editable) {
+        nestedWatchers.forEach { it.afterTextChanged(editable) }
+    }
+}

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * A [TextWatcher] that intercepts changes in the underlying text and can have child watchers.
  */
-class EditorTextWatcher: TextWatcher {
+internal class EditorTextWatcher: TextWatcher {
     private val nestedWatchers: MutableList<TextWatcher> = mutableListOf()
     private val updateIsFromEditor: AtomicBoolean = AtomicBoolean(false)
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import androidx.core.text.isDigitsOnly
+import io.element.android.wysiwyg.EditorTextWatcher
 import io.element.android.wysiwyg.internal.utils.TextRangeHelper
 import io.element.android.wysiwyg.internal.viewmodel.EditorInputAction
 import io.element.android.wysiwyg.internal.viewmodel.ReplaceTextResult
@@ -24,7 +25,13 @@ internal class InterceptInputConnection(
     private val baseInputConnection: InputConnection,
     private val editorEditText: TextView,
     private val viewModel: EditorViewModel,
+    private val textWatcher: EditorTextWatcher,
 ) : BaseInputConnection(editorEditText, true) {
+    init {
+        textWatcher.updateCallback = { updatedText, start, end, previousText ->
+            replaceTextInternal(start, end, updatedText, previousText)
+        }
+    }
 
     override fun getEditable(): Editable {
         return editorEditText.editableText
@@ -114,7 +121,7 @@ internal class InterceptInputConnection(
     // Called when started typing
     override fun setComposingText(text: CharSequence, newCursorPosition: Int): Boolean {
         val (start, end) = getCurrentCompositionOrSelection()
-        val result = processTextEntry(text, start, end)
+        val result = processTextEntry(text, start, end, null)
 
         return if (result != null) {
             beginBatchEdit()
@@ -135,7 +142,7 @@ internal class InterceptInputConnection(
     // Called for suggestion from IME selected
     override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
         val (start, end) = getCurrentCompositionOrSelection()
-        return replaceTextInternal(start, end, text)
+        return replaceTextInternal(start, end, text, null)
     }
 
     // In Android 13+, this is called instead of [commitText] when selecting suggestions from IME
@@ -146,15 +153,16 @@ internal class InterceptInputConnection(
         newCursorPosition: Int,
         textAttribute: TextAttribute?
     ): Boolean {
-        return replaceTextInternal(start, end, text)
+        return replaceTextInternal(start, end, text, null)
     }
 
     private fun replaceTextInternal(
         start: Int,
         end: Int,
         text: CharSequence?,
+        oldText: CharSequence?,
     ): Boolean {
-        val result = processTextEntry(text, start, end)
+        val result = processTextEntry(text, start, end, oldText?.toString())
 
         return if (result != null) {
             beginBatchEdit()
@@ -169,8 +177,8 @@ internal class InterceptInputConnection(
         }
     }
 
-    private fun processTextEntry(newText: CharSequence?, start: Int, end: Int): ReplaceTextResult? {
-        val previousText = editable.substring(start until end)
+    private fun processTextEntry(newText: CharSequence?, start: Int, end: Int, previousText: String?): ReplaceTextResult? {
+        val actualPreviousText = previousText ?: editable.substring(start until end)
         return withProcessor {
             when {
                 // Special case for whitespace, to keep the formatting status we need to add it first
@@ -181,7 +189,7 @@ internal class InterceptInputConnection(
                     // First add whitespace
                     var result = processInput(EditorInputAction.ReplaceTextIn(cEnd, cEnd, " "))
                     // Then replace text if needed
-                    if (toAppend != previousText) {
+                    if (toAppend != actualPreviousText) {
                         result = processInput(EditorInputAction.ReplaceTextIn(cStart, cEnd, toAppend))?.let {
                             // Fix selection to include whitespace at the end
                             val prevSelection = it.selection
@@ -194,18 +202,18 @@ internal class InterceptInputConnection(
                 newText?.lastOrNull() == '\n' -> {
                     processInput(EditorInputAction.InsertParagraph)
                 }
-                previousText.isNotEmpty() && newText?.startsWith(previousText) == true -> {
+                actualPreviousText.isNotEmpty() && newText?.startsWith(actualPreviousText) == true -> {
                     // Appending new text at the end
                     val pos = end - start
-                    val diff = newText.length - previousText.length
+                    val diff = newText.length - actualPreviousText.length
                     val toAppend = newText.substring(pos until pos + diff)
                     val (_, cEnd) = EditorIndexMapper.fromEditorToComposer(start, end, editable)
                         ?: error("Invalid indexes in composer $start, $end")
                     processInput(EditorInputAction.ReplaceTextIn(cEnd, cEnd, toAppend))
                 }
-                newText != null && previousText.startsWith(newText) -> {
+                newText != null && actualPreviousText.startsWith(newText) -> {
                     // Removing text from the end
-                    val diff = previousText.length - newText.length
+                    val diff = actualPreviousText.length - newText.length
                     val pos = end - diff
                     val (cStart, cEnd) = EditorIndexMapper.fromEditorToComposer(pos, end, editable)
                         ?: error("Invalid indexes in composer $pos, $end")
@@ -360,9 +368,15 @@ internal class InterceptInputConnection(
     }
 
     private fun replaceAll(charSequence: CharSequence) {
-        editable.removeFormattingSpans()
-        editable.clear()
-        editable.append(charSequence)
+        textWatcher.inEditor {
+            val beforeLength = editable.length
+            textWatcher.notifyBeforeTextChanged(editable, 0, beforeLength, charSequence.length)
+            editable.removeFormattingSpans()
+            editable.clear()
+            editable.append(charSequence)
+            textWatcher.notifyOnTextChanged(editable, 0, beforeLength, charSequence.length)
+            textWatcher.notifyAfterTextChanged(editable)
+        }
     }
 
     private fun editorIndex(composerIndex: Int, editable: Editable): Int {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -379,13 +379,13 @@ internal class InterceptInputConnection(
         newEnd: Int = charSequence.length
     ) {
         val clampedAfterCount = (newEnd.coerceAtMost(charSequence.length) - start).coerceAtLeast(0)
-        textWatcher.inEditor {
-            textWatcher.notifyBeforeTextChanged(editable, start, end - start, clampedAfterCount)
+        textWatcher.runInEditor {
+            notifyBeforeTextChanged(editable, start, end - start, clampedAfterCount)
             editable.removeFormattingSpans()
             editable.clear()
             editable.append(charSequence)
-            textWatcher.notifyOnTextChanged(editable, start, end - start, clampedAfterCount)
-            textWatcher.notifyAfterTextChanged(editable)
+            notifyOnTextChanged(editable, start, end - start, clampedAfterCount)
+            notifyAfterTextChanged(editable)
         }
     }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
@@ -74,8 +74,8 @@ internal class EditorViewModel(
                     // This conversion to a plain String might be too simple
                     composer?.replaceTextIn(
                         action.value.toString(),
-                        action.start.toUInt(),
-                        action.end.toUInt()
+                        action.start,
+                        action.end
                     )
                 }
 


### PR DESCRIPTION
This should help in cases where the UI text is modified externally by the OS or some app.

Basically, what we do here is we intercept any change made outside of the editor by either the OS or the implementing app, pass them to the editor, apply them, then notify the text watchers of the result of these editor changes.

It seems to work well so far, the tests pass. We probably need to thoroughly test it with some day-to-day usage.

PS: this is heavily based on @ganfra 's work [here](https://github.com/matrix-org/matrix-rich-text-editor/pull/940). Thanks!

## Video example


https://github.com/matrix-org/matrix-rich-text-editor/assets/480955/33234304-038f-40c5-bbd3-b00bd3ffc7f0

