### PR TITLE
Stop the composer being re-initialised when customSuggestionPatterns change

### DIFF
--- a/platforms/web/lib/useComposerModel.test.tsx
+++ b/platforms/web/lib/useComposerModel.test.tsx
@@ -118,7 +118,7 @@ describe('useComposerModel', () => {
     });
 
     it("Doesn't double intialize the model if customSuggestionPatterns are set", async () => {
-        let useProps: {
+        const useProps: {
             editorRef: RefObject<HTMLElement | null>;
             initialContent?: string;
             customSuggestionPatterns?: Array<string>;
@@ -133,14 +133,12 @@ describe('useComposerModel', () => {
                 editorRef: RefObject<HTMLElement | null>;
                 initialContent?: string;
                 customSuggestionPatterns?: Array<string>;
-            }) => {
-                let a = useComposerModel(
+            }) =>
+                useComposerModel(
                     props.editorRef,
                     props.initialContent,
                     props.customSuggestionPatterns,
-                );
-                return a;
-            },
+                ),
             { initialProps: useProps },
         );
 

--- a/platforms/web/lib/useComposerModel.test.tsx
+++ b/platforms/web/lib/useComposerModel.test.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RefObject } from 'react';
+import { act, RefObject } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 
 import * as mockRustModel from '../generated/wysiwyg';
@@ -115,5 +115,48 @@ describe('useComposerModel', () => {
             mockRustModel.new_composer_model_from_html,
         ).toHaveBeenCalledTimes(1);
         expect(mockRustModel.new_composer_model).toHaveBeenCalledTimes(1);
+    });
+
+    it("Doesn't double intialize the model if customSuggestionPatterns are set", async () => {
+        let useProps: {
+            editorRef: RefObject<HTMLElement | null>;
+            initialContent?: string;
+            customSuggestionPatterns?: Array<string>;
+        } = {
+            editorRef: mockComposerRef,
+            initialContent: '',
+            customSuggestionPatterns: undefined,
+        };
+
+        const { result, rerender } = renderHook(
+            (props: {
+                editorRef: RefObject<HTMLElement | null>;
+                initialContent?: string;
+                customSuggestionPatterns?: Array<string>;
+            }) => {
+                let a = useComposerModel(
+                    props.editorRef,
+                    props.initialContent,
+                    props.customSuggestionPatterns,
+                );
+                return a;
+            },
+            { initialProps: useProps },
+        );
+
+        // wait for the composerModel to be created
+        await waitFor(() => {
+            expect(result.current.composerModel).not.toBeNull();
+        });
+
+        await act(() => {
+            useProps.customSuggestionPatterns = ['test'];
+            rerender(useProps);
+        });
+
+        expect(mockRustModel.new_composer_model).toHaveBeenCalledTimes(1);
+        expect(
+            mockRustModel.new_composer_model_from_html,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/platforms/web/lib/useComposerModel.ts
+++ b/platforms/web/lib/useComposerModel.ts
@@ -98,15 +98,18 @@ export function useComposerModel(
             } else {
                 contentModel = new_composer_model();
             }
-            if (customSuggestionPatterns) {
-                contentModel.set_custom_suggestion_patterns(
-                    customSuggestionPatterns,
-                );
-            }
             setComposerModel(contentModel);
         },
-        [setComposerModel, editorRef, customSuggestionPatterns],
+        [setComposerModel, editorRef],
     );
+
+    useEffect(() => {
+        if (composerModel && customSuggestionPatterns) {
+            composerModel.set_custom_suggestion_patterns(
+                customSuggestionPatterns,
+            );
+        }
+    }, [composerModel, customSuggestionPatterns]);
 
     useEffect(() => {
         if (editorRef.current) {


### PR DESCRIPTION
`customSuggestionPatterns` changing was causing the composer to be re-initialised. 
This was causing tests in the react-sdk to be flakey as the input happens right after initialisation, and some characters were being lost.
Moving the setting of customSuggestionPatterns to it's own effect.