### PR TITLE
Use Jsoup instead of TagSoup for HTML parsing.

### DIFF
--- a/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
+++ b/platforms/android/example-compose/src/main/java/io/element/wysiwyg/compose/MainActivity.kt
@@ -81,6 +81,9 @@ class MainActivity : ComponentActivity() {
                 var linkDialogAction by remember { mutableStateOf<LinkAction?>(null) }
                 val coroutineScope = rememberCoroutineScope()
 
+                LaunchedEffect(state.messageHtml) {
+                    Timber.d("Message HTML: '${state.messageHtml}'")
+                }
                 val htmlText = htmlConverter.fromHtmlToSpans(state.messageHtml)
 
                 linkDialogAction?.let { linkAction ->

--- a/platforms/android/gradle/libs.versions.toml
+++ b/platforms/android/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ google-material = { module="com.google.android.material:material", version.ref="
 
 # Misc
 timber = { module="com.jakewharton.timber:timber", version.ref="timber" }
-tagsoup = { module="org.ccil.cowan.tagsoup:tagsoup", version.ref="tagsoup" }
+jsoup = "org.jsoup:jsoup:1.18.1"
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "molecule" }
 
 # Test

--- a/platforms/android/library/build.gradle
+++ b/platforms/android/library/build.gradle
@@ -90,8 +90,8 @@ dependencies {
 
     implementation libs.timber
 
-    // XML Parsing
-    api libs.tagsoup
+    // HTML Parsing
+    api libs.jsoup
 
     implementation libs.androidx.core
     implementation libs.androidx.appcompat

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -26,7 +26,8 @@ class InterceptInputConnectionIntegrationTest {
     private val viewModel = EditorViewModel(
         provideComposer = { newComposerModel() },
     ).also {
-        it.htmlConverter = HtmlConverter.Factory.create(context = app,
+        it.htmlConverter = HtmlConverter.Factory.create(
+            context = app,
             styleConfig = styleConfig,
             mentionDisplayHandler = null,
         )
@@ -57,7 +58,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "hello: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618",
-                    "hello: android.text.style.StyleSpan (0-5) fl=#33",
+                    "hello: android.text.style.StyleSpan (0-5) fl=#17",
                     "hello: android.text.method.TextKeyListener (0-5) fl=#18",
                     "hello: android.text.style.UnderlineSpan (0-5) fl=#289",
                     "hello: android.view.inputmethod.ComposingText (0-5) fl=#289",
@@ -80,7 +81,7 @@ class InterceptInputConnectionIntegrationTest {
         assertThat(
             textView.text.dumpSpans(), equalTo(
                 baseEditedSpans.toMutableList().apply {
-                    add(1, "world: android.text.style.StyleSpan (0-5) fl=#33")
+                    add(1, "world: android.text.style.StyleSpan (0-5) fl=#17")
                 }
             )
         )
@@ -97,7 +98,7 @@ class InterceptInputConnectionIntegrationTest {
         assertThat(
             textView.text.dumpSpans(), equalTo(
                 baseEditedSpans.toMutableList().apply {
-                    add(1, "world: android.text.style.UnderlineSpan (0-5) fl=#33")
+                    add(1, "world: android.text.style.UnderlineSpan (0-5) fl=#17")
                 }
             )
         )
@@ -114,7 +115,7 @@ class InterceptInputConnectionIntegrationTest {
         assertThat(
             textView.text.dumpSpans(), equalTo(
                 baseEditedSpans.toMutableList().apply {
-                    add(1, "world: android.text.style.StrikethroughSpan (0-5) fl=#33")
+                    add(1, "world: android.text.style.StrikethroughSpan (0-5) fl=#17")
                 }
             )
         )
@@ -131,7 +132,7 @@ class InterceptInputConnectionIntegrationTest {
         assertThat(
             textView.text.dumpSpans(), equalTo(
                 baseEditedSpans.toMutableList().apply {
-                    add(1, "world: io.element.android.wysiwyg.view.spans.InlineCodeSpan (0-5) fl=#33")
+                    add(1, "world: io.element.android.wysiwyg.view.spans.InlineCodeSpan (0-5) fl=#17")
                 }
             )
         )
@@ -147,7 +148,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "hello: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618",
-                    "hello: io.element.android.wysiwyg.view.spans.OrderedListSpan (0-5) fl=#34",
+                    "hello: io.element.android.wysiwyg.view.spans.OrderedListSpan (0-5) fl=#17",
                     "hello: android.text.style.UnderlineSpan (0-5) fl=#289",
                     "hello: android.view.inputmethod.ComposingText (0-5) fl=#289",
                     "hello: android.text.method.TextKeyListener (0-5) fl=#18",
@@ -173,7 +174,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans().joinToString(",\n"), equalTo(
                 """
                     hello: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618,
-                    hello: io.element.android.wysiwyg.view.spans.UnorderedListSpan (0-5) fl=#34,
+                    hello: io.element.android.wysiwyg.view.spans.UnorderedListSpan (0-5) fl=#17,
                     hello: android.text.style.UnderlineSpan (0-5) fl=#289,
                     hello: android.view.inputmethod.ComposingText (0-5) fl=#289,
                     hello: android.text.method.TextKeyListener (0-5) fl=#18,
@@ -195,7 +196,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans().joinToString(",\n"), equalTo(
                 """
                     hello: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618,
-                    hello: io.element.android.wysiwyg.view.spans.UnorderedListSpan (0-5) fl=#34,
+                    hello: io.element.android.wysiwyg.view.spans.UnorderedListSpan (0-5) fl=#17,
                     hello: android.text.style.UnderlineSpan (0-5) fl=#289,
                     hello: android.view.inputmethod.ComposingText (0-5) fl=#289,
                     hello: android.text.method.TextKeyListener (0-5) fl=#18,
@@ -221,7 +222,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans().joinToString(",\n"), equalTo(
                 """
                     hello: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618,
-                    hello: io.element.android.wysiwyg.view.spans.OrderedListSpan (0-5) fl=#34,
+                    hello: io.element.android.wysiwyg.view.spans.OrderedListSpan (0-5) fl=#17,
                     hello: android.text.style.UnderlineSpan (0-5) fl=#289,
                     hello: android.view.inputmethod.ComposingText (0-5) fl=#289,
                     hello: android.text.method.TextKeyListener (0-5) fl=#18,
@@ -244,7 +245,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "😋😋: android.widget.TextView.ChangeWatcher (0-4) fl=#6553618",
-                    "😋😋: io.element.android.wysiwyg.view.spans.OrderedListSpan (0-4) fl=#34",
+                    "😋😋: io.element.android.wysiwyg.view.spans.OrderedListSpan (0-4) fl=#17",
                     "😋😋: android.text.style.UnderlineSpan (0-4) fl=#289",
                     "😋😋: android.view.inputmethod.ComposingText (0-4) fl=#289",
                     "😋😋: android.text.method.TextKeyListener (0-4) fl=#18",
@@ -270,7 +271,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "hello: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618",
-                    "hello: io.element.android.wysiwyg.view.spans.CodeBlockSpan (0-5) fl=#33",
+                    "hello: io.element.android.wysiwyg.view.spans.CodeBlockSpan (0-5) fl=#17",
                     "hello: android.text.style.UnderlineSpan (0-5) fl=#289",
                     "hello: android.view.inputmethod.ComposingText (0-5) fl=#289",
                     "hello: android.text.method.TextKeyListener (0-5) fl=#18",
@@ -317,7 +318,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "Test\n$NBSP: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
-                    "Test\n$NBSP: io.element.android.wysiwyg.view.spans.CodeBlockSpan (0-6) fl=#33",
+                    "Test\n$NBSP: io.element.android.wysiwyg.view.spans.CodeBlockSpan (0-6) fl=#17",
                     "$NBSP: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (5-6) fl=#17",
                     "Test\n$NBSP: android.text.method.TextKeyListener (0-6) fl=#18",
                     "Test\n$NBSP: android.widget.Editor.SpanController (0-6) fl=#18",
@@ -335,7 +336,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "Test\n$NBSP: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
-                    "Test: io.element.android.wysiwyg.view.spans.CodeBlockSpan (0-4) fl=#33",
+                    "Test: io.element.android.wysiwyg.view.spans.CodeBlockSpan (0-4) fl=#17",
                     "$NBSP: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (5-6) fl=#17",
                     "Test\n$NBSP: android.text.method.TextKeyListener (0-6) fl=#18",
                     "Test\n$NBSP: android.widget.Editor.SpanController (0-6) fl=#18",
@@ -360,7 +361,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans().joinToString(",\n"), equalTo(
                 """
                     hello: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618,
-                    hello: io.element.android.wysiwyg.view.spans.QuoteSpan (0-5) fl=#33,
+                    hello: io.element.android.wysiwyg.view.spans.QuoteSpan (0-5) fl=#17,
                     hello: android.text.style.UnderlineSpan (0-5) fl=#289,
                     hello: android.view.inputmethod.ComposingText (0-5) fl=#289,
                     hello: android.text.method.TextKeyListener (0-5) fl=#18,
@@ -407,8 +408,8 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "Test\n$NBSP: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
-                    "Test\n$NBSP: io.element.android.wysiwyg.view.spans.QuoteSpan (0-6) fl=#33",
                     "$NBSP: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (5-6) fl=#17",
+                    "Test\n$NBSP: io.element.android.wysiwyg.view.spans.QuoteSpan (0-6) fl=#17",
                     "Test\n$NBSP: android.text.method.TextKeyListener (0-6) fl=#18",
                     "Test\n$NBSP: android.widget.Editor.SpanController (0-6) fl=#18",
                     ": android.text.Selection.START (5-5) fl=#546",
@@ -425,7 +426,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "Test\n$NBSP: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
-                    "Test: io.element.android.wysiwyg.view.spans.QuoteSpan (0-4) fl=#33",
+                    "Test: io.element.android.wysiwyg.view.spans.QuoteSpan (0-4) fl=#17",
                     "$NBSP: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (5-6) fl=#17",
                     "Test\n$NBSP: android.text.method.TextKeyListener (0-6) fl=#18",
                     "Test\n$NBSP: android.widget.Editor.SpanController (0-6) fl=#18",

--- a/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
+++ b/platforms/android/library/src/androidTest/java/io/element/android/wysiwyg/inputhandlers/InterceptInputConnectionIntegrationTest.kt
@@ -361,7 +361,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans().joinToString(",\n"), equalTo(
                 """
                     hello: android.widget.TextView.ChangeWatcher (0-5) fl=#6553618,
-                    hello: io.element.android.wysiwyg.view.spans.QuoteSpan (0-5) fl=#17,
+                    hello: io.element.android.wysiwyg.view.spans.QuoteSpan (0-5) fl=#65553,
                     hello: android.text.style.UnderlineSpan (0-5) fl=#289,
                     hello: android.view.inputmethod.ComposingText (0-5) fl=#289,
                     hello: android.text.method.TextKeyListener (0-5) fl=#18,
@@ -408,8 +408,8 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "Test\n$NBSP: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
+                    "Test\n$NBSP: io.element.android.wysiwyg.view.spans.QuoteSpan (0-6) fl=#65553",
                     "$NBSP: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (5-6) fl=#17",
-                    "Test\n$NBSP: io.element.android.wysiwyg.view.spans.QuoteSpan (0-6) fl=#17",
                     "Test\n$NBSP: android.text.method.TextKeyListener (0-6) fl=#18",
                     "Test\n$NBSP: android.widget.Editor.SpanController (0-6) fl=#18",
                     ": android.text.Selection.START (5-5) fl=#546",
@@ -426,7 +426,7 @@ class InterceptInputConnectionIntegrationTest {
             textView.text.dumpSpans(), equalTo(
                 listOf(
                     "Test\n$NBSP: android.widget.TextView.ChangeWatcher (0-6) fl=#6553618",
-                    "Test: io.element.android.wysiwyg.view.spans.QuoteSpan (0-4) fl=#17",
+                    "Test: io.element.android.wysiwyg.view.spans.QuoteSpan (0-4) fl=#65553",
                     "$NBSP: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (5-6) fl=#17",
                     "Test\n$NBSP: android.text.method.TextKeyListener (0-6) fl=#18",
                     "Test\n$NBSP: android.widget.Editor.SpanController (0-6) fl=#18",

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/EditorTextWatcher.kt
@@ -2,6 +2,7 @@ package io.element.android.wysiwyg
 
 import android.text.Editable
 import android.text.TextWatcher
+import io.element.android.wysiwyg.utils.LoggingConfig
 import timber.log.Timber
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -13,8 +14,6 @@ internal class EditorTextWatcher: TextWatcher {
     private val updateIsFromEditor: AtomicBoolean = AtomicBoolean(false)
 
     val isInEditorChange get() = updateIsFromEditor.get()
-
-    var enableDebugLogs = false
 
     private var beforeText: CharSequence? = null
 
@@ -53,7 +52,7 @@ internal class EditorTextWatcher: TextWatcher {
     }
 
     override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-        if (enableDebugLogs) {
+        if (LoggingConfig.enableDebugLogs) {
             Timber.v("beforeTextChanged | text: \"$s\", start: $start, count: $count, after: $after")
         }
         if (!updateIsFromEditor.get()) {
@@ -62,7 +61,7 @@ internal class EditorTextWatcher: TextWatcher {
     }
 
     override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-        if (enableDebugLogs) {
+        if (LoggingConfig.enableDebugLogs) {
             Timber.v("onTextChanged | text: \"$s\", start: $start, before: $before, count: $count")
         }
         if (!updateIsFromEditor.get()) {
@@ -72,7 +71,7 @@ internal class EditorTextWatcher: TextWatcher {
     }
 
     override fun afterTextChanged(s: Editable?) {
-        if (enableDebugLogs) {
+        if (LoggingConfig.enableDebugLogs) {
             Timber.v("afterTextChanged")
         }
         if (!updateIsFromEditor.get()) {

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/HtmlToSpansParser.kt
@@ -27,6 +27,7 @@ import io.element.android.wysiwyg.view.spans.UnorderedListSpan
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.TextNode
+import timber.log.Timber
 import kotlin.math.roundToInt
 
 /**
@@ -80,6 +81,9 @@ internal class HtmlToSpansParser(
             "blockquote" -> parseQuote(element)
             "p" -> parseParagraph(element)
             "br" -> parseLineBreak(element)
+            else -> if (LoggingConfig.enableDebugLogs) {
+                Timber.d("Unsupported tag: ${element.tagName()}")
+            }
         }
     }
 

--- a/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/LoggingConfig.kt
+++ b/platforms/android/library/src/main/java/io/element/android/wysiwyg/utils/LoggingConfig.kt
@@ -1,0 +1,7 @@
+package io.element.android.wysiwyg.utils
+
+import io.element.android.wysiwyg.BuildConfig
+
+object LoggingConfig {
+    var enableDebugLogs = BuildConfig.DEBUG
+}

--- a/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
+++ b/platforms/android/library/src/test/kotlin/io/element/android/wysiwyg/utils/HtmlToSpansParserTest.kt
@@ -30,13 +30,13 @@ class HtmlToSpansParserTest {
         assertThat(
             spanned.dumpSpans(), equalTo(
                 listOf(
-                    "bold: android.text.style.StyleSpan (0-4) fl=#33",
-                    "italic: android.text.style.StyleSpan (4-10) fl=#33",
-                    "underline: android.text.style.UnderlineSpan (10-19) fl=#33",
-                    "strong: android.text.style.StyleSpan (19-25) fl=#33",
-                    "emphasis: android.text.style.StyleSpan (25-33) fl=#33",
-                    "strikethrough: android.text.style.StrikethroughSpan (33-46) fl=#33",
-                    "code: io.element.android.wysiwyg.view.spans.InlineCodeSpan (46-50) fl=#33",
+                    "bold: android.text.style.StyleSpan (0-4) fl=#17",
+                    "italic: android.text.style.StyleSpan (4-10) fl=#17",
+                    "underline: android.text.style.UnderlineSpan (10-19) fl=#17",
+                    "strong: android.text.style.StyleSpan (19-25) fl=#17",
+                    "emphasis: android.text.style.StyleSpan (25-33) fl=#17",
+                    "strikethrough: android.text.style.StrikethroughSpan (33-46) fl=#17",
+                    "code: io.element.android.wysiwyg.view.spans.InlineCodeSpan (46-50) fl=#17",
                 )
             )
         )
@@ -56,14 +56,13 @@ class HtmlToSpansParserTest {
         """.trimIndent()
         val spanned = convertHtml(html)
 
-
         assertThat(
             spanned.dumpSpans().joinToString(",\n"), equalTo(
                 """
-                    ordered1: io.element.android.wysiwyg.view.spans.OrderedListSpan (0-8) fl=#34,
-                    ordered2: io.element.android.wysiwyg.view.spans.OrderedListSpan (9-17) fl=#34,
-                    bullet1: io.element.android.wysiwyg.view.spans.UnorderedListSpan (18-25) fl=#34,
-                    bullet2: io.element.android.wysiwyg.view.spans.UnorderedListSpan (26-33) fl=#34
+                    ordered1: io.element.android.wysiwyg.view.spans.OrderedListSpan (0-8) fl=#17,
+                    ordered2: io.element.android.wysiwyg.view.spans.OrderedListSpan (9-17) fl=#17,
+                    bullet1: io.element.android.wysiwyg.view.spans.UnorderedListSpan (18-25) fl=#17,
+                    bullet2: io.element.android.wysiwyg.view.spans.UnorderedListSpan (26-33) fl=#17
                 """.trimIndent()
             )
         )
@@ -104,13 +103,12 @@ class HtmlToSpansParserTest {
         assertThat(
             spanned.dumpSpans(), equalTo(
                 listOf(
-                    "$NBSP: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (0-1) fl=#17",
-                    "$NBSP: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (2-3) fl=#17"
+                    "\n: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (0-1) fl=#17",
                 )
             )
         )
         assertThat(
-            spanned.toString(), equalTo("$NBSP\n$NBSP")
+            spanned.toString(), equalTo("\n$NBSP")
         )
     }
 
@@ -119,9 +117,7 @@ class HtmlToSpansParserTest {
         val html = "<p>Hello</p><br /><p>world</p>"
         val spanned = convertHtml(html)
         assertThat(
-            spanned.dumpSpans(), equalTo(
-                emptyList()
-            )
+            spanned.dumpSpans(), equalTo(emptyList())
         )
         assertThat(
             spanned.toString(), equalTo("Hello\n\nworld")
@@ -131,9 +127,8 @@ class HtmlToSpansParserTest {
     @Test
     fun testMentionDisplayWithCustomMentionDisplayHandler() {
         val html = """
-            <a href="https://element.io">link</a>
-            <a href="https://matrix.to/#/@test:example.org" contenteditable="false">jonny</a>
-            @room
+            <a href="https://element.io">link</a>$NBSP
+            <a href="https://matrix.to/#/@test:example.org" contenteditable="false">jonny</a>$NBSP@room
         """.trimIndent()
         val spanned = convertHtml(html, mentionDisplayHandler = object : MentionDisplayHandler {
             override fun resolveAtRoomMentionDisplay(): TextDisplay =
@@ -145,15 +140,15 @@ class HtmlToSpansParserTest {
         assertThat(
             spanned.dumpSpans(), equalTo(
                 listOf(
-                    "link: io.element.android.wysiwyg.view.spans.LinkSpan (0-4) fl=#33",
-                    "jonny: io.element.android.wysiwyg.view.spans.PillSpan (5-10) fl=#33",
+                    "link: io.element.android.wysiwyg.view.spans.LinkSpan (0-4) fl=#17",
                     "onny: io.element.android.wysiwyg.view.spans.ExtraCharacterSpan (6-10) fl=#33",
+                    "jonny: io.element.android.wysiwyg.view.spans.PillSpan (5-10) fl=#17",
                     "@room: io.element.android.wysiwyg.view.spans.PillSpan (11-16) fl=#33",
                 )
             )
         )
         assertThat(
-            spanned.toString(), equalTo("link\njonny\n@room")
+            spanned.toString().replace(NBSP, ' '), equalTo("link jonny @room")
         )
     }
 


### PR DESCRIPTION
Jsoup, being way more flexible, allows us to simplify the parsing *a lot* and do checks we couldn't do before like one which lets us know when extra line breaks between inline nodes and block ones are needed.