### PR TITLE
Escape text in links and mentions for wasm bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ name = "wysiwyg-wasm"
 version = "2.37.8"
 dependencies = [
  "console_error_panic_hook",
+ "html-escape",
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/bindings/wysiwyg-wasm/Cargo.toml
+++ b/bindings/wysiwyg-wasm/Cargo.toml
@@ -26,6 +26,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
+html-escape = "0.2.11"
 js-sys = "0.3.60"
 wasm-bindgen = "0.2.83"
 wasm-bindgen-futures = "0.4.33"

--- a/bindings/wysiwyg-wasm/src/lib.rs
+++ b/bindings/wysiwyg-wasm/src/lib.rs
@@ -327,7 +327,7 @@ impl ComposerModel {
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.set_link_with_text(
             Utf16String::from_str(url),
-            Utf16String::from_str(text),
+            Utf16String::from_str(&html_escape::encode_safe(&text)),
             attributes.into_vec(),
         ))
     }
@@ -360,7 +360,7 @@ impl ComposerModel {
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.insert_mention(
             Utf16String::from_str(url),
-            Utf16String::from_str(text),
+            Utf16String::from_str(&html_escape::encode_safe(&text)),
             attributes.into_vec(),
         ))
     }
@@ -389,7 +389,7 @@ impl ComposerModel {
     ) -> ComposerUpdate {
         ComposerUpdate::from(self.inner.insert_mention_at_suggestion(
             Utf16String::from_str(url),
-            Utf16String::from_str(text),
+            Utf16String::from_str(&html_escape::encode_safe(&text)),
             wysiwyg::SuggestionPattern::from(suggestion.clone()),
             attributes.into_vec(),
         ))

--- a/platforms/web/lib/suggestion.test.tsx
+++ b/platforms/web/lib/suggestion.test.tsx
@@ -14,13 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { SuggestionPattern } from '../generated/wysiwyg';
+import init, {
+    new_composer_model,
+    SuggestionPattern,
+} from '../generated/wysiwyg';
 import { SUGGESTIONS } from './constants';
 import {
     getSuggestionChar,
     getSuggestionType,
     mapSuggestion,
 } from './suggestion';
+
+beforeAll(async () => {
+    await init();
+});
 
 describe('getSuggestionChar', () => {
     it('returns the expected character', () => {
@@ -90,5 +97,33 @@ describe('mapSuggestion', () => {
             type: 'mention',
             text: suggestion.text,
         });
+    });
+});
+
+describe('suggestionPattern', () => {
+    it('Content should be encoded', () => {
+        // Given
+        const model = new_composer_model();
+        model.replace_text('hello ');
+        const update = model.replace_text('@alic');
+
+        let suggestion = update.menu_action().suggestion();
+
+        // When
+        if (!suggestion) {
+            fail('There should be an suggestion!');
+        }
+
+        model.insert_mention_at_suggestion(
+            'https://matrix.to/#/@alice:matrix.org',
+            ':D</a> a broken mention!',
+            suggestion.suggestion_pattern,
+            new Map(),
+        );
+
+        // Then
+        expect(model.get_content_as_html()).toBe(
+            'hello <a data-mention-type="user" href="https://matrix.to/#/@alice:matrix.org" contenteditable="false">:D&lt;&#x2F;a&gt; a broken mention!</a>\u{a0}',
+        );
     });
 });

--- a/platforms/web/lib/suggestion.test.tsx
+++ b/platforms/web/lib/suggestion.test.tsx
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+// eslint-disable-next-line camelcase
 import init, {
     new_composer_model,
     SuggestionPattern,
@@ -106,8 +106,7 @@ describe('suggestionPattern', () => {
         const model = new_composer_model();
         model.replace_text('hello ');
         const update = model.replace_text('@alic');
-
-        let suggestion = update.menu_action().suggestion();
+        const suggestion = update.menu_action().suggestion();
 
         // When
         if (!suggestion) {

--- a/platforms/web/lib/suggestion.test.tsx
+++ b/platforms/web/lib/suggestion.test.tsx
@@ -13,8 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-// eslint-disable-next-line camelcase
+
 import init, {
+    // eslint-disable-next-line camelcase
     new_composer_model,
     SuggestionPattern,
 } from '../generated/wysiwyg';


### PR DESCRIPTION
Escape text in links and mentions for wasm bindings

Same as https://github.com/matrix-org/matrix-rich-text-editor/pull/988 but for wasm