### PR TITLE
Upgrade matrix-org/sonarcloud-workflow-action to 3.2

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: "🩻 SonarCloud Scan"
         id: sonarcloud
-        uses: matrix-org/sonarcloud-workflow-action@v2.3
+        uses: matrix-org/sonarcloud-workflow-action@v3.2
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           is_pr: ${{ github.event.workflow_run.event == 'pull_request' }}


### PR DESCRIPTION
There have been fixes in  matrix-org/sonarcloud-workflow-action 3+ that _I think_ should be consumed here.

CC @davidegirardi 