### PR TITLE
Android: make `CustomMentionSpan` public

### DIFF
--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/CustomMentionSpan.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/view/spans/CustomMentionSpan.kt
@@ -10,8 +10,8 @@ import android.text.style.ReplacementSpan
  * It is used to allow reuse of the same underlying span across multiple ranges
  * of a spanned text.
  */
-internal class CustomMentionSpan(
-    private val providedSpan: ReplacementSpan,
+class CustomMentionSpan(
+    val providedSpan: ReplacementSpan,
     val url: String? = null,
 ) : ReplacementSpan() {
     override fun draw(


### PR DESCRIPTION
This is needed to check and change its contents in real time, aka: resolving display names given a user id or a room name given a room id.