### PR TITLE
Fix a couple of bug's with isContentEmpty in Swift.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ENV
 **/.python-version
 **/.vscode
+**/.idea
 **/.DS_Store
 # Generated
 /target/

--- a/crates/wysiwyg/src/composer_model/delete_text.rs
+++ b/crates/wysiwyg/src/composer_model/delete_text.rs
@@ -52,7 +52,7 @@ where
         if s == e {
             // We have no selection - check for special list behaviour
             // TODO: should probably also get inside here if our selection
-            // only contains a zero-wdith space.
+            // only contains a zero-width space.
             let range = self.state.dom.find_range(s, e);
             self.backspace_single_cursor(range)
         } else {

--- a/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/HTMLParser/Extensions/NSAttributedString+Range.swift
@@ -79,6 +79,15 @@ extension NSAttributedString {
     ///   - range: the range on which the elements should be detected. Entire range if omitted
     /// - Returns: an array of matching ranges
     func discardableTextRanges(in range: NSRange? = nil) -> [NSRange] {
+        // When typing a space into an empty composer, the single space being disposable results in
+        // `applyReplaceAll` failing, leaving attributedContent out of sync. The reconciliation then
+        // adds a second space to the model that isn't in the text view.
+        if string == .zwsp {
+            // This fixes that, although it doesn't help in the case of adding a single space to e.g.
+            // a list/quote where the same result can be seen with the model having an extra space.
+            return []
+        }
+        
         var ranges = [NSRange]()
 
         enumerateTypedAttribute(.discardableText, in: range) { (isDiscardable: Bool, range: NSRange, _) in

--- a/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
+++ b/platforms/ios/lib/WysiwygComposer/Sources/WysiwygComposer/Components/WysiwygComposerView/WysiwygComposerViewModel.swift
@@ -154,7 +154,7 @@ public class WysiwygComposerViewModel: WysiwygComposerViewModelProtocol, Observa
         model.delegate = self
         // Publish composer empty state.
         $attributedContent.sink { [unowned self] content in
-            isContentEmpty = content.text.length == 0
+            isContentEmpty = content.text.length == 0 || content.plainText == "\n" // An empty <p> is left when deleting multi-line content.
         }
         .store(in: &cancellables)
         

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -41,6 +41,21 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         viewModel.textView.attributedText = viewModel.attributedContent.text
         waitExpectation(expectation: expectTrue, timeout: 2.0)
     }
+    
+    func testIsContentEmptyAfterDeletingSingleSpace() {
+        // When typing a single space.
+        _ = viewModel.replaceText(range: .zero, replacementText: " ")
+        viewModel.textView.attributedText = NSAttributedString(string: " ")
+        viewModel.didUpdateText()
+        
+        // And then deleting that space.
+        _ = viewModel.replaceText(range: .init(location: 0, length: 1), replacementText: "")
+        viewModel.textView.attributedText = NSAttributedString(string: "")
+        viewModel.didUpdateText()
+        
+        // Then the content should be empty for the placeholder to be shown.
+        XCTAssertTrue(viewModel.isContentEmpty)
+    }
 
     func testSimpleTextInputIsAccepted() throws {
         let shouldChange = viewModel.replaceText(range: .zero,

--- a/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
+++ b/platforms/ios/lib/WysiwygComposer/Tests/WysiwygComposerTests/Components/WysiwygComposerView/WysiwygComposerViewModelTests.swift
@@ -56,6 +56,21 @@ final class WysiwygComposerViewModelTests: XCTestCase {
         // Then the content should be empty for the placeholder to be shown.
         XCTAssertTrue(viewModel.isContentEmpty)
     }
+    
+    func testIsContentEmptyAfterDeletingMultilineContent() {
+        // When typing a new line.
+        _ = viewModel.replaceText(range: .zero, replacementText: "\n")
+        viewModel.textView.attributedText = NSAttributedString(string: "\n")
+        viewModel.didUpdateText()
+        
+        // And then deleting that new line.
+        _ = viewModel.replaceText(range: .init(location: 0, length: 1), replacementText: "")
+        viewModel.textView.attributedText = NSAttributedString(string: "")
+        viewModel.didUpdateText()
+        
+        // Then the content should be empty for the placeholder to be shown.
+        XCTAssertTrue(viewModel.isContentEmpty)
+    }
 
     func testSimpleTextInputIsAccepted() throws {
         let shouldChange = viewModel.replaceText(range: .zero,


### PR DESCRIPTION
The first bug is caused by typing a ` ` resulting in the model containing `  ` whilst the text view only contains the single space inserted by the user. Deleting that space leaves the model with ` ` which can't be deleted as the text view is now empty.

Discussed this with @Velin92 and we concluded the simplest fix for now was what this PR does, although it doesn't help when typing a single space for a new item in a list or as the first line in a quote, where you can see the same behaviour with an extra space in the model compared to the text view.

The second bug is caused by writing a multi-line paragraph and then deleting it. It leaves a single empty paragraph within the model (and there are tests in Rust to ensure this is the case). In this instance we can check for a `\n` character which isn't valid HTML and ignore it.

Fixes both issues mentioned in https://github.com/element-hq/element-x-ios/issues/2538