### PR TITLE
Discard mentions with no associated text

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -336,6 +336,9 @@ internal class HtmlToSpansParser(
         val url = last.span.link
         val innerText = text.subSequence(last.start, text.length).toString()
 
+        // Invalid mention, it's not mapped to any text
+        if (innerText.isEmpty()) return
+
         val isMention = isMention?.invoke(innerText, url) == true ||
                 last.span.data.containsKey("data-mention-type")
 

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -6,7 +6,9 @@ import io.element.android.wysiwyg.display.MentionDisplayHandler
 import io.element.android.wysiwyg.test.fakes.createFakeStyleConfig
 import io.element.android.wysiwyg.test.utils.dumpSpans
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -152,6 +154,26 @@ class HtmlToSpansParserTest {
         )
         assertThat(
             spanned.toString(), equalTo("link\njonny\n@room")
+        )
+    }
+
+    @Test
+    fun testMentionWithNoTextIsIgnored() {
+        val html = """
+            foo<a href="https://matrix.to/#/@test:example.org" contenteditable="false"></a>bar
+        """.trimIndent()
+        val spanned = convertHtml(html, mentionDisplayHandler = object : MentionDisplayHandler {
+            override fun resolveAtRoomMentionDisplay(): TextDisplay =
+                TextDisplay.Pill
+
+            override fun resolveMentionDisplay(text: String, url: String): TextDisplay =
+                TextDisplay.Pill
+        })
+        assertThat(
+            spanned.dumpSpans(), not(contains("PillSpan"))
+        )
+        assertThat(
+            spanned.toString(), equalTo("foobar")
         )
     }
 


### PR DESCRIPTION
On iOS we're just not displaying anything for these kind of mention pills. Android should do the same.