### PR TITLE
Android: fix composition issues with Compose

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/display/MemoizedLinkDisplayHandler.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/display/MemoizedLinkDisplayHandler.kt
@@ -38,4 +38,8 @@ internal class MemoizingMentionDisplayHandler(
 
         return calculated
     }
+
+    fun delegateEquals(other: MentionDisplayHandler?): Boolean {
+        return delegate == other
+    }
 }


### PR DESCRIPTION
Only re-render the contents when it's really necessary. And even when it's needed, try to restore the composing region.

This code caused an issue of missing composing regions (and incorrect input because of this) when embedding the editor in compose code that isn't present when using it with legacy Android views.

It should also improve performance as we won't be re-rendering the text for every change to it.

I added some changes to keep the Trime keyboard working while fixing a new discovered issue when backspacing in SwiftKey after https://github.com/matrix-org/matrix-rich-text-editor/pull/949 was merged.