### PR TITLE
Rename publish step for Swift.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   ios:
-    name: Create Release PR on SwiftPM Repo
+    name: Publish to Swift repo
     runs-on: macos-14
     steps:
       - name: 🧮 Checkout code


### PR DESCRIPTION
Tiny unimportant tweak seeing as there are no PRs involved any more.