### PR TITLE
Android (CI): use API level 29 for the emulator 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,13 +22,14 @@ concurrency:
 jobs:
   tests:
     if: |
+      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Android'))
     name: Run all tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [31]
+        api-level: [29]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,7 +69,6 @@ jobs:
           api-level: ${{ matrix.api-level }}
           arch: ${{ env.ARCH }}
           profile: ${{ env.DEVICE }}
-          force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           enable-hw-keyboard: true


### PR DESCRIPTION
API 31 somehow breaks the emulator action, the `config.ini` file doesn't seem to be used anymore, or at least the value for the userdata partition isn't honoured (the CI complaints of no disk space for a 7GB partition when the config.ini file says it should be only 3GB).

Also, enable dispatch for the `Android` action so it can be more easily tested in the future.