### PR TITLE
Android: fix selection mismatch on Android 14 after autocompletion

### DIFF
--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -7,9 +7,9 @@ import android.widget.EditText
 import androidx.test.core.app.ApplicationProvider
 import io.element.android.wysiwyg.EditorTextWatcher
 import io.element.android.wysiwyg.fakes.createFakeStyleConfig
+import io.element.android.wysiwyg.internal.viewmodel.ComposerResult
 import io.element.android.wysiwyg.internal.viewmodel.EditorInputAction
 import io.element.android.wysiwyg.internal.viewmodel.EditorViewModel
-import io.element.android.wysiwyg.test.utils.Editor
 import io.element.android.wysiwyg.test.utils.dumpSpans
 import io.element.android.wysiwyg.utils.HtmlConverter
 import io.element.android.wysiwyg.utils.NBSP
@@ -489,9 +489,9 @@ class InterceptInputConnectionIntegrationTest {
     @Test
     fun testIncrementalCommitTextRespectsFormatting() {
         // Set initial text
-        val initialText = viewModel.processInput(
+        val initialText = (viewModel.processInput(
             EditorInputAction.ReplaceAllHtml("<strong>test</strong>")
-        )?.text
+        ) as? ComposerResult.ReplaceText)?.text
         textView.setText(initialText)
         // Disable bold at end of string
         textView.setSelection(4)
@@ -558,7 +558,7 @@ class InterceptInputConnectionIntegrationTest {
     }
 
     @Test
-    fun testPunctuationSymbolAfterCommitingText() {
+    fun testPunctuationSymbolAfterCommittingText() {
         // This simulates the behaviour of Gboard on Android < 13 when adding a punctuation symbol
         // after a committed word.
         inputConnection.run {
@@ -566,6 +566,27 @@ class InterceptInputConnectionIntegrationTest {
             setComposingText("A", 1)
             // Committed text from suggestions
             commitText("Anything ", 1)
+            // Assert selection is properly updated
+            assertThat(textView.selectionEnd, equalTo(9))
+            // Punctuation symbol added, first the extra whitespace is removed by the system
+            deleteSurroundingText(1, 0)
+            // Then the punctuation symbol is added instead
+            commitText(".", 1)
+        }
+        assertThat(textView.text.toString(), equalTo("Anything."))
+    }
+
+    @Test
+    fun testPunctuationSymbolAfterCommittingText_Android14() {
+        // This simulates the behaviour of Gboard on Android < 13 when adding a punctuation symbol
+        // after a committed word.
+        inputConnection.run {
+            // Manually entered letter
+            setComposingText("A", 1)
+            // Committed text from suggestions
+            replaceText(0, 1, "Anything ", 1, null)
+            // Assert selection is properly updated
+            assertThat(textView.selectionEnd, equalTo(9))
             // Punctuation symbol added, first the extra whitespace is removed by the system
             deleteSurroundingText(1, 0)
             // Then the punctuation symbol is added instead
@@ -575,8 +596,14 @@ class InterceptInputConnectionIntegrationTest {
     }
 
     private fun simulateInput(editorInputAction: EditorInputAction) =
-        viewModel.processInput(editorInputAction)?.let { (text, selection) ->
-            textView.setText(text)
-            textView.setSelection(selection.first, selection.last)
+        when (val result = viewModel.processInput(editorInputAction)) {
+            is ComposerResult.ReplaceText -> {
+                textView.setText(result.text)
+                textView.setSelection(result.selection.first, result.selection.last)
+            }
+            is ComposerResult.SelectionUpdated -> {
+                textView.setSelection(result.selection.first, result.selection.last)
+            }
+            null -> Unit
         }
 }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/EditorViewModel.kt
@@ -62,7 +62,7 @@ internal class EditorViewModel(
         composer?.log()
     }
 
-    fun processInput(action: EditorInputAction): ReplaceTextResult? {
+    fun processInput(action: EditorInputAction): ComposerResult? {
         val update = runCatching {
             when (action) {
                 is EditorInputAction.ReplaceText -> {
@@ -131,7 +131,7 @@ internal class EditorViewModel(
         return handleComposerUpdates(update)
     }
 
-    private fun handleComposerUpdates(update: ComposerUpdate?): ReplaceTextResult? {
+    private fun handleComposerUpdates(update: ComposerUpdate?): ComposerResult? {
         if (update != null) {
             val menuState = update.menuState()
             if (menuState is MenuState.Update) {
@@ -160,13 +160,16 @@ internal class EditorViewModel(
                 val mentionsState = getMentionsState()
                 mentionsStateCallback?.invoke(mentionsState)
 
-                ReplaceTextResult(
+                ComposerResult.ReplaceText(
                     text = stringToSpans(replacementHtml),
                     selection = textUpdate.startUtf16Codeunit.toInt()..textUpdate.endUtf16Codeunit.toInt(),
                 )
             }
 
-            is TextUpdate.Select,
+            is TextUpdate.Select -> {
+                val selection = textUpdate.startUtf16Codeunit.toInt()..textUpdate.endUtf16Codeunit.toInt()
+                ComposerResult.SelectionUpdated(selection = selection)
+            }
             is TextUpdate.Keep,
             null -> null
         }

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/ReplaceTextResult.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/internal/viewmodel/ReplaceTextResult.kt
@@ -3,13 +3,27 @@ package io.element.android.wysiwyg.internal.viewmodel
 import android.text.Spanned
 import android.widget.EditText
 import uniffi.wysiwyg_composer.TextUpdate.ReplaceAll
+import uniffi.wysiwyg_composer.TextUpdate.Select
 
 /**
- * Mapped model of [ReplaceAll] from the Rust code to be applied to the [EditText].
+ * Result of a composer operation to be applied to the [EditText].
  */
-internal data class ReplaceTextResult(
-    /** Text in [Spanned] format after being parsed from HTML. */
-    val text: CharSequence,
-    /** Selection to apply to the editor. */
-    val selection: IntRange,
-)
+internal sealed interface ComposerResult {
+    /**
+     * Mapped model of [ReplaceAll] from the Rust code to be applied to the [EditText].
+     */
+    data class ReplaceText(
+        /** Text in [Spanned] format after being parsed from HTML. */
+        val text: CharSequence,
+        /** Selection to apply to the editor. */
+        val selection: IntRange,
+    ) : ComposerResult
+
+    /**
+     * Mapped model of [Select] from the Rust code to be applied to the [EditText].
+     */
+    data class SelectionUpdated(
+        /** Selection to apply to the editor. */
+        val selection: IntRange,
+    ) : ComposerResult
+}


### PR DESCRIPTION
This was caused by `EditorInputAction.UpdateSelection` not returning a `ReplaceTextResult`.

`ReplaceTextResult` was wrapped inside a `ComposerResult` sealed interface and the missing `SelectionUpdated` was added to it.