### PR TITLE
Android: make `RichTextEditorState.messageMarkdown` store pure markdown

### DIFF
--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -131,7 +131,7 @@ private fun RealEditor(
                     addTextChangedListener {
                         state.internalHtml = getInternalHtml()
                         state.messageHtml = getContentAsMessageHtml()
-                        state.messageMarkdown = getMarkdown()
+                        state.messageMarkdown = getContentAsMessageMarkdown()
 
                         onTyping(state.internalHtml.isNotEmpty())
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorEditText.kt
@@ -492,7 +492,7 @@ class EditorEditText : AppCompatEditText {
     }
 
     /**
-     * Get the editor content as clean HTML suitable for sending as a message
+     * Get the editor content as clean HTML suitable for sending as a message.
      */
     fun getContentAsMessageHtml(): String {
         return viewModel.getContentAsMessageHtml()
@@ -506,6 +506,13 @@ class EditorEditText : AppCompatEditText {
      * Get the text as markdown.
      */
     fun getMarkdown(): String = viewModel.getMarkdown()
+
+    /**
+     * Get the editor content as clean markdown suitable for sending as a message.
+     */
+    fun getContentAsMessageMarkdown(): String {
+        return viewModel.getContentAsMessageMarkdown()
+    }
 
     /**
      * Set the text as markdown, it will be turned into to HTML internally.

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
@@ -180,6 +180,14 @@ internal class EditorViewModel(
             recoveryContentPlainText
         }
 
+    fun getContentAsMessageMarkdown(): String = runCatching {
+        composer?.getContentAsMessageMarkdown().orEmpty()
+    }.onFailure(
+        ::onComposerFailure
+    ).getOrElse {
+        recoveryContentPlainText
+    }
+
     fun getMarkdown(): String = runCatching {
         composer?.getContentAsMarkdown().orEmpty()
     }.onFailure(


### PR DESCRIPTION
At the moment it contains some pseudo MD-HTML hybrid we could use to display mention pills, but we're not actually using right now AFAICT.

It's causing https://github.com/element-hq/element-x-android/issues/2214.