### PR TITLE
Ignore DTCoreText in Renovate updates.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "ignoreDeps": ["Cocoanetics/DTCoreText"],
   "packageRules" : [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
We're specifically pinning to 1.6.26, see https://github.com/matrix-org/matrix-rich-text-editor/pull/743 for more info.

JSON is based on https://docs.renovatebot.com/configuration-options/#ignoredeps