### PR TITLE
Android: add `RichTextEditorState.setMarkdown(text)` function

### DIFF
--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorActionsTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorActionsTest.kt
@@ -21,7 +21,7 @@ class RichTextEditorActionsTest {
     val composeTestRule = createComposeRule()
 
     @get:Rule
-    val flakyEmulatorRule = createFlakyEmulatorRule()
+    val flakyEmulatorRule = createFlakyEmulatorRule(retry = false)
 
     @Test
     fun testBold() = runTest {

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
@@ -140,4 +140,24 @@ class RichTextEditorStateTest {
 
         onView(withText("Original text")).check(matches(isDisplayed()))
     }
+
+    @Test
+    fun testSettingMarkdownText() = runTest {
+        val state = RichTextEditorState(
+            "Original text"
+        )
+        composeTestRule.setContent {
+            MaterialTheme {
+                RichTextEditor(
+                    state = state,
+                    registerStateUpdates = true
+                )
+            }
+        }
+
+        state.setMarkdown("**Updated text**")
+        composeTestRule.awaitIdle()
+
+        onView(withText("Updated text")).check(matches(isDisplayed()))
+    }
 }

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStateTest.kt
@@ -18,9 +18,9 @@ import io.element.android.wysiwyg.test.rules.createFlakyEmulatorRule
 import io.element.android.wysiwyg.utils.NBSP
 import io.element.android.wysiwyg.view.models.InlineFormat
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 
@@ -29,7 +29,7 @@ class RichTextEditorStateTest {
     val composeTestRule = createComposeRule()
 
     @get:Rule
-    val flakyEmulatorRule = createFlakyEmulatorRule()
+    val flakyEmulatorRule = createFlakyEmulatorRule(retry = false)
 
     @Test
     fun testSharingState() = runTest {
@@ -90,7 +90,7 @@ class RichTextEditorStateTest {
         state.setSelection(4)
         composeTestRule.awaitIdle()
         // Ensure line count is set
-        Assert.assertEquals(2, state.lineCount)
+        assertEquals(2, state.lineCount)
 
         // Hide and show the editor to simulate a configuration change
         hideEditor.emit(true)
@@ -100,9 +100,9 @@ class RichTextEditorStateTest {
 
         // If the text is found, the state was restored
         onView(withText("Hello\nworld")).check(matches(isDisplayed()))
-        Assert.assertEquals(state.selection, 4 to 4)
+        assertEquals(state.selection, 4 to 4)
         // Line count is kept
-        Assert.assertEquals(2, state.lineCount)
+        assertEquals(2, state.lineCount)
     }
 
     @Test
@@ -135,8 +135,11 @@ class RichTextEditorStateTest {
             }
         }
 
-        state.setHtml("Updated text")
+        // `setHtml` waits until the actions can be processed by the UI, but that won't happen
+        // with `registerStateUpdates = false`
+        val job = launch { state.setHtml("Updated text") }
         composeTestRule.awaitIdle()
+        job.cancel()
 
         onView(withText("Original text")).check(matches(isDisplayed()))
     }

--- a/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStyleTest.kt
+++ b/platforms/android/library-compose/src/androidTest/java/io/element/android/wysiwyg/compose/RichTextEditorStyleTest.kt
@@ -24,7 +24,7 @@ class RichTextEditorStyleTest {
     val composeTestRule = createComposeRule()
 
     @get:Rule
-    val flakyEmulatorRule = createFlakyEmulatorRule()
+    val flakyEmulatorRule = createFlakyEmulatorRule(retry = false)
 
     private val state = createState()
     private val bulletRadius = MutableStateFlow(2.dp)

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditor.kt
@@ -22,6 +22,7 @@ import io.element.android.wysiwyg.display.MentionDisplayHandler
 import io.element.android.wysiwyg.display.TextDisplay
 import io.element.android.wysiwyg.utils.RustErrorCollector
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -142,7 +143,7 @@ private fun RealEditor(
                     }
                     val shouldRestoreFocus = state.hasFocus
                     if (shouldRestoreFocus) {
-                        requestFocus()
+                        performClick()
                     }
                     onFocusChangeListener = View.OnFocusChangeListener { view, hasFocus ->
                         state.onFocusChanged(view.hashCode(), hasFocus)
@@ -163,31 +164,33 @@ private fun RealEditor(
                 // Only start listening for text changes after the initial state has been restored
                 if (registerStateUpdates) {
                     coroutineScope.launch(context = Dispatchers.Main) {
-                        state.viewActions.collect {
-                            when (it) {
-                                is ViewAction.ToggleInlineFormat -> toggleInlineFormat(it.inlineFormat)
-                                is ViewAction.ToggleList -> toggleList(it.ordered)
-                                is ViewAction.ToggleCodeBlock -> toggleCodeBlock()
-                                is ViewAction.ToggleQuote -> toggleQuote()
-                                is ViewAction.Undo -> undo()
-                                is ViewAction.Redo -> redo()
-                                is ViewAction.Indent -> indent()
-                                is ViewAction.Unindent -> unindent()
-                                is ViewAction.SetHtml -> setHtml(it.html)
-                                is ViewAction.RequestFocus -> requestFocus()
-                                is ViewAction.SetLink -> setLink(it.url)
-                                is ViewAction.RemoveLink -> removeLink()
-                                is ViewAction.InsertLink -> insertLink(it.url, it.text)
-                                is ViewAction.ReplaceSuggestionText -> replaceTextSuggestion(it.text)
-                                is ViewAction.InsertMentionAtSuggestion -> insertMentionAtSuggestion(url = it.url, text = it.text)
-                                is ViewAction.InsertAtRoomMentionAtSuggestion -> insertAtRoomMentionAtSuggestion()
-                                is ViewAction.SetSelection -> setSelection(it.start, it.end)
+                        state.viewActions
+                            .onStart { state.isReadyToProcessActions = true }
+                            .collect {
+                                when (it) {
+                                    is ViewAction.ToggleInlineFormat -> toggleInlineFormat(it.inlineFormat)
+                                    is ViewAction.ToggleList -> toggleList(it.ordered)
+                                    is ViewAction.ToggleCodeBlock -> toggleCodeBlock()
+                                    is ViewAction.ToggleQuote -> toggleQuote()
+                                    is ViewAction.Undo -> undo()
+                                    is ViewAction.Redo -> redo()
+                                    is ViewAction.Indent -> indent()
+                                    is ViewAction.Unindent -> unindent()
+                                    is ViewAction.SetHtml -> setHtml(it.html)
+                                    is ViewAction.SetMarkdown -> setMarkdown(it.markdown)
+                                    is ViewAction.RequestFocus -> state.hasFocus = true
+                                    is ViewAction.SetLink -> setLink(it.url)
+                                    is ViewAction.RemoveLink -> removeLink()
+                                    is ViewAction.InsertLink -> insertLink(it.url, it.text)
+                                    is ViewAction.ReplaceSuggestionText -> replaceTextSuggestion(it.text)
+                                    is ViewAction.InsertMentionAtSuggestion -> insertMentionAtSuggestion(url = it.url, text = it.text)
+                                    is ViewAction.InsertAtRoomMentionAtSuggestion -> insertAtRoomMentionAtSuggestion()
+                                    is ViewAction.SetSelection -> setSelection(it.start, it.end)
+                                }
                             }
-                        }
                     }
                 }
             }
-
             view
         },
         update = { view ->
@@ -197,6 +200,15 @@ private fun RealEditor(
             view.typeface = typeface
             view.updateStyle(style.toStyleConfig(view.context), mentionDisplayHandler)
             view.rustErrorCollector = RustErrorCollector(onError)
+
+            if (registerStateUpdates && state.hasFocus && !view.hasFocus()) {
+                state.hasFocus = view.requestFocus()
+            }
+        },
+        onRelease = {
+            if (registerStateUpdates) {
+                state.onRelease()
+            }
         }
     )
 }

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/RichTextEditorState.kt
@@ -212,7 +212,6 @@ class RichTextEditorState(
      * Whether the editor is ready to receive commands.
      */
     var isReadyToProcessActions: Boolean by mutableStateOf(false)
-        internal set
 
     /**
      * Request focus of the editor input field.

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/FakeViewConnection.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/FakeViewConnection.kt
@@ -43,6 +43,7 @@ internal class FakeViewActionCollector(
             ViewAction.RemoveLink -> removeLink()
             ViewAction.RequestFocus -> requestFocus()
             is ViewAction.SetHtml -> setHtml(value.html)
+            is ViewAction.SetMarkdown -> setMarkdown(value.markdown)
             is ViewAction.SetLink -> setLink(value.url)
             ViewAction.ToggleCodeBlock -> toggleCodeBlock()
             is ViewAction.ToggleInlineFormat -> toggleInlineFormat(value.inlineFormat)
@@ -112,6 +113,11 @@ internal class FakeViewActionCollector(
     private fun setHtml(html: String) {
         state.messageHtml = html
         state.messageMarkdown = html
+    }
+
+    private fun setMarkdown(markdown: String) {
+        state.messageHtml = markdown
+        state.messageMarkdown = markdown
     }
 
     private fun requestFocus(): Boolean {

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/RichTextEditorStyleExt.kt
@@ -33,6 +33,39 @@ import io.element.android.wysiwyg.view.PillStyleConfig
 import io.element.android.wysiwyg.view.StyleConfig
 import kotlin.math.roundToInt
 
+/**
+ * Applies the [RichTextEditorStyle] to the current [TextView].
+ */
+fun TextView.applyStyleInCompose(style: RichTextEditorStyle) {
+    includeFontPadding = style.text.includeFontPadding
+    setTextColor(style.text.color.toArgb())
+    setTextSize(TypedValue.COMPLEX_UNIT_SP, style.text.fontSize.value)
+    if (style.text.lineHeight.isSpecified && style.text.lineHeight.value > 0f) {
+        val lineHeightInPx = TypedValue.applyDimension(
+            style.text.lineHeight.type.toTypeUnit(),
+            style.text.lineHeight.value,
+            context.resources.displayMetrics
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            lineHeight = lineHeightInPx.roundToInt()
+        } else {
+            val fontHeightInPx = TypedValue.applyDimension(
+                style.text.fontSize.type.toTypeUnit(),
+                style.text.fontSize.value,
+                context.resources.displayMetrics
+            )
+            val extra = lineHeightInPx - fontHeightInPx
+            setLineSpacing(extra, 1f)
+        }
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val cursorDrawable = ContextCompat.getDrawable(context, R.drawable.cursor)
+        cursorDrawable?.setTint(style.cursor.color.toArgb())
+        textCursorDrawable = cursorDrawable
+        setLinkTextColor(style.link.color.toArgb())
+    }
+}
+
 internal fun RichTextEditorStyle.toStyleConfig(context: Context): StyleConfig = StyleConfig(
     bulletList = bulletList.toStyleConfig(context),
     inlineCode = inlineCode.toStyleConfig(context),
@@ -87,36 +120,6 @@ internal fun TextStyle.rememberTypeface(): State<Typeface> {
             fontSynthesis = fontSynthesis ?: FontSynthesis.All,
         )
     } as State<Typeface>
-}
-
-internal fun TextView.applyStyleInCompose(style: RichTextEditorStyle) {
-    includeFontPadding = style.text.includeFontPadding
-    setTextColor(style.text.color.toArgb())
-    setTextSize(TypedValue.COMPLEX_UNIT_SP, style.text.fontSize.value)
-    if (style.text.lineHeight.isSpecified && style.text.lineHeight.value > 0f) {
-        val lineHeightInPx = TypedValue.applyDimension(
-            style.text.lineHeight.type.toTypeUnit(),
-            style.text.lineHeight.value,
-            context.resources.displayMetrics
-        )
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            lineHeight = lineHeightInPx.roundToInt()
-        } else {
-            val fontHeightInPx = TypedValue.applyDimension(
-                style.text.fontSize.type.toTypeUnit(),
-                style.text.fontSize.value,
-                context.resources.displayMetrics
-            )
-            val extra = lineHeightInPx - fontHeightInPx
-            setLineSpacing(extra, 1f)
-        }
-    }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        val cursorDrawable = ContextCompat.getDrawable(context, R.drawable.cursor)
-        cursorDrawable?.setTint(style.cursor.color.toArgb())
-        textCursorDrawable = cursorDrawable
-        setLinkTextColor(style.link.color.toArgb())
-    }
 }
 
 private fun TextUnitType.toTypeUnit() = when (this) {

--- a/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/ViewAction.kt
+++ b/platforms/android/library-compose/src/main/java/io/element/android/wysiwyg/compose/internal/ViewAction.kt
@@ -12,6 +12,7 @@ internal sealed class ViewAction {
     data object Indent: ViewAction()
     data object Unindent: ViewAction()
     data class SetHtml(val html: String): ViewAction()
+    data class SetMarkdown(val markdown: String): ViewAction()
     data object RequestFocus: ViewAction()
     data class SetLink(val url: String?): ViewAction()
     data object RemoveLink: ViewAction()

--- a/platforms/android/library-compose/src/test/java/io/element/android/wysiwyg/compose/FakeRichTextEditorStateTest.kt
+++ b/platforms/android/library-compose/src/test/java/io/element/android/wysiwyg/compose/FakeRichTextEditorStateTest.kt
@@ -1,5 +1,6 @@
 package io.element.android.wysiwyg.compose
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
@@ -13,12 +14,11 @@ import org.junit.Test
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
 
-
 class FakeRichTextEditorStateTest {
     @Test
     fun `toggleInlineFormat(bold) updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -31,7 +31,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `toggleInlineFormat(italic) updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -44,7 +44,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `toggleInlineFormat(underline) updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions){ state }
         }.test {
             val initialState = awaitItem()
@@ -57,7 +57,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `toggleInlineFormat(strikethrough) updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -70,7 +70,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `toggleInlineFormat(inlinecode) updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -83,7 +83,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `toggleList(ordered) updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -96,7 +96,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `toggleList(unordered) updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -109,7 +109,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `toggleCodeBlock updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -122,7 +122,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `toggleQuote updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -135,7 +135,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `undo updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -148,7 +148,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `redo updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -161,7 +161,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `indent updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -174,7 +174,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `unindent updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -187,7 +187,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `setLink updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.linkAction) { state }
         }.test {
             val initialState = awaitItem()
@@ -200,7 +200,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `removeLink updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.linkAction) { state }
         }.test {
             val initialState = awaitItem()
@@ -215,7 +215,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `insertLink updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.linkAction) { state }
         }.test {
             val initialState = awaitItem()
@@ -228,7 +228,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `toggling multiple times toggles state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.actions) { state }
         }.test {
             val initialState = awaitItem()
@@ -252,14 +252,30 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `setHtml updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.messageHtml, state.messageMarkdown) { state }
         }.test {
             val initialState = awaitItem()
             initialState.setHtml("<b>new html</b>")
             val nextState = awaitItem()
+            // We're testing a fake connection, so the HTML is not converted to markdown
             assertThat(nextState.messageHtml, equalTo("<b>new html</b>"))
             assertThat(nextState.messageMarkdown, equalTo("<b>new html</b>"))
+        }
+    }
+
+    @Test
+    fun `setMarkdown updates the state`() = runTest {
+        moleculeFlow(RecompositionMode.Immediate) {
+            val state = fakeRichTextEditorState()
+            remember(state.messageHtml, state.messageMarkdown) { state }
+        }.test {
+            val initialState = awaitItem()
+            initialState.setMarkdown("**new markdown**")
+            val nextState = awaitItem()
+            // We're testing a fake connection, so the markdown is not converted to HTML
+            assertThat(nextState.messageHtml, equalTo("**new markdown**"))
+            assertThat(nextState.messageMarkdown, equalTo("**new markdown**"))
         }
     }
 
@@ -307,7 +323,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `requestFocus updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.hasFocus) { state }
         }.test {
             val initialState = awaitItem()
@@ -321,7 +337,7 @@ class FakeRichTextEditorStateTest {
     @Test
     fun `setSelection updates the state`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
-            val state = rememberRichTextEditorState(fake = true)
+            val state = fakeRichTextEditorState()
             remember(state.selection) { state }
         }.test {
             val initialState = awaitItem()
@@ -331,5 +347,10 @@ class FakeRichTextEditorStateTest {
             initialState.setSelection(0, 1)
             assertThat(awaitItem().selection, equalTo(0 to 1))
         }
+    }
+    
+    @Composable
+    private fun fakeRichTextEditorState(): RichTextEditorState {
+        return rememberRichTextEditorState(fake = true).apply { isReadyToProcessActions = true }
     }
 }

--- a/platforms/android/test/src/main/java/io/element/android/wysiwyg/test/rules/FlakyEmulatorRule.kt
+++ b/platforms/android/test/src/main/java/io/element/android/wysiwyg/test/rules/FlakyEmulatorRule.kt
@@ -6,6 +6,11 @@ import org.junit.rules.TestRule
 /**
  * Creates a rule that helps to reduce emulator related flakiness.
  */
-fun createFlakyEmulatorRule(): TestRule = RuleChain
-    .outerRule(RetryOnFailureRule())
-    .around(DismissAnrRule())
+fun createFlakyEmulatorRule(retry: Boolean = true): TestRule = if (retry) {
+    RuleChain
+        .outerRule(RetryOnFailureRule())
+        .around(DismissAnrRule())
+} else {
+    RuleChain
+        .outerRule(DismissAnrRule())
+}


### PR DESCRIPTION
Also:
- Make `TextView.applyStyleInCompose(RichTextEditorStyle)` public.
- Handle focus request in compose in a better way.
- When sending some actions through `RichTextEditorState`, wait until the UI is ready to process them.

This code is needed to add a plain text editor on Android for Compose.