### PR TITLE
Use the shared tools in the Swift release script.

### DIFF
--- a/platforms/ios/tools/release/Package.resolved
+++ b/platforms/ios/tools/release/Package.resolved
@@ -8,6 +8,14 @@
         "revision" : "46989693916f56d1186bd59ac15124caef896560",
         "version" : "1.3.1"
       }
+    },
+    {
+      "identity" : "swift-command-line-tools",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/element-hq/swift-command-line-tools.git",
+      "state" : {
+        "revision" : "a6ad90808f4f6cac615ab8496c6ff1bc5f9fa192"
+      }
     }
   ],
   "version" : 2

--- a/platforms/ios/tools/release/Package.swift
+++ b/platforms/ios/tools/release/Package.swift
@@ -11,8 +11,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
+        .package(url: "https://github.com/element-hq/swift-command-line-tools.git", revision: "a6ad90808f4f6cac615ab8496c6ff1bc5f9fa192")
+        // .package(path: "../../../../../swift-command-line-tools")
     ],
     targets: [
-        .executableTarget(name: "Release", dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")]),
+        .executableTarget(name: "Release",
+                          dependencies: [
+                            .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                            .product(name: "CommandLineTools", package: "swift-command-line-tools")
+                          ]),
     ]
 )

--- a/platforms/ios/tools/release/Sources/Release.swift
+++ b/platforms/ios/tools/release/Sources/Release.swift
@@ -1,16 +1,20 @@
 import ArgumentParser
-import CryptoKit
+import CommandLineTools
 import Foundation
 
 @main
 struct Release: AsyncParsableCommand {
-    
     @Option(help: "The version of the library that is being released.")
     var version: String
     
+    @Flag(help: "Prevents the run from pushing anything to GitHub.")
+    var localOnly = false
+    
     var apiToken = ProcessInfo.processInfo.environment["SWIFT_RELEASE_TOKEN"]!
     
-    var packageRepo = "matrix-org/matrix-rich-text-editor-swift"
+    var sourceRepo = Repository(owner: "matrix-org", name: "matrix-rich-text-editor")
+    var packageRepo = Repository(owner: "matrix-org", name: "matrix-rich-text-editor-swift")
+    
     var buildDirectory = URL(filePath: #file)
         .deletingLastPathComponent() // Release.swift
         .deletingLastPathComponent() // Sources
@@ -20,219 +24,65 @@ struct Release: AsyncParsableCommand {
         .deletingLastPathComponent() // platforms
     
     mutating func run() async throws {
-        info("Build directory: \(buildDirectory.path())")
-        
-        let libraryDirectory = try buildLibrary()
-        let (zipFileURL, checksum) = try zipBinary(at: libraryDirectory)
         let packageDirectory = try clonePackageRepo()
+        let package = Package(repository: packageRepo, directory: packageDirectory, apiToken: apiToken, urlSession: localOnly ? .releaseMock : .shared)
+        Zsh.defaultDirectory = buildDirectory
         
-        try await updatePackage(at: packageDirectory, from: libraryDirectory, checksum: checksum)
-        let commitHash = try commitAndPush(in: packageDirectory)
-        try await makeRelease(at: commitHash, uploading: zipFileURL)
-    }
-    
-    func buildLibrary() throws -> URL {
-        try run(command: "make ios")
-        return buildDirectory.appending(path: "platforms/ios/lib/WysiwygComposer/")
-    }
-    
-    func zipBinary(at libraryDirectory: URL) throws -> (URL, String) {
-        let zipFileURL = buildDirectory.appending(component: "WysiwygComposerFFI.xcframework.zip")
-        if FileManager.default.fileExists(atPath: zipFileURL.path()) {
-            info("Deleting old framework")
-            try FileManager.default.removeItem(at: zipFileURL)
-        }
-
-        info("Zipping framework")
-        try run(command: "zip -r '\(zipFileURL.path())' WysiwygComposerFFI.xcframework", directory: libraryDirectory)
-        let checksum = try checksum(for: zipFileURL)
-        info("Checksum: \(checksum)")
+        Log.info("Build directory: \(buildDirectory.path())")
         
-        return (zipFileURL, checksum)
+        let product = try build()
+        let (zipFileURL, checksum) = try package.zipBinary(with: product)
+        
+        try await updatePackage(package, with: product, checksum: checksum)
+        try commitAndPush(package, with: product)
+        try await package.makeRelease(with: product, uploading: zipFileURL)
     }
     
     func clonePackageRepo() throws -> URL {
-        info("Checking out Swift package…")
+        Log.info("Checking out Swift package…")
         let packageDirectory = buildDirectory.appending(component: "matrix-rich-text-editor-swift")
         if !FileManager.default.fileExists(atPath: packageDirectory.path()) {
-            try run(command: "git clone git@github.com:\(packageRepo) \(packageDirectory.path())")
+            try Zsh.run(command: "git clone git@github.com:\(packageRepo.owner)/\(packageRepo.name) \(packageDirectory.path())")
         }
-        try run(command: "git fetch && git checkout main", directory: packageDirectory)
+        try Zsh.run(command: "git fetch && git checkout main", directory: packageDirectory)
         return packageDirectory
     }
     
-    func updatePackage(at packageDirectory: URL, from libraryDirectory: URL, checksum: String) async throws {
-        info("Copying sources")
-        let source = libraryDirectory.appending(component: "Sources", directoryHint: .isDirectory).path()
-        let destination = packageDirectory.appending(component: "Sources", directoryHint: .isDirectory).path()
-        try run(command: "rsync -a --delete '\(source)' '\(destination)'")
+    func build() throws -> BuildProduct {
+        let commitHash = try Zsh.run(command: "git rev-parse HEAD")!.trimmingCharacters(in: .whitespacesAndNewlines)
+        let branch = try Zsh.run(command: "git rev-parse --abbrev-ref HEAD")!.trimmingCharacters(in: .whitespacesAndNewlines)
         
-        info("Updating manifest")
-        let manifestURL = packageDirectory.appending(component: "Package.swift")
-        var updatedManifest = ""
+        Log.info("Building \(branch) at \(commitHash)")
         
-        #warning("Strips empty lines")
-        for try await line in manifestURL.lines {
-            if line.starts(with: "let version = ") {
-                updatedManifest.append("let version = \"\(version)\"")
-            } else if line.starts(with: "let checksum = ") {
-                updatedManifest.append("let checksum = \"\(checksum)\"")
-            } else {
-                updatedManifest.append(line)
-            }
-            updatedManifest.append("\n")
+        try Zsh.run(command: "make ios")
+        
+        return BuildProduct(sourceRepo: sourceRepo,
+                            version: version,
+                            commitHash: commitHash,
+                            branch: branch,
+                            directory: buildDirectory.appending(path: "platforms/ios/lib/WysiwygComposer/"),
+                            frameworkName: "WysiwygComposerFFI.xcframework")
+    }
+    
+    func updatePackage(_ package: Package, with product: BuildProduct, checksum: String) async throws {
+        Log.info("Copying sources")
+        let source = product.directory.appending(component: "Sources", directoryHint: .isDirectory).path()
+        let destination = package.directory.appending(component: "Sources", directoryHint: .isDirectory).path()
+        try Zsh.run(command: "rsync -a --delete '\(source)' '\(destination)'")
+        
+        try await package.updateManifest(with: product, checksum: checksum)
+    }
+    
+    func commitAndPush(_ package: Package, with product: BuildProduct) throws {
+        Log.info("Pushing changes")
+        try Zsh.run(command: "git add .", directory: package.directory)
+        try Zsh.run(command: "git commit -m 'Bump to version \(product.version) (\(product.sourceRepo.name)/\(product.branch) \(product.commitHash))'", directory: package.directory)
+        
+        guard !localOnly else {
+            Log.info("Skipping push for --local-only")
+            return
         }
         
-        try updatedManifest.write(to: manifestURL, atomically: true, encoding: .utf8)
-    }
-    
-    func commitAndPush(in packageDirectory: URL) throws -> String {
-        let commitHash = try run(command: "git rev-parse HEAD")!.trimmingCharacters(in: .whitespacesAndNewlines)
-        let branch = try run(command: "git rev-parse --abbrev-ref HEAD")!.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        info("Pushing changes")
-        try run(command: "git add .", directory: packageDirectory)
-        try run(command: "git commit -m 'Bump to version \(version) (matrix-rich-text-editor/\(branch) \(commitHash))'", directory: packageDirectory)
-        try run(command: "git push", directory: packageDirectory)
-        
-        return commitHash
-    }
-    
-    func makeRelease(at commitHash: String, uploading zipFileURL: URL) async throws {
-        info("Making release")
-        let url = URL(string: "https://api.github.com/repos")!
-            .appending(path: packageRepo)
-            .appending(component: "releases")
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.addValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content")
-        
-        let body = GitHubReleaseRequest(tagName: version,
-                                        targetCommitish: "main",
-                                        name: version,
-                                        body: "https://github.com/matrix-org/matrix-rich-text-editor/tree/\(commitHash)",
-                                        draft: false,
-                                        prerelease: false,
-                                        generateReleaseNotes: false,
-                                        makeLatest: "true")
-        
-        let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = .convertToSnakeCase
-        let bodyData = try encoder.encode(body)
-        request.httpBody = bodyData
-        
-        let (data, _) = try await URLSession.shared.data(for: request)
-        let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
-        
-        info("Release created \(release.htmlURL)")
-        
-        try await uploadFramework(at: zipFileURL, to: release.uploadURL)
-    }
-    
-    func uploadFramework(at fileURL: URL, to uploadURL: URL) async throws {
-        info("Uploading framework")
-        
-        var uploadComponents = URLComponents(url: uploadURL, resolvingAgainstBaseURL: false)!
-        uploadComponents.queryItems = [URLQueryItem(name: "name", value: fileURL.lastPathComponent)]
-        
-        var request = URLRequest(url: uploadComponents.url!)
-        request.httpMethod = "POST"
-        request.addValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.addValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        request.addValue("application/zip", forHTTPHeaderField: "Content-Type")
-        
-        let (data, response) = try await URLSession.shared.upload(for: request, fromFile: fileURL)
-        
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw ReleaseError.httpResponse(-1)
-        }
-        guard httpResponse.statusCode == 201 else {
-            throw ReleaseError.httpResponse(httpResponse.statusCode)
-        }
-        
-        let upload = try JSONDecoder().decode(GitHubUploadResponse.self, from: data)
-        info("Upload finished \(upload.browserDownloadURL)")
-    }
-    
-    // MARK: Helpers
-    
-    private func info(_ message: String) {
-        print("🚀 \(message)")
-    }
-    
-    @discardableResult
-    private func run(command: String, directory: URL? = nil) throws -> String? {
-        let process = Process()
-        let outputPipe = Pipe()
-        
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = ["-cu", command]
-        process.currentDirectoryURL = directory ?? buildDirectory
-        process.standardOutput = outputPipe
-        
-        try process.run()
-        process.waitUntilExit()
-        
-        guard process.terminationReason == .exit, process.terminationStatus == 0 else {
-            throw ReleaseError.commandFailure(command: command, directory: directory ?? buildDirectory)
-        }
-        
-        guard let outputData = try outputPipe.fileHandleForReading.readToEnd() else { return nil }
-        return String(data: outputData, encoding: .utf8)
-    }
-    
-    private func checksum(for fileURL: URL) throws -> String {
-        var hasher = SHA256()
-        let handle = try FileHandle(forReadingFrom: fileURL)
-        
-        while let bytes = try handle.read(upToCount: SHA256.blockByteCount) {
-            hasher.update(data: bytes)
-        }
-        
-        let digest = hasher.finalize()
-        return digest.map { String(format: "%02hhx", $0) }.joined()
-    }
-}
-
-enum ReleaseError: Error {
-    case commandFailure(command: String, directory: URL)
-    case httpResponse(Int)
-}
-
-// MARK: - GitHub Release https://docs.github.com/en/rest/releases/releases#create-a-release
-
-struct GitHubReleaseRequest: Encodable {
-    let tagName: String
-    let targetCommitish: String
-    let name: String
-    let body: String
-    let draft: Bool
-    let prerelease: Bool
-    let generateReleaseNotes: Bool
-    let makeLatest: String
-}
-
-struct GitHubRelease: Decodable {
-    let htmlURL: URL
-    let uploadURLString: String // Decode as a string to avoid URL percent encoding.
-    
-    var uploadURL: URL {
-        URL(string: String(uploadURLString.split(separator: "{")[0]))!
-    }
-    
-    enum CodingKeys: String, CodingKey {
-        case htmlURL = "html_url"
-        case uploadURLString = "upload_url"
-    }
-}
-
-struct GitHubUploadResponse: Decodable {
-    let browserDownloadURL: String
-    
-    enum CodingKeys: String, CodingKey {
-        case browserDownloadURL = "browser_download_url"
+        try Zsh.run(command: "git push", directory: package.directory)
     }
 }


### PR DESCRIPTION
Sources most of the logic from https://github.com/element-hq/swift-command-line-tools instead of keeping it locally (this is shared with the Rust SDK release script).