### PR TITLE
Version 2.37.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [2.37.7] - 2024-07-18
+- [Common] Add auto completion for emojis.
+- [Android] Fix issues with new lines by replacing the HTML parser with Jsoup.
+- [iOS] Added support for Xcode 15.4, improved XCFramework generation script. 
+
 # [2.37.6] - 2024-07-15
 - [iOS] Re-enabled inline prediction and replaced the behaviour of reconciliate with a commmited text system for latin and common only characters, to allow for a better user experience with inline prediction.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-wysiwyg-composer"
-version = "2.37.6"
+version = "2.37.7"
 dependencies = [
  "html-escape",
  "matrix_mentions",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg"
-version = "2.37.6"
+version = "2.37.7"
 dependencies = [
  "cfg-if",
  "email_address",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "wysiwyg-wasm"
-version = "2.37.6"
+version = "2.37.7"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/bindings/wysiwyg-ffi/Cargo.toml
+++ b/bindings/wysiwyg-ffi/Cargo.toml
@@ -7,7 +7,7 @@ description = "Swift and Kotlin bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
 name = "uniffi-wysiwyg-composer"
-version = "2.37.6"
+version = "2.37.7"
 rust-version = { workspace = true }
 
 [features]

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASM bindings for wysiwyg-rust"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
 name = "wysiwyg-wasm"
-version = "2.37.6"
+version = "2.37.7"
 rust-version = { workspace = true }
 
 [package.metadata.wasm-pack.profile.profiling]

--- a/bindings/wysiwyg-wasm/package-lock.json
+++ b/bindings/wysiwyg-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.37.6",
+  "version": "2.37.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wysiwyg-wasm",
-      "version": "2.37.6",
+      "version": "2.37.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^28.1.0",

--- a/bindings/wysiwyg-wasm/package.json
+++ b/bindings/wysiwyg-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wysiwyg-wasm",
-  "version": "2.37.6",
+  "version": "2.37.7",
   "homepage": "https://gitlab.com/andybalaam/wysiwyg-rust",
   "description": "WASM bindings for wysiwyg-rust",
   "license": "Apache-2.0",

--- a/crates/wysiwyg/Cargo.toml
+++ b/crates/wysiwyg/Cargo.toml
@@ -7,7 +7,7 @@ description = "Model code to power a rich text editor for Matrix"
 keywords = ["matrix", "chat", "messaging", "composer", "wysiwyg"]
 license = "Apache-2.0"
 name = "wysiwyg"
-version = "2.37.6"
+version = "2.37.7"
 rust-version = { workspace = true }
 
 [features]

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -27,7 +27,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=io.element.android
 # POM_ARTIFACT_ID is configured in each module's gradle.properties
-VERSION_NAME=2.37.6
+VERSION_NAME=2.37.7
 
 POM_NAME=Matrix WYSIWYG
 POM_DESCRIPTION=Cross-platform rich text editor that generates HTML output.

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-wysiwyg",
-    "version": "2.37.6",
+    "version": "2.37.7",
     "type": "module",
     "description": "Wysiwyg composer for matrix.org using React",
     "author": "matrix.org",


### PR DESCRIPTION
# [2.37.7] - 2024-07-18
- [Common] Add auto completion for emojis.
- [Android] Fix issues with new lines by replacing the HTML parser with Jsoup.
- [iOS] Added support for Xcode 15.4, improved XCFramework generation script. 