### PR TITLE
Fix lib type export

### DIFF
--- a/platforms/web/.eslintignore
+++ b/platforms/web/.eslintignore
@@ -9,3 +9,4 @@ vite.demo.config.ts
 scripts
 cypress
 example-wysiwyg
+coverage

--- a/platforms/web/lib/types.ts
+++ b/platforms/web/lib/types.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { ComposerUpdate } from '../generated/wysiwyg';
 import { ACTION_TYPES, SUGGESTIONS } from './constants';
 import { AllowedMentionAttributes, LinkEvent } from './useListeners/types';
 
@@ -71,3 +72,9 @@ export type MappedSuggestion = {
     text: string;
     type: SuggestionType;
 };
+export type TraceAction = (
+    update: ComposerUpdate | null,
+    name: string,
+    value1?: string | number,
+    value2?: string | number,
+) => ComposerUpdate | null;

--- a/platforms/web/lib/useTestCases/types.ts
+++ b/platforms/web/lib/useTestCases/types.ts
@@ -14,9 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { ComposerUpdate } from '../../generated/wysiwyg';
 import { useTestCases } from './useTestCases';
 
 export type TestUtilities = ReturnType<typeof useTestCases>['utilities'];
+export type TraceAction = (
+    update: ComposerUpdate | null,
+    name: string,
+    value1?: string | number,
+    value2?: string | number,
+) => ComposerUpdate | null;
 
 export type SelectTuple = ['select', number, number];
 export type Tuple =

--- a/platforms/web/lib/useTestCases/types.ts
+++ b/platforms/web/lib/useTestCases/types.ts
@@ -14,17 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ComposerUpdate } from '../../generated/wysiwyg';
 import { useTestCases } from './useTestCases';
 
 export type TestUtilities = ReturnType<typeof useTestCases>['utilities'];
-export type TraceAction = (
-    update: ComposerUpdate | null,
-    name: string,
-    value1?: string | number,
-    value2?: string | number,
-) => ComposerUpdate | null;
-
 export type SelectTuple = ['select', number, number];
 export type Tuple =
     | SelectTuple

--- a/platforms/web/lib/useTestCases/useTestCases.ts
+++ b/platforms/web/lib/useTestCases/useTestCases.ts
@@ -16,20 +16,13 @@ limitations under the License.
 
 import { RefObject, useCallback, useMemo, useRef, useState } from 'react';
 
-import { ComposerModel, ComposerUpdate } from '../../generated/wysiwyg';
-import { Actions } from './types';
+import { ComposerModel } from '../../generated/wysiwyg';
+import { Actions, TraceAction } from './types';
 import {
     getSelectionAccordingToActions,
     resetTestCase,
     traceAction,
 } from './utils';
-
-export type TraceAction = (
-    update: ComposerUpdate | null,
-    name: string,
-    value1?: string | number,
-    value2?: string | number,
-) => ComposerUpdate | null;
 
 export type UseTestCases = {
     testRef: RefObject<HTMLDivElement>;
@@ -105,3 +98,4 @@ export function useTestCases(
         utilities,
     };
 }
+export type { TraceAction };

--- a/platforms/web/lib/useTestCases/useTestCases.ts
+++ b/platforms/web/lib/useTestCases/useTestCases.ts
@@ -17,12 +17,13 @@ limitations under the License.
 import { RefObject, useCallback, useMemo, useRef, useState } from 'react';
 
 import { ComposerModel } from '../../generated/wysiwyg';
-import { Actions, TraceAction } from './types';
+import { Actions } from './types';
 import {
     getSelectionAccordingToActions,
     resetTestCase,
     traceAction,
 } from './utils';
+import { TraceAction } from '../types';
 
 export type UseTestCases = {
     testRef: RefObject<HTMLDivElement>;
@@ -98,4 +99,3 @@ export function useTestCases(
         utilities,
     };
 }
-export type { TraceAction };

--- a/platforms/web/lib/useTestCases/utils.ts
+++ b/platforms/web/lib/useTestCases/utils.ts
@@ -22,9 +22,9 @@ import {
     new_composer_model_from_html,
 } from '../../generated/wysiwyg';
 import { getCurrentSelection } from '../dom';
+import { TraceAction } from '../types';
 import { isSelectTuple } from './assert';
 import { Actions } from './types';
-import { TraceAction } from './useTestCases';
 
 export function traceAction(
     testNode: HTMLElement | null,

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -27,7 +27,7 @@ import { useComposerModel } from './useComposerModel';
 import { useListeners } from './useListeners';
 import { useTestCases } from './useTestCases';
 import { mapSuggestion } from './suggestion.js';
-import { TraceAction } from './useTestCases/useTestCases.js';
+import { TraceAction } from './useTestCases/types.js';
 
 export { richToPlain, plainToRich } from './conversion';
 

--- a/platforms/web/lib/useWysiwyg.ts
+++ b/platforms/web/lib/useWysiwyg.ts
@@ -21,13 +21,13 @@ import {
     FormattingFunctions,
     InputEventProcessor,
     MappedSuggestion,
+    TraceAction,
 } from './types.js';
 import { useFormattingFunctions } from './useFormattingFunctions';
 import { useComposerModel } from './useComposerModel';
 import { useListeners } from './useListeners';
 import { useTestCases } from './useTestCases';
 import { mapSuggestion } from './suggestion.js';
-import { TraceAction } from './useTestCases/types.js';
 
 export { richToPlain, plainToRich } from './conversion';
 

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
                 'lib/types.ts',
                 'lib/constants.ts',
                 'lib/useListeners/types.ts',
+                'lib/useTestCases/types.ts',
             ],
             rollupTypes: true,
         }),


### PR DESCRIPTION
`TraceAction` wasn't exported so the last release broke the renovate PR on react-sdk.