### PR TITLE
Android: fix English characters in some Chinese keyboards

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -1,6 +1,7 @@
 package io.element.android.wysiwyg.inputhandlers
 
 import android.app.Application
+import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.test.core.app.ApplicationProvider
@@ -537,6 +538,20 @@ class InterceptInputConnectionIntegrationTest {
         assertThat(viewModel.getContentAsMessageHtml(), equalTo("Test"))
         assertThat(textView.selectionStart, equalTo(2))
         assertThat(textView.selectionEnd, equalTo(2))
+    }
+
+    @Test
+    fun testHalfWidthEnglishInChineseKeyboards() {
+        inputConnection.run {
+            sendHardwareKeyboardInput(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_T))
+            setComposingText("", 1)
+            sendHardwareKeyboardInput(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_E))
+            setComposingText("", 1)
+            sendHardwareKeyboardInput(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_S))
+            setComposingText("", 1)
+            sendHardwareKeyboardInput(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_T))
+        }
+        assertThat(textView.text.toString(), equalTo("test"))
     }
 
     private fun simulateInput(editorInputAction: EditorInputAction) =

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -114,6 +114,11 @@ internal class InterceptInputConnection(
     // Called when started typing
     override fun setComposingText(text: CharSequence, newCursorPosition: Int): Boolean {
         val (start, end) = getCurrentCompositionOrSelection()
+        // Some Chinese keyboards send empty text when the user is typing English characters
+        if (text.isEmpty() && Selection.getSelectionStart(editable) == Selection.getSelectionEnd(editable)) {
+            finishComposingText()
+            return false
+        }
         val result = processTextEntry(text, start, end)
 
         return if (result != null) {


### PR DESCRIPTION
Some Chinese keyboards send an empty composing text event before each key event for English characters. Those should be ignored and instead the current composition should be finished.

Fixes https://github.com/element-hq/element-x-android/issues/2439.