### PR TITLE
Simplify input connection code by using `InputConnectionWrapper`.

### DIFF
--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorTest.kt
@@ -13,7 +13,6 @@ import io.element.android.wysiwyg.compose.testutils.StateFactory.createState
 import io.element.android.wysiwyg.compose.testutils.ViewMatchers.isRichTextEditor
 import io.element.android.wysiwyg.compose.testutils.copy
 import io.element.android.wysiwyg.compose.testutils.showContent
-import io.element.android.wysiwyg.test.rules.createFlakyEmulatorRule
 import io.element.android.wysiwyg.view.models.LinkAction
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -26,9 +25,6 @@ import uniffi.wysiwyg_composer.MenuAction
 class RichTextEditorTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
-
-    @get:Rule
-    val flakyEmulatorRule = createFlakyEmulatorRule()
 
     @Test
     fun testTypeText() {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -201,10 +201,10 @@ class EditorEditText : AppCompatEditText {
 
     override fun onSelectionChanged(selStart: Int, selEnd: Int) {
         super.onSelectionChanged(selStart, selEnd)
-        if (this.isInitialized) {
+        if (this.isInitialized && !this.textWatcher.isInEditorChange) {
             this.viewModel.updateSelection(editableText, selStart, selEnd)
+            selectionChangeListener?.selectionChanged(selStart, selEnd)
         }
-        selectionChangeListener?.selectionChanged(selStart, selEnd)
     }
 
     /**

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -203,8 +203,8 @@ class EditorEditText : AppCompatEditText {
         super.onSelectionChanged(selStart, selEnd)
         if (this.isInitialized && !this.textWatcher.isInEditorChange) {
             this.viewModel.updateSelection(editableText, selStart, selEnd)
-            selectionChangeListener?.selectionChanged(selStart, selEnd)
         }
+        selectionChangeListener?.selectionChanged(selStart, selEnd)
     }
 
     /**
@@ -634,7 +634,7 @@ class EditorEditText : AppCompatEditText {
 
     private fun setSelectionFromComposerUpdate(start: Int, end: Int = start) {
         val (newStart, newEnd) = EditorIndexMapper.fromComposerToEditor(start, end, editableText)
-        if (newStart in editableText.indices && newEnd in 0..editableText.length) {
+        if (newStart in 0..editableText.length && newEnd in 0..editableText.length) {
             setSelection(newStart, newEnd)
         }
     }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
@@ -12,6 +12,8 @@ internal class EditorTextWatcher: TextWatcher {
     private val nestedWatchers: MutableList<TextWatcher> = mutableListOf()
     private val updateIsFromEditor: AtomicBoolean = AtomicBoolean(false)
 
+    val isInEditorChange get() = updateIsFromEditor.get()
+
     var enableDebugLogs = false
 
     private var beforeText: CharSequence? = null

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -24,11 +24,11 @@ import kotlin.math.min
 
 internal class InterceptInputConnection(
     baseInputConnection: InputConnection,
-    editorEditText: TextView,
+    private val editorEditText: TextView,
     private val viewModel: EditorViewModel,
     private val textWatcher: EditorTextWatcher,
 ) : InputConnectionWrapper(baseInputConnection, true) {
-    private val editable = editorEditText.editableText
+    private val editable get() = editorEditText.editableText
 
     init {
         textWatcher.updateCallback = { updatedText, start, end, previousText ->

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorInputAction.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorInputAction.kt
@@ -108,5 +108,4 @@ internal sealed interface EditorInputAction {
     object Indent: EditorInputAction
 
     object Unindent: EditorInputAction
-
 }


### PR DESCRIPTION
Also reduce the number of times the selection changed listener is called.