### PR TITLE
Android: use the right selection indexes when deleting text.

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -557,6 +557,23 @@ class InterceptInputConnectionIntegrationTest {
         assertThat(textView.text.toString(), equalTo("test"))
     }
 
+    @Test
+    fun testPunctuationSymbolAfterCommitingText() {
+        // This simulates the behaviour of Gboard on Android < 13 when adding a punctuation symbol
+        // after a committed word.
+        inputConnection.run {
+            // Manually entered letter
+            setComposingText("A", 1)
+            // Committed text from suggestions
+            commitText("Anything ", 1)
+            // Punctuation symbol added, first the extra whitespace is removed by the system
+            deleteSurroundingText(1, 0)
+            // Then the punctuation symbol is added instead
+            commitText(".", 1)
+        }
+        assertThat(textView.text.toString(), equalTo("Anything."))
+    }
+
     private fun simulateInput(editorInputAction: EditorInputAction) =
         viewModel.processInput(editorInputAction)?.let { (text, selection) ->
             textView.setText(text)

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnection.kt
@@ -126,15 +126,20 @@ internal class InterceptInputConnection(
                     var result = processInput(EditorInputAction.ReplaceTextIn(cEnd, cEnd, " "))
                     // Then replace text if needed
                     if (toAppend != actualPreviousText) {
-                        result = processInput(EditorInputAction.ReplaceTextIn(cStart, cEnd, toAppend))?.let { replaceResult ->
-                            // Fix selection to include whitespace at the end
-                            val prevSelection = replaceResult.selection
-                            val newEnd = (prevSelection.last + 1).coerceAtMost(replaceResult.text.length)
-                            val newSelectionResult = processInput(
-                                EditorInputAction.UpdateSelection(newEnd.toUInt(), newEnd.toUInt())
-                            )
-                            newSelectionResult?.copy(selection = newSelectionResult.selection) ?: replaceResult
-                        }
+                        result = processInput(EditorInputAction.ReplaceTextIn(cStart, cEnd, toAppend))
+                            ?.let { replaceResult ->
+                                // Fix selection to include whitespace at the end
+                                val prevSelection = replaceResult.selection
+                                val newEnd = (prevSelection.last + 1).coerceAtMost(replaceResult.text.length)
+                                val newSelectionResult = processInput(
+                                    EditorInputAction.UpdateSelection(newEnd.toUInt(), newEnd.toUInt())
+                                )
+                                if (newSelectionResult != null) {
+                                    replaceResult.copy(selection = newSelectionResult.selection)
+                                } else {
+                                    replaceResult
+                                }
+                            }
                     }
                     result
                 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorInputAction.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorInputAction.kt
@@ -108,4 +108,13 @@ internal sealed interface EditorInputAction {
     object Indent: EditorInputAction
 
     object Unindent: EditorInputAction
+
+    /**
+     * Sets the current selection to the [start]..[end] range in the composer,
+     * using composer indices. These may not match the UI text indices.
+     *
+     * @param start The start index of the selection in the composer.
+     * @param end The end index of the selection in the composer.
+     */
+    data class UpdateSelection(val start: UInt, val end: UInt) : EditorInputAction
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
@@ -121,6 +121,7 @@ internal class EditorViewModel(
                 is EditorInputAction.Unindent -> composer?.unindent()
                 is EditorInputAction.InsertMentionAtSuggestion -> insertMentionAtSuggestion(action)
                 is EditorInputAction.InsertAtRoomMentionAtSuggestion -> insertAtRoomMentionAtSuggestion()
+                is EditorInputAction.UpdateSelection -> composer?.select(action.start, action.end)
             }
         }.onFailure(::onComposerFailure)
             .getOrNull()


### PR DESCRIPTION
- Backspacing was not updating the selection and it could become out of sync causing https://github.com/element-hq/element-x-android/issues/2784.
- Forward deletion wasn't sending composer indexes, it was using Android editor's ones.